### PR TITLE
Implement personal Stremio addon manifest and catalog proxy

### DIFF
--- a/apps/addon/src/index.ts
+++ b/apps/addon/src/index.ts
@@ -2,43 +2,57 @@ import Fastify from "fastify";
 
 const app = Fastify({ logger: true });
 
+const CATALOGGY_API_BASE = process.env.CATALOGGY_API_BASE ?? "http://api:7000";
+const CATALOGGY_API_TOKEN = process.env.CATALOGGY_API_TOKEN;
+const ADDON_PUBLIC_BASE = process.env.ADDON_PUBLIC_BASE;
+
 const manifest = {
-  id: "com.cataloggy.addon",
+  id: "com.cataloggy.personal",
+  name: "Cataloggy (Personal)",
   version: "0.1.0",
-  name: "CataLoggy",
-  description: "Catalog and stream metadata addon for CataLoggy.",
-  resources: ["catalog", "meta", "stream"],
+  description: "Personal watchlist + continue watching from your self-hosted Cataloggy.",
+  resources: ["catalog"],
   types: ["movie", "series"],
   catalogs: [
-    {
-      type: "movie",
-      id: "cataloggy-movies",
-      name: "CataLoggy Movies"
-    }
+    { type: "movie", id: "my_watchlist_movies", name: "Cataloggy Watchlist (Movies)" },
+    { type: "series", id: "my_watchlist_series", name: "Cataloggy Watchlist (Shows)" },
+    { type: "series", id: "my_continue_series", name: "Cataloggy Continue Watching" },
+    { type: "movie", id: "my_recent_movies", name: "Cataloggy Recently Watched (Movies)" }
   ]
 };
 
-app.get("/health", async () => ({ status: "ok", service: "addon" }));
+const catalogRouteMap: Record<string, string> = {
+  "movie:my_watchlist_movies": "my_watchlist_movies",
+  "series:my_watchlist_series": "my_watchlist_series",
+  "series:my_continue_series": "my_continue_series",
+  "movie:my_recent_movies": "my_recent_movies"
+};
+
+app.get("/health", async () => ({ status: "ok", service: "addon", publicBase: ADDON_PUBLIC_BASE ?? null }));
 app.get("/manifest.json", async () => manifest);
 
-app.get<{ Params: { type: string; id: string } }>("/catalog/:type/:id.json", async (req) => ({
-  metas: [],
-  type: req.params.type,
-  id: req.params.id
-}));
+app.get<{ Params: { type: string; id: string } }>("/catalog/:type/:id.json", async (request, reply) => {
+  const routeKey = `${request.params.type}:${request.params.id}`;
+  const catalogId = catalogRouteMap[routeKey];
 
-app.get<{ Params: { type: string; id: string } }>("/meta/:type/:id.json", async (req) => ({
-  meta: {
-    id: req.params.id,
-    type: req.params.type,
-    name: "Placeholder",
-    description: "Replace with real metadata source"
+  if (!catalogId) {
+    return reply.code(404).send({ error: "Catalog not found" });
   }
-}));
 
-app.get<{ Params: { type: string; id: string } }>("/stream/:type/:id.json", async () => ({
-  streams: []
-}));
+  const apiUrl = new URL(`/stremio/catalog/${catalogId}`, CATALOGGY_API_BASE);
+
+  const upstreamResponse = await fetch(apiUrl, {
+    headers: CATALOGGY_API_TOKEN ? { Authorization: `Bearer ${CATALOGGY_API_TOKEN}` } : {}
+  });
+
+  const payload = await upstreamResponse.json().catch(() => ({ metas: [] }));
+
+  if (!upstreamResponse.ok) {
+    return reply.code(upstreamResponse.status).send(payload);
+  }
+
+  return reply.send(payload);
+});
 
 const start = async () => {
   const port = Number(process.env.PORT ?? 7001);


### PR DESCRIPTION
### Motivation

- Provide a Stremio/Omni-compatible personal addon that exposes the requested manifest shape and serves catalog endpoints for personal watchlist and continue-watching features.
- Proxy Stremio catalog requests to the existing Cataloggy API so the addon surface is small and leverages the app API for data.

### Description

- Replace the addon manifest in `apps/addon/src/index.ts` with the required personal manifest (`id: com.cataloggy.personal`, `name: Cataloggy (Personal)`, `version: 0.1.0`, `description`, `resources: ["catalog"]`, `types: ["movie","series"]`, and the four specified `catalogs`).
- Add environment configuration support for `CATALOGGY_API_BASE` (default `http://api:7000`), `CATALOGGY_API_TOKEN`, and `ADDON_PUBLIC_BASE` and surface `ADDON_PUBLIC_BASE` in `/health` for visibility.
- Implement `GET /catalog/:type/:id.json` with an explicit allowlist mapping the four accepted `(type, id)` combinations to upstream catalog ids and return `404` for unknown combinations.
- Proxy allowed catalog requests to `GET {CATALOGGY_API_BASE}/stremio/catalog/:catalogId`, forward `Authorization: Bearer {CATALOGGY_API_TOKEN}` when configured, and relay upstream JSON payloads (including `{ metas: [...] }`) and non-2xx status codes when possible.

### Testing

- Ran `pnpm --filter @cataloggy/addon typecheck`, which failed due to a network/proxy error while Corepack attempted to download `pnpm` (error from `corepack`/proxy tunnel), so type checking could not complete.
- No unit tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5b0359804832595a197d6d5e14a2b)