### PR TITLE
Add POST /trakt/poll for incremental history polling and an internal scheduler

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -16,6 +16,8 @@ const getTraktClient = () => {
 };
 
 const API_TOKEN = process.env.API_TOKEN;
+const TRAKT_LAST_POLLED_AT_KEY = "trakt:lastPolledAt";
+const TRAKT_POLL_INTERVAL_SEC = Number(process.env.TRAKT_POLL_INTERVAL_SEC ?? 300);
 const UUID_V4_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 type AuthenticatedRequest = FastifyRequest;
@@ -81,6 +83,186 @@ const getDefaultWatchlist = async () => {
   return prisma.list.create({
     data: { kind: ListKind.watchlist, name: "Watchlist" }
   });
+};
+
+const getTraktPollStartAt = async () => {
+  const kvValue = await prisma.kV.findUnique({ where: { key: TRAKT_LAST_POLLED_AT_KEY } });
+
+  if (!kvValue) {
+    return new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+  }
+
+  const parsed = new Date(kvValue.value);
+  if (Number.isNaN(parsed.getTime())) {
+    return new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+  }
+
+  return parsed;
+};
+
+const pollTraktHistory = async (logger: FastifyRequest["log"]) => {
+  const client = getTraktClient();
+  const pollStartAt = await getTraktPollStartAt();
+  const pollCompletedAt = new Date();
+  const pollStartAtIso = pollStartAt.toISOString();
+
+  const [movieHistory, episodeHistory] = await Promise.all([
+    client.fetchMovieHistory(logger, pollStartAtIso),
+    client.fetchEpisodeHistory(logger, pollStartAtIso)
+  ]);
+
+  const importedWatchEvents = { movies: 0, episodes: 0 };
+  const seriesProgressByImdb = new Map<string, { lastSeason: number; lastEpisode: number; updatedAt: Date }>();
+
+  for (const entry of movieHistory) {
+    const imdbId = entry.movie?.ids?.imdb;
+    const watchedAt = entry.watched_at;
+
+    if (!imdbId || !watchedAt) {
+      continue;
+    }
+
+    const watchedAtDate = new Date(watchedAt);
+    const title = entry.movie?.title?.trim();
+    if (title) {
+      await prisma.item.upsert({
+        where: { type_imdbId: { type: ItemType.movie, imdbId } },
+        create: { type: ItemType.movie, imdbId, title },
+        update: { title }
+      });
+    }
+
+    const existingEvent = await prisma.watchEvent.findFirst({
+      where: {
+        type: "movie",
+        imdbId,
+        watchedAt: watchedAtDate
+      }
+    });
+
+    if (existingEvent) {
+      await prisma.watchEvent.update({
+        where: { id: existingEvent.id },
+        data: { plays: 1 }
+      });
+    } else {
+      await prisma.watchEvent.create({
+        data: {
+          type: "movie",
+          imdbId,
+          watchedAt: watchedAtDate,
+          plays: 1
+        }
+      });
+    }
+
+    importedWatchEvents.movies += 1;
+  }
+
+  for (const entry of episodeHistory) {
+    const episodeImdbId = entry.episode?.ids?.imdb;
+    const seriesImdbId = entry.show?.ids?.imdb;
+    const watchedAt = entry.watched_at;
+    const season = entry.episode?.season;
+    const episode = entry.episode?.number;
+
+    if (!episodeImdbId || !seriesImdbId || !watchedAt || season === undefined || episode === undefined) {
+      continue;
+    }
+
+    const watchedAtDate = new Date(watchedAt);
+    const seriesTitle = entry.show?.title?.trim();
+    if (seriesTitle) {
+      await prisma.item.upsert({
+        where: { type_imdbId: { type: ItemType.series, imdbId: seriesImdbId } },
+        create: { type: ItemType.series, imdbId: seriesImdbId, title: seriesTitle },
+        update: { title: seriesTitle }
+      });
+    }
+
+    const existingEvent = await prisma.watchEvent.findFirst({
+      where: {
+        type: "episode",
+        imdbId: episodeImdbId,
+        seriesImdbId,
+        season,
+        episode,
+        watchedAt: watchedAtDate
+      }
+    });
+
+    if (existingEvent) {
+      await prisma.watchEvent.update({
+        where: { id: existingEvent.id },
+        data: { plays: 1 }
+      });
+    } else {
+      await prisma.watchEvent.create({
+        data: {
+          type: "episode",
+          imdbId: episodeImdbId,
+          seriesImdbId,
+          season,
+          episode,
+          watchedAt: watchedAtDate,
+          plays: 1
+        }
+      });
+    }
+
+    const existing = seriesProgressByImdb.get(seriesImdbId);
+    if (
+      !existing ||
+      watchedAtDate.getTime() > existing.updatedAt.getTime() ||
+      (watchedAtDate.getTime() === existing.updatedAt.getTime() &&
+        (season > existing.lastSeason || (season === existing.lastSeason && episode > existing.lastEpisode)))
+    ) {
+      seriesProgressByImdb.set(seriesImdbId, {
+        lastSeason: season,
+        lastEpisode: episode,
+        updatedAt: watchedAtDate
+      });
+    }
+
+    importedWatchEvents.episodes += 1;
+  }
+
+  for (const [seriesImdbId, progress] of seriesProgressByImdb.entries()) {
+    await prisma.seriesProgress.upsert({
+      where: { seriesImdbId },
+      create: {
+        seriesImdbId,
+        lastSeason: progress.lastSeason,
+        lastEpisode: progress.lastEpisode,
+        updatedAt: progress.updatedAt
+      },
+      update: {
+        lastSeason: progress.lastSeason,
+        lastEpisode: progress.lastEpisode,
+        updatedAt: progress.updatedAt
+      }
+    });
+  }
+
+  await prisma.kV.upsert({
+    where: { key: TRAKT_LAST_POLLED_AT_KEY },
+    create: {
+      key: TRAKT_LAST_POLLED_AT_KEY,
+      value: pollCompletedAt.toISOString(),
+      updatedAt: pollCompletedAt
+    },
+    update: {
+      value: pollCompletedAt.toISOString(),
+      updatedAt: pollCompletedAt
+    }
+  });
+
+  return {
+    since: pollStartAtIso,
+    polledAt: pollCompletedAt.toISOString(),
+    importedWatchEvents,
+    updatedSeriesProgress: seriesProgressByImdb.size
+  };
 };
 
 app.get("/health", async () => ({ status: "ok", service: "api" }));
