### PR TITLE
Bind services to LAN and add API CORS allowlist

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,7 @@ API_TOKEN=dev-token
 DATABASE_URL=
 PORT=
 TRAKT_POLL_INTERVAL_SEC=300
+CATALOGGY_ALLOWED_ORIGINS=http://localhost:7002
 
 # Addon runtime (optional; docker-compose sets internal defaults)
 CATALOGGY_API_BASE=

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -2,6 +2,7 @@ DATABASE_URL="postgresql://postgres:postgres@localhost:5432/cataloggy"
 PORT=7000
 
 API_TOKEN=dev-token
+CATALOGGY_ALLOWED_ORIGINS=http://localhost:7002
 TRAKT_CLIENT_ID=
 TRAKT_CLIENT_SECRET=
 TRAKT_ACCESS_TOKEN=

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -20,6 +20,12 @@ const API_TOKEN = process.env.API_TOKEN;
 const TRAKT_LAST_POLLED_AT_KEY = "trakt:lastPolledAt";
 const TRAKT_POLL_INTERVAL_SEC = Number(process.env.TRAKT_POLL_INTERVAL_SEC ?? 300);
 const UUID_V4_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const CATALOGGY_ALLOWED_ORIGINS = (process.env.CATALOGGY_ALLOWED_ORIGINS ?? "")
+  .split(",")
+  .map((origin) => origin.trim())
+  .filter(Boolean);
+const CORS_METHODS = "GET,POST,DELETE,OPTIONS";
+const CORS_HEADERS = "Authorization,Content-Type";
 
 type AuthenticatedRequest = FastifyRequest;
 type StremioMetaType = "movie" | "series";
@@ -53,6 +59,27 @@ type SeriesProgressCandidate = {
 const DEFAULT_STREMIO_LIMIT = 50;
 const MAX_STREMIO_LIMIT = 200;
 
+const isAllowedOrigin = (origin: string | undefined) => {
+  if (!origin) {
+    return false;
+  }
+
+  return CATALOGGY_ALLOWED_ORIGINS.includes(origin);
+};
+
+const applyCorsHeaders = (request: FastifyRequest, reply: FastifyReply) => {
+  const origin = request.headers.origin;
+
+  if (!isAllowedOrigin(origin)) {
+    return;
+  }
+
+  reply.header("Access-Control-Allow-Origin", origin);
+  reply.header("Access-Control-Allow-Methods", CORS_METHODS);
+  reply.header("Access-Control-Allow-Headers", CORS_HEADERS);
+  reply.header("Vary", "Origin");
+};
+
 const toSha256Digest = (value: string) => createHash("sha256").update(value).digest();
 
 const verifyToken = async (request: AuthenticatedRequest, reply: FastifyReply) => {
@@ -74,6 +101,14 @@ const verifyToken = async (request: AuthenticatedRequest, reply: FastifyReply) =
     return reply.code(401).send({ error: "Unauthorized" });
   }
 };
+
+app.addHook("onRequest", async (request, reply) => {
+  applyCorsHeaders(request, reply);
+
+  if (request.method === "OPTIONS") {
+    return reply.code(204).send();
+  }
+});
 
 
 const getMetadataType = (rawType: string): MetadataType | null => {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,11 +4,11 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host 0.0.0.0 --port 7002",
     "build": "tsc -b && vite build",
     "typecheck": "tsc -b",
     "lint": "eslint src",
-    "preview": "vite preview"
+    "preview": "vite preview --host 0.0.0.0 --port 7002"
   },
   "dependencies": {
     "react": "^18.3.1",

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -33,5 +33,13 @@ export default defineConfig({
         globPatterns: ["**/*.{js,css,html,ico,png,svg,woff2}"]
       }
     })
-  ]
+  ],
+  server: {
+    host: "0.0.0.0",
+    port: 7002
+  },
+  preview: {
+    host: "0.0.0.0",
+    port: 7002
+  }
 });


### PR DESCRIPTION
### Motivation
- Allow running the app on a LAN so other devices can access the web UI and call the API without CORS issues.
- Provide a simple allowlist for API origins to permit browser requests from specific frontend hosts while restricting cross-origin access.

### Description
- Added `CATALOGGY_ALLOWED_ORIGINS` parsing in `apps/api/src/index.ts` to read a comma-separated allowlist and check `Origin` headers against it.
- Added CORS response headers (`Access-Control-Allow-Origin`, `Access-Control-Allow-Methods`, `Access-Control-Allow-Headers`, and `Vary: Origin`) and allowed methods `GET,POST,DELETE,OPTIONS` with allowed headers `Authorization,Content-Type` via a global `onRequest` hook, and return `204` for `OPTIONS` preflight requests.
- Updated web dev/preview to bind to `0.0.0.0:7002` by changing `apps/web/package.json` scripts and adding `server`/`preview` host/port in `apps/web/vite.config.ts`.
- Documented `CATALOGGY_ALLOWED_ORIGINS` in the root `.env.example` and `apps/api/.env.example`.

### Testing
- Ran `pnpm --filter @cataloggy/api typecheck && pnpm --filter @cataloggy/web typecheck && pnpm --filter @cataloggy/addon typecheck`, which failed due to missing type dependencies in this environment (TypeScript error `TS2688: Cannot find type definition file for 'node'`).
- Attempted `pnpm install`, but installation is blocked in this environment with `ERR_PNPM_FETCH_403` (npm registry auth/network restriction), so full dependency install and further typechecks could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5c3c1fb288325aef70a8e9067df02)