### PR TITLE
Add dashboard list APIs and enrich catalog metadata responses

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -27,6 +27,17 @@ type StremioMetaPreview = {
   id: string;
   type: StremioMetaType;
   name: string;
+  poster?: string;
+  year?: number;
+  description?: string;
+};
+
+type ContinueMetaPreview = StremioMetaPreview & {
+  lastWatched: {
+    season: number;
+    episode: number;
+    updatedAt: string;
+  };
 };
 
 const DEFAULT_STREMIO_LIMIT = 50;
@@ -112,12 +123,21 @@ const parseCatalogLimit = (rawLimit: unknown) => {
   return Math.min(parsed, MAX_STREMIO_LIMIT);
 };
 
+const parseMetaType = (rawType: unknown): StremioMetaType | null => {
+  if (rawType === "movie" || rawType === "series") {
+    return rawType;
+  }
+
+  return null;
+};
+
 const buildMetasFromIds = async (ids: string[], type: StremioMetaType): Promise<StremioMetaPreview[]> => {
   if (ids.length === 0) {
     return [];
   }
 
   const itemType = type === "movie" ? ItemType.movie : ItemType.series;
+  const metadataType = type === "movie" ? MetadataType.movie : MetadataType.series;
   const items = await prisma.item.findMany({
     where: {
       type: itemType,
@@ -128,14 +148,118 @@ const buildMetasFromIds = async (ids: string[], type: StremioMetaType): Promise<
       title: true
     }
   });
+  const metadata = await prisma.metadata.findMany({
+    where: {
+      imdbId: { in: ids },
+      type: metadataType
+    },
+    select: {
+      imdbId: true,
+      name: true,
+      poster: true,
+      year: true,
+      description: true
+    }
+  });
 
   const titleByImdbId = new Map(items.map((item) => [item.imdbId, item.title?.trim() ?? ""]));
+  const metadataByImdbId = new Map(metadata.map((entry) => [entry.imdbId, entry]));
 
-  return ids.map((id) => ({
-    id,
-    type,
-    name: titleByImdbId.get(id) || id
-  }));
+  return ids.map((id) => {
+    const meta = metadataByImdbId.get(id);
+
+    return {
+      id,
+      type,
+      name: titleByImdbId.get(id) || meta?.name || id,
+      poster: meta?.poster ?? undefined,
+      year: meta?.year ?? undefined,
+      description: meta?.description ?? undefined
+    };
+  });
+};
+
+const getWatchlistMetas = async (type: StremioMetaType, limit: number) => {
+  const watchlist = await getDefaultWatchlist();
+  const listItemType = type === "movie" ? ListItemType.movie : ListItemType.series;
+
+  const watchlistItems = await prisma.listItem.findMany({
+    where: { listId: watchlist.id, type: listItemType },
+    orderBy: { addedAt: "desc" },
+    take: limit,
+    select: { imdbId: true }
+  });
+
+  return buildMetasFromIds(
+    watchlistItems.map((item) => item.imdbId),
+    type
+  );
+};
+
+const getRecentMetas = async (type: StremioMetaType, limit: number) => {
+  if (type === "movie") {
+    const groupedMovies = await prisma.watchEvent.groupBy({
+      by: ["imdbId"],
+      where: { type: "movie" },
+      _max: { watchedAt: true },
+      orderBy: { _max: { watchedAt: "desc" } },
+      take: limit
+    });
+
+    return buildMetasFromIds(groupedMovies.map((event) => event.imdbId), type);
+  }
+
+  const groupedSeries = await prisma.watchEvent.groupBy({
+    by: ["seriesImdbId"],
+    where: {
+      type: "episode",
+      seriesImdbId: { not: null }
+    },
+    _max: { watchedAt: true },
+    orderBy: { _max: { watchedAt: "desc" } },
+    take: limit
+  });
+
+  const ids = groupedSeries.map((event) => event.seriesImdbId).filter((id): id is string => Boolean(id));
+
+  return buildMetasFromIds(ids, type);
+};
+
+const getContinueMetas = async (limit: number): Promise<ContinueMetaPreview[]> => {
+  const seriesProgress = await prisma.seriesProgress.findMany({
+    orderBy: { updatedAt: "desc" },
+    take: limit,
+    select: {
+      seriesImdbId: true,
+      lastSeason: true,
+      lastEpisode: true,
+      updatedAt: true
+    }
+  });
+
+  const metas = await buildMetasFromIds(
+    seriesProgress.map((progress) => progress.seriesImdbId),
+    "series"
+  );
+
+  const progressBySeriesId = new Map(seriesProgress.map((progress) => [progress.seriesImdbId, progress]));
+  return metas
+    .map((meta) => {
+      const progress = progressBySeriesId.get(meta.id);
+      if (!progress) {
+        return null;
+      }
+
+      return {
+        ...meta,
+        lastWatched: {
+          season: progress.lastSeason,
+          episode: progress.lastEpisode,
+          updatedAt: progress.updatedAt.toISOString()
+        }
+      };
+    })
+    .filter((meta): meta is ContinueMetaPreview => Boolean(meta));
 };
 
 const ensureDefaultWatchlist = async () => {
@@ -494,74 +618,59 @@ app.get("/lists", { preHandler: verifyToken }, async () => {
 
 app.get<{ Querystring: { limit?: string } }>("/stremio/catalog/my_watchlist_movies", { preHandler: verifyToken }, async (request) => {
   const limit = parseCatalogLimit(request.query.limit);
-  const watchlist = await getDefaultWatchlist();
-
-  const watchlistItems = await prisma.listItem.findMany({
-    where: { listId: watchlist.id, type: ListItemType.movie },
-    orderBy: { addedAt: "desc" },
-    take: limit,
-    select: { imdbId: true }
-  });
-
-  const metas = await buildMetasFromIds(
-    watchlistItems.map((item) => item.imdbId),
-    "movie"
-  );
+  const metas = await getWatchlistMetas("movie", limit);
 
   return { metas };
 });
 
 app.get<{ Querystring: { limit?: string } }>("/stremio/catalog/my_watchlist_series", { preHandler: verifyToken }, async (request) => {
   const limit = parseCatalogLimit(request.query.limit);
-  const watchlist = await getDefaultWatchlist();
-
-  const watchlistItems = await prisma.listItem.findMany({
-    where: { listId: watchlist.id, type: ListItemType.series },
-    orderBy: { addedAt: "desc" },
-    take: limit,
-    select: { imdbId: true }
-  });
-
-  const metas = await buildMetasFromIds(
-    watchlistItems.map((item) => item.imdbId),
-    "series"
-  );
+  const metas = await getWatchlistMetas("series", limit);
 
   return { metas };
 });
 
 app.get<{ Querystring: { limit?: string } }>("/stremio/catalog/my_recent_movies", { preHandler: verifyToken }, async (request) => {
   const limit = parseCatalogLimit(request.query.limit);
-
-  const groupedMovies = await prisma.watchEvent.groupBy({
-    by: ["imdbId"],
-    where: { type: "movie" },
-    _max: { watchedAt: true },
-    orderBy: { _max: { watchedAt: "desc" } },
-    take: limit
-  });
-
-  const metas = await buildMetasFromIds(
-    groupedMovies.map((event) => event.imdbId),
-    "movie"
-  );
+  const metas = await getRecentMetas("movie", limit);
 
   return { metas };
 });
 
 app.get<{ Querystring: { limit?: string } }>("/stremio/catalog/my_continue_series", { preHandler: verifyToken }, async (request) => {
   const limit = parseCatalogLimit(request.query.limit);
+  const metas = await getContinueMetas(limit);
 
-  const seriesProgress = await prisma.seriesProgress.findMany({
-    orderBy: { updatedAt: "desc" },
-    take: limit,
-    select: { seriesImdbId: true }
-  });
+  return { metas };
+});
 
-  const metas = await buildMetasFromIds(
-    seriesProgress.map((progress) => progress.seriesImdbId),
-    "series"
-  );
+app.get<{ Querystring: { type?: string; limit?: string } }>("/watchlist", { preHandler: verifyToken }, async (request, reply) => {
+  const type = parseMetaType(request.query.type);
+  if (!type) {
+    return reply.code(400).send({ error: "type must be one of: movie, series" });
+  }
+
+  const limit = parseCatalogLimit(request.query.limit);
+  const metas = await getWatchlistMetas(type, limit);
+
+  return { metas };
+});
+
+app.get<{ Querystring: { limit?: string } }>("/continue", { preHandler: verifyToken }, async (request) => {
+  const limit = parseCatalogLimit(request.query.limit);
+  const metas = await getContinueMetas(limit);
+
+  return { metas };
+});
+
+app.get<{ Querystring: { type?: string; limit?: string } }>("/recent", { preHandler: verifyToken }, async (request, reply) => {
+  const type = parseMetaType(request.query.type);
+  if (!type) {
+    return reply.code(400).send({ error: "type must be one of: movie, series" });
+  }
+
+  const limit = parseCatalogLimit(request.query.limit);
+  const metas = await getRecentMetas(type, limit);
 
   return { metas };
 });

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -29,6 +29,9 @@ export type CatalogMeta = {
   id: string;
   type: MediaType;
   name: string;
+  poster?: string;
+  year?: number;
+  description?: string;
 };
 
 const authHeaders = () => {
@@ -91,9 +94,9 @@ export const api = {
   },
   dashboard() {
     return Promise.all([
-      request<{ metas: CatalogMeta[] }>("/stremio/catalog/my_watchlist_movies?limit=10"),
-      request<{ metas: CatalogMeta[] }>("/stremio/catalog/my_continue_series?limit=10"),
-      request<{ metas: CatalogMeta[] }>("/stremio/catalog/my_recent_movies?limit=10")
+      request<{ metas: CatalogMeta[] }>("/watchlist?type=movie&limit=10"),
+      request<{ metas: CatalogMeta[] }>("/continue?limit=10"),
+      request<{ metas: CatalogMeta[] }>("/recent?type=movie&limit=10")
     ]);
   }
 };

--- a/apps/web/src/components/MediaList.tsx
+++ b/apps/web/src/components/MediaList.tsx
@@ -14,8 +14,21 @@ export function MediaList({ title, items }: Props) {
       ) : (
         <ul className="space-y-2">
           {items.map((item) => (
-            <li key={`${item.type}:${item.id}`} className="rounded bg-slate-800/60 px-3 py-2 text-sm">
-              {item.name}
+            <li key={`${item.type}:${item.id}`} className="flex items-center gap-3 rounded bg-slate-800/60 px-3 py-2 text-sm">
+              {item.poster ? (
+                <img
+                  src={item.poster}
+                  alt={`${item.name} poster`}
+                  className="h-14 w-10 shrink-0 rounded object-cover"
+                  loading="lazy"
+                />
+              ) : (
+                <div className="h-14 w-10 shrink-0 rounded bg-slate-700" aria-hidden />
+              )}
+              <div className="min-w-0">
+                <p className="truncate font-medium text-slate-100">{item.name}</p>
+                {item.year ? <p className="text-xs text-slate-400">{item.year}</p> : null}
+              </div>
             </li>
           ))}
         </ul>


### PR DESCRIPTION
### Motivation
- Provide dashboard-facing list APIs that return richer metadata so the UI can render posters and titles. 
- Expose simple `watchlist`, `continue`, and `recent` endpoints with `type` and `limit` query options to support the dashboard layout and Stremio-style catalogs. 
- Surface last-watched episode progress for series so the UI can show continue-watching details.

### Description
- Add richer meta shapes and helpers in the API: new `StremioMetaPreview` (with `poster`, `year`, `description`) and `ContinueMetaPreview`, plus `buildMetasFromIds`, `getWatchlistMetas`, `getRecentMetas`, and `getContinueMetas` helpers in `apps/api/src/index.ts`. 
- Add new authenticated endpoints `GET /watchlist?type=movie|series&limit=...`, `GET /continue?limit=...`, and `GET /recent?type=movie|series&limit=...`, and refactor existing `/stremio/catalog/*` list routes to reuse the new helpers. 
- Enrich list responses with metadata from the `metadata` table when present (fields: `poster`, `year`, `description`) and include `lastWatched` progress for `/continue`. 
- Update web client to use the new endpoints and extended meta type (`apps/web/src/api.ts`) and change the dashboard `MediaList` to render posters, title, and year with a placeholder when a poster is missing (`apps/web/src/components/MediaList.tsx`).

### Testing
- Attempted TypeScript checks with `pnpm typecheck`, but the run failed due to missing dependency installs in the environment (type definitions unavailable). (failed)
- Attempted to install dependencies with `pnpm install`, but the registry returned `403` for package fetches in this environment so installs could not complete. (failed)
- Ran `pnpm --filter @cataloggy/api typecheck` to focus on the API, but it was blocked by the same missing type definitions due to the install failure. (failed)
- Attempted a Playwright page visit to capture the dashboard (`http://localhost:5173`) but the web app was not running in this environment so the check returned `ERR_EMPTY_RESPONSE`. (failed)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5bc3391108325acf9a52d1b9510dd)