@@ -398,9 +580,30 @@ app.post("/trakt/import", { preHandler: verifyToken }, async (request, reply) =>
   });
 });
 
+app.post("/trakt/poll", { preHandler: verifyToken }, async (request, reply) => {
+  try {
+    const result = await pollTraktHistory(request.log);
+    return reply.code(200).send(result);
+  } catch (error) {
+    request.log.error(error, "Trakt poll failed");
+    return reply.code(500).send({ error: "Trakt poll failed" });
+  }
+});
+
 const start = async () => {
   const port = Number(process.env.PORT ?? 7000);
   await ensureDefaultWatchlist();
+
+  if (TRAKT_POLL_INTERVAL_SEC > 0) {
+    setInterval(() => {
+      void pollTraktHistory(app.log).catch((error) => {
+        app.log.error(error, "Scheduled Trakt poll failed");
+      });
+    }, TRAKT_POLL_INTERVAL_SEC * 1000);
+  } else {
+    app.log.info("Scheduled Trakt poll disabled because TRAKT_POLL_INTERVAL_SEC is set to 0");
+  }
+
   await app.listen({ port, host: "0.0.0.0" });
 };
 

--- a/apps/api/src/trakt.ts
+++ b/apps/api/src/trakt.ts
@@ -83,15 +83,19 @@ export class TraktClient {
     return this.fetchAllPages<TraktShowPayload>("/sync/watchlist/shows", logger);
   }
 
