### PR TITLE
Add PWA support with icons, manifest, service worker, and install UI

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -3,7 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>CataLoggy</title>
+    <meta name="theme-color" content="#0ea5e9" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <meta name="apple-mobile-web-app-title" content="Cataloggy" />
+    <link rel="apple-touch-icon" href="/icons/icon-192.svg" />
+    <title>Cataloggy</title>
   </head>
   <body class="bg-slate-950">
     <div id="root"></div>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -23,6 +23,7 @@
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.16",
     "typescript": "^5.7.2",
-    "vite": "^5.4.11"
+    "vite": "^5.4.11",
+    "vite-plugin-pwa": "^0.20.5"
   }
 }

--- a/apps/web/public/icons/icon-192.svg
+++ b/apps/web/public/icons/icon-192.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="192" height="192" viewBox="0 0 192 192" role="img" aria-label="Cataloggy icon">
+  <rect width="192" height="192" rx="36" fill="#0f172a" />
+  <circle cx="96" cy="96" r="62" fill="#0ea5e9" opacity="0.25" />
+  <path d="M58 62h76v16H74v16h52v16H74v20h60v16H58z" fill="#e2e8f0" />
+</svg>

--- a/apps/web/public/icons/icon-512.svg
+++ b/apps/web/public/icons/icon-512.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512" role="img" aria-label="Cataloggy icon">
+  <rect width="512" height="512" rx="96" fill="#0f172a" />
+  <circle cx="256" cy="256" r="172" fill="#0ea5e9" opacity="0.25" />
+  <path d="M155 165h202v42H197v42h138v42H197v56h160v42H155z" fill="#e2e8f0" />
+</svg>

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,4 +1,5 @@
 import { Link, NavLink, Route, Routes } from "react-router-dom";
+import { InstallButton } from "./components/InstallButton";
 import { DashboardPage } from "./pages/DashboardPage";
 import { ListsPage } from "./pages/ListsPage";
 import { SearchPage } from "./pages/SearchPage";
