### PR TITLE
Add Stremio meta resource support in addon

### DIFF
--- a/apps/addon/src/index.ts
+++ b/apps/addon/src/index.ts
@@ -11,7 +11,7 @@ const manifest = {
   name: "Cataloggy (Personal)",
   version: "0.1.0",
   description: "Personal watchlist + continue watching from your self-hosted Cataloggy.",
-  resources: ["catalog"],
+  resources: ["catalog", "meta"],
   types: ["movie", "series"],
   catalogs: [
     { type: "movie", id: "my_watchlist_movies", name: "Cataloggy Watchlist (Movies)" },
@@ -52,6 +52,46 @@ app.get<{ Params: { type: string; id: string } }>("/catalog/:type/:id.json", asy
   }
 
   return reply.send(payload);
+});
+
+app.get<{ Params: { type: string; id: string } }>("/meta/:type/:id.json", async (request, reply) => {
+  const { type, id } = request.params;
+
+  if (type !== "movie" && type !== "series") {
+    return reply.code(400).send({ error: "type must be one of: movie, series" });
+  }
+
+  const imdbId = id.trim();
+  if (!imdbId) {
+    return reply.code(400).send({ error: "id is required" });
+  }
+
+  const apiUrl = new URL(`/meta/${type}/${encodeURIComponent(imdbId)}`, CATALOGGY_API_BASE);
+
+  const upstreamResponse = await fetch(apiUrl, {
+    headers: CATALOGGY_API_TOKEN ? { Authorization: `Bearer ${CATALOGGY_API_TOKEN}` } : {}
+  });
+
+  const payload = await upstreamResponse.json().catch(() => ({}));
+
+  if (!upstreamResponse.ok) {
+    return reply.code(upstreamResponse.status).send(payload);
+  }
+
+  const releaseInfo = typeof payload.year === "number" ? String(payload.year) : undefined;
+
+  return reply.send({
+    meta: {
+      id: imdbId,
+      type,
+      name: typeof payload.name === "string" && payload.name.trim() ? payload.name : imdbId,
+      poster: typeof payload.poster === "string" ? payload.poster : undefined,
+      background: typeof payload.background === "string" ? payload.background : undefined,
+      description: typeof payload.description === "string" ? payload.description : undefined,
+      releaseInfo,
+      year: typeof payload.year === "number" ? payload.year : undefined
+    }
+  });
 });
 
 const start = async () => {


### PR DESCRIPTION
### Motivation
- Enable Stremio clients to request detailed metadata (so Omni shows rich item info) by exposing the Stremio `meta` resource from the addon.
- Reuse the API service's TMDB-backed metadata (with fetch/cache) instead of duplicating TMDB logic in the addon.

### Description
- Added `meta` to the addon manifest `resources` so clients can request metadata in addition to catalogs via `manifest.json`.
- Implemented `GET /meta/:type/:id.json` in `apps/addon/src/index.ts` that validates `type` (`movie`/`series`) and non-empty `id` before forwarding to the upstream API at `GET /meta/:type/:imdbId`.
- Propagates non-OK upstream responses and maps a successful upstream payload into the Stremio meta shape with `id`, `type`, `name`, `poster`, `background`, `description`, `releaseInfo`, and `year`.
- Relies on the API service to fetch/cache metadata from TMDB when missing, and performs basic defensive typing on returned fields.

### Testing
- Ran `pnpm --filter @cataloggy/addon typecheck`, which failed in this environment due to a missing development dependency (`@types/node`).
- Ran `pnpm --filter @cataloggy/addon lint`, which failed in this environment due to a missing ESLint plugin (`@eslint/js`).
- Verified the new route compiles syntactically in the project file and basic runtime shape by local inspection of the updated `apps/addon/src/index.ts` file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5bd95860083259bcf3e4c553a1611)