-  async fetchMovieHistory(logger: FastifyBaseLogger): Promise<TraktMovieHistoryPayload[]> {
-    return this.fetchAllPages<TraktMovieHistoryPayload>("/sync/history/movies", logger);
+  async fetchMovieHistory(logger: FastifyBaseLogger, startAt?: string): Promise<TraktMovieHistoryPayload[]> {
+    return this.fetchAllPages<TraktMovieHistoryPayload>("/sync/history/movies", logger, startAt ? { start_at: startAt } : undefined);
   }
 
-  async fetchEpisodeHistory(logger: FastifyBaseLogger): Promise<TraktEpisodeHistoryPayload[]> {
-    return this.fetchAllPages<TraktEpisodeHistoryPayload>("/sync/history/episodes", logger);
+  async fetchEpisodeHistory(logger: FastifyBaseLogger, startAt?: string): Promise<TraktEpisodeHistoryPayload[]> {
+    return this.fetchAllPages<TraktEpisodeHistoryPayload>("/sync/history/episodes", logger, startAt ? { start_at: startAt } : undefined);
   }
 
-  private async fetchAllPages<T>(path: string, logger: FastifyBaseLogger): Promise<T[]> {
+  private async fetchAllPages<T>(
+    path: string,
+    logger: FastifyBaseLogger,
+    queryParams?: Record<string, string>
+  ): Promise<T[]> {
     const items: T[] = [];
     let page = 1;
     let pageCount = 1;
@@ -104,6 +108,7 @@ export class TraktClient {
           "trakt-api-key": this.clientId,
           Authorization: `Bearer ${this.accessToken}`
         },
+        queryParams,
         page,
         perPage: 100,
         logger
@@ -139,6 +144,7 @@ export class TraktClient {
       method: "GET" | "POST";
       headers: Record<string, string>;
       body?: string;
+      queryParams?: Record<string, string>;
       page?: number;
       perPage?: number;
       logger: FastifyBaseLogger;
@@ -148,6 +154,12 @@ export class TraktClient {
     const url = new URL(path, TRAKT_API_BASE);
     if (options.page !== undefined) {
       url.searchParams.set("page", String(options.page));
+    }
+
+    if (options.queryParams) {
+      for (const [key, value] of Object.entries(options.queryParams)) {
+        url.searchParams.set(key, value);
+      }
     }
 
     if (options.perPage !== undefined) {


### PR DESCRIPTION
### Motivation
- Provide an endpoint and background runner to ingest Trakt watch history incrementally so external scrobbles become visible in Cataloggy shortly after they occur. 
- Persist the last successful poll time in `KV` so subsequent polls only fetch new history and avoid duplicating work. 
- Make polling configurable (interval or disabled) so deployments can control frequency and resource use.

### Description
- Added `TRAKT_LAST_POLLED_AT_KEY` and `TRAKT_POLL_INTERVAL_SEC` (default `300`) and a `getTraktPollStartAt` helper that reads `KV` and falls back to `now - 7 days` when missing/invalid. 
- Implemented `pollTraktHistory` which fetches movie and episode history since the last poll, upserts `WatchEvent` rows (find-or-create/update by watched timestamp), computes and upserts `SeriesProgress`, and writes the new poll timestamp back to `KV` on success. 
- Exposed an authenticated `POST /trakt/poll` route that triggers `pollTraktHistory` and returns polling metadata/counters. 
- Extended the Trakt client to accept a `start_at` query parameter and propagate it through paginated requests so history endpoints can be fetched incrementally. 
- Added an internal interval runner in startup that calls `pollTraktHistory` every `TRAKT_POLL_INTERVAL_SEC` seconds and disables the scheduler when the env is set to `0`.

### Testing
- Attempted to run the API typecheck with `pnpm --filter @cataloggy/api typecheck`, but the environment failed to bootstrap the package manager due to a network/registry/proxy error, so type checking could not be completed. 
- No other automated tests were executed in this environment; manual review of diffs and local type locations was performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5aea7519c83258775013aca268ce1)