### PR TITLE
Expose custom lists as Stremio catalogs and add /stremio/list endpoint

### DIFF
--- a/apps/addon/src/index.ts
+++ b/apps/addon/src/index.ts
@@ -6,6 +6,12 @@ const CATALOGGY_API_BASE = process.env.CATALOGGY_API_BASE ?? "http://api:7000";
 const CATALOGGY_API_TOKEN = process.env.CATALOGGY_API_TOKEN;
 const ADDON_PUBLIC_BASE = process.env.ADDON_PUBLIC_BASE;
 
+type CataloggyList = {
+  id: string;
+  name: string;
+  kind: "watchlist" | "custom";
+};
+
 const manifest = {
   id: "com.cataloggy.personal",
   name: "Cataloggy (Personal)",
@@ -29,14 +35,70 @@ const catalogRouteMap: Record<string, string> = {
 };
 
 app.get("/health", async () => ({ status: "ok", service: "addon", publicBase: ADDON_PUBLIC_BASE ?? null }));
-app.get("/manifest.json", async () => manifest);
+
+const fetchCustomLists = async (): Promise<CataloggyList[]> => {
+  const apiUrl = new URL("/lists", CATALOGGY_API_BASE);
+  const upstreamResponse = await fetch(apiUrl, {
+    headers: CATALOGGY_API_TOKEN ? { Authorization: `Bearer ${CATALOGGY_API_TOKEN}` } : {}
+  });
+
+  if (!upstreamResponse.ok) {
+    throw new Error(`Failed to fetch lists: ${upstreamResponse.status}`);
+  }
+
+  const payload = (await upstreamResponse.json()) as { lists?: CataloggyList[] };
+  return (payload.lists ?? []).filter((list) => list.kind === "custom");
+};
+
+app.get("/manifest.json", async (request, reply) => {
+  try {
+    const customLists = await fetchCustomLists();
+    const customCatalogs = customLists.flatMap((list) => [
+      { type: "movie", id: `list_${list.id}_movies`, name: `Cataloggy List: ${list.name} (Movies)` },
+      { type: "series", id: `list_${list.id}_series`, name: `Cataloggy List: ${list.name} (Shows)` }
+    ]);
+
+    return reply.send({
+      ...manifest,
+      catalogs: [...manifest.catalogs, ...customCatalogs]
+    });
+  } catch (error) {
+    request.log.error(error, "Failed to fetch custom lists for manifest");
+    return reply.code(502).send({ error: "Failed to build manifest" });
+  }
+});
 
 app.get<{ Params: { type: string; id: string } }>("/catalog/:type/:id.json", async (request, reply) => {
   const routeKey = `${request.params.type}:${request.params.id}`;
   const catalogId = catalogRouteMap[routeKey];
 
   if (!catalogId) {
-    return reply.code(404).send({ error: "Catalog not found" });
+    const customListMatch = request.params.id.match(/^list_([0-9a-f-]+)_(movies|series)$/i);
+    if (!customListMatch) {
+      return reply.code(404).send({ error: "Catalog not found" });
+    }
+
+    const listId = customListMatch[1];
+    const listType = customListMatch[2] === "movies" ? "movie" : "series";
+
+    if (request.params.type !== listType) {
+      return reply.code(404).send({ error: "Catalog not found" });
+    }
+
+    const apiUrl = new URL(`/stremio/list/${encodeURIComponent(listId)}`, CATALOGGY_API_BASE);
+    apiUrl.searchParams.set("type", listType);
+
+    const upstreamResponse = await fetch(apiUrl, {
+      headers: CATALOGGY_API_TOKEN ? { Authorization: `Bearer ${CATALOGGY_API_TOKEN}` } : {}
+    });
+
+    const payload = await upstreamResponse.json().catch(() => ({ metas: [] }));
+
+    if (!upstreamResponse.ok) {
+      return reply.code(upstreamResponse.status).send(payload);
+    }
+
+    return reply.send(payload);
   }
 
   const apiUrl = new URL(`/stremio/catalog/${catalogId}`, CATALOGGY_API_BASE);

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -262,6 +262,21 @@ const getContinueMetas = async (limit: number): Promise<ContinueMetaPreview[]> =
     .filter((meta): meta is ContinueMetaPreview => Boolean(meta));
 };
 
+const getCustomListMetas = async (listId: string, type: StremioMetaType, limit: number) => {
+  const listItemType = type === "movie" ? ListItemType.movie : ListItemType.series;
+  const listItems = await prisma.listItem.findMany({
+    where: { listId, type: listItemType },
+    orderBy: { addedAt: "desc" },
+    take: limit,
+    select: { imdbId: true }
+  });
+
+  return buildMetasFromIds(
+    listItems.map((item) => item.imdbId),
+    type
+  );
+};
+
 const ensureDefaultWatchlist = async () => {
   await prisma.$transaction(
     async (tx) => {
@@ -640,6 +655,31 @@ app.get<{ Querystring: { limit?: string } }>("/stremio/catalog/my_recent_movies"
 app.get<{ Querystring: { limit?: string } }>("/stremio/catalog/my_continue_series", { preHandler: verifyToken }, async (request) => {
   const limit = parseCatalogLimit(request.query.limit);
   const metas = await getContinueMetas(limit);
+
+  return { metas };
+});
+
+app.get<{ Params: { listId: string }; Querystring: { type?: string; limit?: string } }>("/stremio/list/:listId", { preHandler: verifyToken }, async (request, reply) => {
+  const type = parseMetaType(request.query.type);
+  if (!type) {
+    return reply.code(400).send({ error: "type must be one of: movie, series" });
+  }
+
+  if (!UUID_V4_PATTERN.test(request.params.listId)) {
+    return reply.code(400).send({ error: "listId must be a valid UUID" });
+  }
+
+  const list = await prisma.list.findUnique({
+    where: { id: request.params.listId },
+    select: { id: true, kind: true }
+  });
+
+  if (!list || list.kind !== ListKind.custom) {
+    return reply.code(404).send({ error: "Custom list not found" });
+  }
+
+  const limit = parseCatalogLimit(request.query.limit);
+  const metas = await getCustomListMetas(list.id, type, limit);
 
   return { metas };
 });


### PR DESCRIPTION
### Motivation
- Make user-created `custom` lists browseable in Stremio by exposing them as dynamic catalogs in the addon manifest.
- Route Stremio catalog requests for those dynamic catalogs to the API so catalog items are served from the existing metadata pipeline.
- Provide a token-protected API endpoint to return list items as Stremio metas with limit handling and validation.

### Description
- Updated `apps/addon/src/index.ts` to fetch `GET /lists` from the API, filter `kind === "custom"`, and append two catalogs per list using IDs `list_<listId>_movies` and `list_<listId>_series` and names `Cataloggy List: <name> (Movies/Shows)`.
- Implemented dynamic manifest generation and added `fetchCustomLists` to call the API with optional `Authorization` header from `CATALOGGY_API_TOKEN` and return a 502 on failure.
- Extended catalog routing in the addon to recognize IDs matching `^list_<uuid>_(movies|series)$` and proxy those to `GET /stremio/list/<listId>?type=movie|series` on the API with token forwarding.
- Added `getCustomListMetas` helper and a new API route `GET /stremio/list/:listId?type=movie|series&limit=...` in `apps/api/src/index.ts` which validates `type`, ensures `listId` is a UUID, verifies the list exists and is `kind === ListKind.custom`, applies `limit` parsing, and returns Stremio metas via existing `buildMetasFromIds` logic.

### Testing
- Ran `pnpm typecheck`, which failed because dependencies/types are missing in this environment after install failure.
- Ran `pnpm install`, which failed due to registry authorization (npm registry returned 403), so full typecheck/build could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5be3f50d483259ac74cce444715da)