### PR TITLE
Add Prisma catalog models with initial Postgres migration

### DIFF
--- a/apps/api/prisma/migrations/20260302120000_init/migration.sql
+++ b/apps/api/prisma/migrations/20260302120000_init/migration.sql
@@ -1,0 +1,88 @@
+-- CreateEnum
+CREATE TYPE "ItemType" AS ENUM ('movie', 'series', 'episode');
+
+-- CreateEnum
+CREATE TYPE "ListKind" AS ENUM ('watchlist', 'custom');
+
+-- CreateEnum
+CREATE TYPE "ListItemType" AS ENUM ('movie', 'series');
+
+-- CreateEnum
+CREATE TYPE "WatchEventType" AS ENUM ('movie', 'episode');
+
+-- CreateTable
+CREATE TABLE "Item" (
+    "id" UUID NOT NULL,
+    "type" "ItemType" NOT NULL,
+    "imdbId" TEXT NOT NULL,
+    "parentImdbId" TEXT,
+    "season" INTEGER,
+    "episode" INTEGER,
+    "title" TEXT,
+    "createdAt" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Item_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "List" (
+    "id" UUID NOT NULL,
+    "name" TEXT NOT NULL,
+    "kind" "ListKind" NOT NULL,
+    "createdAt" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "List_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ListItem" (
+    "listId" UUID NOT NULL,
+    "type" "ListItemType" NOT NULL,
+    "imdbId" TEXT NOT NULL,
+    "addedAt" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- CreateTable
+CREATE TABLE "WatchEvent" (
+    "id" UUID NOT NULL,
+    "type" "WatchEventType" NOT NULL,
+    "imdbId" TEXT NOT NULL,
+    "seriesImdbId" TEXT,
+    "season" INTEGER,
+    "episode" INTEGER,
+    "watchedAt" TIMESTAMPTZ(6) NOT NULL,
+    "plays" INTEGER NOT NULL DEFAULT 1,
+
+    CONSTRAINT "WatchEvent_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "SeriesProgress" (
+    "seriesImdbId" TEXT NOT NULL,
+    "lastSeason" INTEGER NOT NULL,
+    "lastEpisode" INTEGER NOT NULL,
+    "updatedAt" TIMESTAMPTZ(6) NOT NULL,
+
+    CONSTRAINT "SeriesProgress_pkey" PRIMARY KEY ("seriesImdbId")
+);
+
+-- CreateTable
+CREATE TABLE "KV" (
+    "key" TEXT NOT NULL,
+    "value" TEXT NOT NULL,
+    "updatedAt" TIMESTAMP(6) NOT NULL,
+
+    CONSTRAINT "KV_pkey" PRIMARY KEY ("key")
+);
+
+-- CreateIndex
+CREATE INDEX "Item_imdbId_idx" ON "Item"("imdbId");
+
+-- CreateIndex
+CREATE INDEX "ListItem_listId_idx" ON "ListItem"("listId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ListItem_listId_type_imdbId_key" ON "ListItem"("listId", "type", "imdbId");
+
+-- AddForeignKey
+ALTER TABLE "ListItem" ADD CONSTRAINT "ListItem_listId_fkey" FOREIGN KEY ("listId") REFERENCES "List"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/migrations/migration_lock.toml
+++ b/apps/api/prisma/migrations/migration_lock.toml
@@ -1,0 +1,1 @@
+provider = "postgresql"

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -7,9 +7,80 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-model User {
-  id        String   @id @default(cuid())
-  email     String   @unique
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+enum ItemType {
+  movie
+  series
+  episode
+}
+
+enum ListKind {
+  watchlist
+  custom
+}
+
+enum ListItemType {
+  movie
+  series
+}
+
+enum WatchEventType {
+  movie
+  episode
+}
+
+model Item {
+  id           String   @id @default(uuid()) @db.Uuid
+  type         ItemType
+  imdbId       String
+  parentImdbId String?
+  season       Int?
+  episode      Int?
+  title        String?
+  createdAt    DateTime @default(now()) @db.Timestamp(6)
+
+  @@index([imdbId])
+}
+
+model List {
+  id        String     @id @default(uuid()) @db.Uuid
+  name      String
+  kind      ListKind
+  createdAt DateTime   @default(now()) @db.Timestamp(6)
+  items     ListItem[]
+}
+
+model ListItem {
+  listId  String       @db.Uuid
+  type    ListItemType
+  imdbId  String
+  addedAt DateTime     @default(now()) @db.Timestamp(6)
+
+  list List @relation(fields: [listId], references: [id], onDelete: Cascade)
+
+  @@unique([listId, type, imdbId])
+  @@index([listId])
+}
+
+model WatchEvent {
+  id           String         @id @default(uuid()) @db.Uuid
+  type         WatchEventType
+  imdbId       String
+  seriesImdbId String?
+  season       Int?
+  episode      Int?
+  watchedAt    DateTime       @db.Timestamptz(6)
+  plays        Int            @default(1)
+}
+
+model SeriesProgress {
+  seriesImdbId String   @id
+  lastSeason   Int
+  lastEpisode  Int
+  updatedAt    DateTime @db.Timestamptz(6)
+}
+
+model KV {
+  key       String   @id
+  value     String
+  updatedAt DateTime @db.Timestamp(6)
 }


### PR DESCRIPTION
### Motivation
- Provide a Postgres-backed Prisma schema for the catalog domain to store items, lists, watch history, series progress, and simple KV state.
- Enforce domain constraints and query performance via enums, UUID primary keys, indexes, and unique constraints.

### Description
- Added enums `ItemType`, `ListKind`, `ListItemType`, and `WatchEventType` and replaced the placeholder model with the requested models `Item`, `List`, `ListItem`, `WatchEvent`, `SeriesProgress`, and `KV` in `apps/api/prisma/schema.prisma`.
- Mapped UUIDs and timestamps to Postgres types using `@db.Uuid`, `@db.Timestamp(6)`, and `@db.Timestamptz(6)` where appropriate and made nullable fields match the spec.
- Added indexes and constraints including `@@index([imdbId])` on `Item`, `@@unique([listId, type, imdbId])` on `ListItem`, and the foreign key relation `ListItem.listId -> List.id` with `ON DELETE CASCADE`.
- Created an initial SQL migration at `apps/api/prisma/migrations/20260302120000_init/migration.sql` and a Prisma migration lock file `apps/api/prisma/migrations/migration_lock.toml` that materialize the enums, tables, indexes, unique constraint, and FK for Postgres.

### Testing
- Ran `pnpm --filter @cataloggy/api prisma generate` to build the Prisma client, which failed due to Corepack being unable to download `pnpm` in this environment (network/proxy restrictions), so client generation did not complete.
- Attempted `docker compose up -d db` to bring up a fresh Postgres for `prisma migrate`, which failed because `docker` is not available in this environment, so migrations could not be applied against a live DB here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5a804cb288325ba71e1247b2989c9)