@@ -11,19 +12,22 @@ export function App() {
     <div className="mx-auto min-h-screen w-full max-w-6xl px-4 py-6">
       <header className="mb-6 flex items-center justify-between">
         <Link to="/" className="text-xl font-semibold text-sky-300">
-          CataLoggy
+          Cataloggy
         </Link>
-        <nav className="flex gap-2">
-          <NavLink to="/" end className={navClass}>
-            Dashboard
-          </NavLink>
-          <NavLink to="/search" className={navClass}>
-            Search
-          </NavLink>
-          <NavLink to="/lists" className={navClass}>
-            Lists
-          </NavLink>
-        </nav>
+        <div className="flex items-center gap-3">
+          <InstallButton />
+          <nav className="flex gap-2">
+            <NavLink to="/" end className={navClass}>
+              Dashboard
+            </NavLink>
+            <NavLink to="/search" className={navClass}>
+              Search
+            </NavLink>
+            <NavLink to="/lists" className={navClass}>
+              Lists
+            </NavLink>
+          </nav>
+        </div>
       </header>
 
       <main>

--- a/apps/web/src/components/InstallButton.tsx
+++ b/apps/web/src/components/InstallButton.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useState } from "react";
+
+type BeforeInstallPromptEvent = Event & {
+  prompt: () => Promise<void>;
+  userChoice: Promise<{ outcome: "accepted" | "dismissed"; platform: string }>;
+};
+
+const isIOS = /iphone|ipad|ipod/i.test(window.navigator.userAgent);
+const isStandalone =
+  window.matchMedia("(display-mode: standalone)").matches ||
+  ("standalone" in window.navigator && Boolean((window.navigator as Navigator & { standalone?: boolean }).standalone));
+
+export function InstallButton() {
+  const [deferredPrompt, setDeferredPrompt] = useState<BeforeInstallPromptEvent | null>(null);
+  const [showManualHint, setShowManualHint] = useState(false);
+
+  useEffect(() => {
+    const onBeforeInstallPrompt = (event: Event) => {
+      event.preventDefault();
+      setDeferredPrompt(event as BeforeInstallPromptEvent);
+      setShowManualHint(false);
+    };
+
+    window.addEventListener("beforeinstallprompt", onBeforeInstallPrompt);
+    return () => window.removeEventListener("beforeinstallprompt", onBeforeInstallPrompt);
+  }, []);
+
+  if (isStandalone) {
+    return null;
+  }
+
+  const onInstall = async () => {
+    if (deferredPrompt) {
+      await deferredPrompt.prompt();
+      await deferredPrompt.userChoice;
+      setDeferredPrompt(null);
+      return;
+    }
+
+    setShowManualHint(true);
+  };
+
+  return (
+    <div className="flex flex-col items-end gap-2">
+      <button
+        type="button"
+        onClick={() => {
+          void onInstall();
+        }}
+        className="rounded-md border border-sky-400/60 bg-sky-500/10 px-3 py-2 text-xs font-medium text-sky-200 hover:bg-sky-500/20"
+      >
+        Install Cataloggy
+      </button>
+      {showManualHint && (
+        <p className="max-w-xs text-right text-xs text-slate-400">
+          {isIOS
+            ? "Safari: tap Share, then Add to Home Screen."
+            : "Use your browser menu and choose Install app / Add to Home Screen."}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,8 +1,11 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
+import { registerSW } from "virtual:pwa-register";
 import { App } from "./App";
 import "./index.css";
+
+registerSW({ immediate: true });
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,6 +1,37 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import { VitePWA } from "vite-plugin-pwa";
 
 export default defineConfig({
-  plugins: [react()]
+  plugins: [
+    react(),
+    VitePWA({
+      registerType: "autoUpdate",
+      includeAssets: ["icons/icon-192.svg", "icons/icon-512.svg"],
+      manifest: {
+        name: "Cataloggy",
+        short_name: "Cataloggy",
+        start_url: "/",
+        display: "standalone",
+        background_color: "#0f172a",
+        theme_color: "#0ea5e9",
+        icons: [
+          {
+            src: "/icons/icon-192.svg",
+            sizes: "192x192",
+            type: "image/svg+xml"
+          },
+          {
+            src: "/icons/icon-512.svg",
+            sizes: "512x512",
+            type: "image/svg+xml"
+          }
+        ]
+      },
+      workbox: {
+        navigateFallback: "/index.html",
+        globPatterns: ["**/*.{js,css,html,ico,png,svg,woff2}"]
+      }
+    })
+  ]
 });


### PR DESCRIPTION
### Motivation

- Enable progressive web app (PWA) capabilities so the site can be installed and run standalone with offline support.
- Provide proper mobile/Apple meta tags and app icon assets for a better home-screen experience.
- Surface an in-app install affordance and fix the app title to a consistent `Cataloggy` name.

### Description

- Added `vite-plugin-pwa` to `apps/web/package.json` and configured it in `apps/web/vite.config.ts` with a manifest, icons, and Workbox options.
- Registered the service worker by calling `registerSW({ immediate: true })` in `apps/web/src/main.tsx`.
- Added Apple/mobile meta tags and set the document title in `apps/web/index.html` and included an `apple-touch-icon` reference.
- Added SVG icon assets at `apps/web/public/icons/icon-192.svg` and `apps/web/public/icons/icon-512.svg` and included them in the PWA manifest.
- Implemented an `InstallButton` component at `apps/web/src/components/InstallButton.tsx` that handles the `beforeinstallprompt` flow and provides manual install hints for iOS, and integrated it into the header in `apps/web/src/App.tsx`.
- Standardized the visible app name to `Cataloggy` in the UI.

### Testing

- Ran TypeScript checks with `npm run typecheck` for the web app and it completed successfully.
- Performed a production build with `npm run build` in `apps/web` and the build succeeded without errors.
- Verified the dev server start with `npm run dev` locally to ensure no runtime import or plugin errors occurred.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5c212fa5483258376c021d97d1a92)