### PR TITLE
Persist Trakt OAuth tokens in database

### DIFF
--- a/apps/api/prisma/migrations/20260302143000_add_trakt_token/migration.sql
+++ b/apps/api/prisma/migrations/20260302143000_add_trakt_token/migration.sql
@@ -1,0 +1,10 @@
+-- CreateTable
+CREATE TABLE "TraktToken" (
+    "id" TEXT NOT NULL DEFAULT 'default',
+    "accessToken" TEXT NOT NULL,
+    "refreshToken" TEXT NOT NULL,
+    "expiresAt" TIMESTAMPTZ(6) NOT NULL,
+    "updatedAt" TIMESTAMPTZ(6) NOT NULL,
+
+    CONSTRAINT "TraktToken_pkey" PRIMARY KEY ("id")
+);

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -85,3 +85,11 @@ model KV {
   value     String
   updatedAt DateTime @db.Timestamp(6)
 }
+
+model TraktToken {
+  id           String   @id @default("default")
+  accessToken  String
+  refreshToken String
+  expiresAt    DateTime @db.Timestamptz(6)
+  updatedAt    DateTime @updatedAt @db.Timestamptz(6)
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -7,9 +7,9 @@ const prisma = new PrismaClient();
 const app = Fastify({ logger: true });
 let traktClient: TraktClient | null = null;
 
-const getTraktClient = () => {
+const getTraktClient = async () => {
   if (!traktClient) {
-    traktClient = new TraktClient();
+    traktClient = await TraktClient.create(prisma);
   }
 
   return traktClient;
@@ -149,7 +149,7 @@ const getTraktPollStartAt = async () => {
 };
 
 const pollTraktHistory = async (logger: FastifyRequest["log"]) => {
-  const client = getTraktClient();
+  const client = await getTraktClient();
   const pollStartAt = await getTraktPollStartAt();
   const pollCompletedAt = new Date();
   const pollStartAtIso = pollStartAt.toISOString();
@@ -538,7 +538,7 @@ app.delete<{ Params: { listId: string; type: string; imdbId: string } }>("/lists
 app.post("/trakt/import", { preHandler: verifyToken }, async (request, reply) => {
   let client: TraktClient;
   try {
-    client = getTraktClient();
+    client = await getTraktClient();
   } catch (error) {
     request.log.error(error, "Trakt client initialization failed");
     return reply.code(500).send({ error: "Trakt integration is not configured" });

--- a/apps/api/src/trakt.ts
+++ b/apps/api/src/trakt.ts
@@ -1,7 +1,9 @@
 import type { FastifyBaseLogger } from "fastify";
+import type { PrismaClient } from "@prisma/client";
 
 const TRAKT_API_BASE = "https://api.trakt.tv";
 const MAX_PAGES = 100;
+const DEFAULT_TOKEN_ROW_ID = "default";
 
 type TraktIds = {
   imdb?: string | null;
@@ -48,31 +50,75 @@ type TraktMovieHistoryPayload = {
 type TraktTokenResponse = {
   access_token: string;
   refresh_token: string;
+  expires_in?: number;
 };
 
 export class TraktClient {
   private readonly clientId: string;
   private readonly clientSecret: string;
+  private readonly prisma: PrismaClient;
   private accessToken: string;
   private refreshToken: string;
-  private hasLoggedPersistenceWarning = false;
 
-  constructor() {
+  private constructor(options: {
+    clientId: string;
+    clientSecret: string;
+    accessToken: string;
+    refreshToken: string;
+    prisma: PrismaClient;
+  }) {
+    this.clientId = options.clientId;
+    this.clientSecret = options.clientSecret;
+    this.accessToken = options.accessToken;
+    this.refreshToken = options.refreshToken;
+    this.prisma = options.prisma;
+  }
+
+  static async create(prisma: PrismaClient): Promise<TraktClient> {
     const clientId = process.env.TRAKT_CLIENT_ID;
     const clientSecret = process.env.TRAKT_CLIENT_SECRET;
+
+    if (!clientId || !clientSecret) {
+      throw new Error("Trakt credentials are incomplete. Set TRAKT_CLIENT_ID and TRAKT_CLIENT_SECRET.");
+    }
+
+    const persistedToken = await prisma.traktToken.findUnique({ where: { id: DEFAULT_TOKEN_ROW_ID } });
+
+    if (persistedToken) {
+      return new TraktClient({
+        clientId,
+        clientSecret,
+        accessToken: persistedToken.accessToken,
+        refreshToken: persistedToken.refreshToken,
+        prisma
+      });
+    }
+
     const accessToken = process.env.TRAKT_ACCESS_TOKEN;
     const refreshToken = process.env.TRAKT_REFRESH_TOKEN;
 
-    if (!clientId || !clientSecret || !accessToken || !refreshToken) {
+    if (!accessToken || !refreshToken) {
       throw new Error(
-        "Trakt credentials are incomplete. Set TRAKT_CLIENT_ID, TRAKT_CLIENT_SECRET, TRAKT_ACCESS_TOKEN, and TRAKT_REFRESH_TOKEN."
+        "Trakt tokens are missing. Configure TRAKT_ACCESS_TOKEN and TRAKT_REFRESH_TOKEN or seed TraktToken in the database."
       );
     }
 
-    this.clientId = clientId;
-    this.clientSecret = clientSecret;
-    this.accessToken = accessToken;
-    this.refreshToken = refreshToken;
+    await prisma.traktToken.create({
+      data: {
+        id: DEFAULT_TOKEN_ROW_ID,
+        accessToken,
+        refreshToken,
+        expiresAt: new Date(0)
+      }
+    });
+
+    return new TraktClient({
+      clientId,
+      clientSecret,
+      accessToken,
+      refreshToken,
+      prisma
+    });
   }
 
   async fetchWatchlistMovies(logger: FastifyBaseLogger): Promise<TraktMoviePayload[]> {
@@ -215,12 +261,27 @@ export class TraktClient {
     this.accessToken = tokenResponse.access_token;
     this.refreshToken = tokenResponse.refresh_token;
 
-    if (!this.hasLoggedPersistenceWarning) {
-      logger.warn(
-        "Trakt tokens were refreshed in memory only. Persist refreshed tokens to durable storage for production use."
-      );
-      this.hasLoggedPersistenceWarning = true;
-    }
+    const expiresAt =
+      typeof tokenResponse.expires_in === "number" && Number.isFinite(tokenResponse.expires_in)
+        ? new Date(Date.now() + tokenResponse.expires_in * 1000)
+        : new Date(0);
+
+    await this.prisma.traktToken.upsert({
+      where: { id: DEFAULT_TOKEN_ROW_ID },
+      update: {
+        accessToken: this.accessToken,
+        refreshToken: this.refreshToken,
+        expiresAt
+      },
+      create: {
+        id: DEFAULT_TOKEN_ROW_ID,
+        accessToken: this.accessToken,
+        refreshToken: this.refreshToken,
+        expiresAt
+      }
+    });
+
+    logger.info("Trakt tokens refreshed and persisted");
   }
 }
 


### PR DESCRIPTION
### Motivation
- Ensure Trakt OAuth tokens survive API restarts so background Trakt polling continues after token refreshes.
- Remove the fragile “in-memory only” refresh behavior and provide durable storage for refreshed tokens.
- Allow initial token seeding from environment variables when a DB row is not present for simple deployments.

### Description
- Added a new Prisma model `TraktToken` (single-row usage, `id` defaulting to `"default"`) with `accessToken`, `refreshToken`, `expiresAt` (`timestamptz`) and `updatedAt` (`@updatedAt` timestamptz). 
- Added a migration SQL file to create the `TraktToken` table and updated Prisma schema accordingly.
- Reworked `TraktClient` to be created via `static async create(prisma)` which loads tokens from DB or seeds the DB from `TRAKT_ACCESS_TOKEN`/`TRAKT_REFRESH_TOKEN` when missing, and made the constructor private to require the factory method.
- Persist token refreshes: the refresh flow now computes `expiresAt` from `expires_in` and `upsert`s `accessToken`, `refreshToken`, and `expiresAt` into the `TraktToken` row and logs persistence; removed the prior in-memory-only warning.
- Updated API wiring (`index.ts`) so `getTraktClient` is asynchronous (`TraktClient.create(prisma)`) and all call sites (poll/import) `await` client initialization.

### Testing
- Ran `pnpm -C apps/api prisma:generate` which completed successfully and regenerated the Prisma client.
- Ran `pnpm -C apps/api typecheck` which failed in this environment due to missing Node type definitions (environment/workspace issue), not due to code changes.
- Attempted workspace install with `pnpm -C /workspace/cataloggy install` which failed due to a lockfile inconsistency (`@eslint/js@9.17.0 not found in pnpm-lock.yaml`), preventing a full package check in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5b44f22488325bbce2494fce680d1)