### PR TITLE
Add web service to docker-compose (port 7002) and add web/.env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,6 @@ TRAKT_REFRESH_TOKEN=
 
 # TMDB integration (optional; required for /search and /meta/:type/:imdbId)
 TMDB_API_KEY=
+
+# Web runtime (optional; docker-compose sets internal defaults)
+VITE_API_BASE=

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ cataloggy/
    cp .env.example .env
    ```
 
+   Set `TMDB_API_KEY` in `.env` if you plan to use the search/meta endpoints.
+
 3. Start everything with Docker Compose:
 
    ```bash
@@ -53,6 +55,7 @@ cataloggy/
 
 - API: http://localhost:7000/health
 - Addon: http://localhost:7001/manifest.json
+- Web: http://localhost:7002
 - Postgres: `localhost:5432` (`postgres` / `postgres`, db `cataloggy`)
 
 ## Useful Commands

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,2 @@
+# API base URL used by the web app
+VITE_API_BASE=http://localhost:7000

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:20-alpine
+
+WORKDIR /app
+RUN corepack enable
+RUN apk add --no-cache wget
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json eslint.config.mjs ./
+COPY apps/web/package.json ./apps/web/package.json
+
+RUN pnpm install --frozen-lockfile
+
+COPY apps/web ./apps/web
+
+RUN addgroup -S app && adduser -S app -G app && chown -R app:app /app
+USER app
+
+EXPOSE 7002
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s CMD wget -q --spider http://127.0.0.1:7002/ || exit 1
+CMD ["sh", "-c", "pnpm --filter @cataloggy/web build && pnpm --filter @cataloggy/web preview --host 0.0.0.0 --port 7002"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,5 +63,25 @@ services:
       retries: 10
       start_period: 10s
 
+  web:
+    build:
+      context: .
+      dockerfile: apps/web/Dockerfile
+    env_file:
+      - .env
+    environment:
+      VITE_API_BASE: ${VITE_API_BASE:-http://api:7000}
+    ports:
+      - "7002:7002"
+    depends_on:
+      api:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://127.0.0.1:7002/ || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+
 volumes:
   pgdata:


### PR DESCRIPTION
### Motivation
- Enable the frontend app to be run inside Docker Compose by adding a `web` service that builds and serves the Vite app on port `7002`.
- Provide an example env file for the web app so `VITE_API_BASE` is documented and can be set for local/dev usage.
- Ensure TMDB integration is documented in the repository `.env.example` and README so search/meta endpoints are discoverable and configurable.

### Description
- Added a `web` service block to `docker-compose.yml` that builds from `apps/web/Dockerfile`, exposes `7002`, depends on the API healthcheck, and sets `VITE_API_BASE` defaulting to `http://api:7000`.
- Added `apps/web/Dockerfile` to install workspace deps, build the web app and serve it with `vite preview --host 0.0.0.0 --port 7002`, including a healthcheck.
- Added `apps/web/.env.example` with `VITE_API_BASE=http://localhost:7000` and extended the root `.env.example` with an optional `VITE_API_BASE` entry while keeping `TMDB_API_KEY` documented.
- Updated `README.md` to include the web service URL and a note instructing users to set `TMDB_API_KEY` in `.env` when using search/meta endpoints.

### Testing
- Attempted `docker compose config` but it could not run because the Docker CLI is not available in the environment, so compose validation could not be performed.
- Ran `pnpm --filter @cataloggy/web build` which failed due to missing workspace `node_modules` (build expected a bootstrapped workspace).
- Ran `pnpm install` which failed in this environment due to an npm registry authentication `403` error, preventing full local build validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5c17fc9548325afb6a23b005a1cef)