### PR TITLE
Make Docker Compose LAN-friendly: add public URL envs and wire runtime defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,13 @@ API_TOKEN=dev-token
 DATABASE_URL=
 PORT=
 TRAKT_POLL_INTERVAL_SEC=300
-CATALOGGY_ALLOWED_ORIGINS=http://localhost:7002
+CATALOGGY_ALLOWED_ORIGINS=
+
+# Public LAN URLs used by clients outside Docker (set these to your host LAN IP)
+CATALOGGY_PUBLIC_BASE=http://192.168.1.50
+CATALOGGY_API_PUBLIC=http://192.168.1.50:7000
+CATALOGGY_ADDON_PUBLIC=http://192.168.1.50:7001
+CATALOGGY_WEB_PUBLIC=http://192.168.1.50:7002
 
 # Addon runtime (optional; docker-compose sets internal defaults)
 CATALOGGY_API_BASE=
@@ -29,4 +35,4 @@ TRAKT_REFRESH_TOKEN=
 TMDB_API_KEY=
 
 # Web runtime (optional; docker-compose sets internal defaults)
-VITE_API_BASE=
+VITE_API_BASE=${CATALOGGY_API_PUBLIC}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@db:5432/${POSTGRES_DB:-cataloggy}
       PORT: 7000
+      CATALOGGY_ALLOWED_ORIGINS: ${CATALOGGY_ALLOWED_ORIGINS:-${CATALOGGY_WEB_PUBLIC:-http://localhost:7002}}
     ports:
       - "7000:7000"
     depends_on:
@@ -50,7 +51,7 @@ services:
       PORT: 7001
       CATALOGGY_API_BASE: ${CATALOGGY_API_BASE:-http://api:7000}
       CATALOGGY_API_TOKEN: ${CATALOGGY_API_TOKEN:-dev-token}
-      ADDON_PUBLIC_BASE: ${ADDON_PUBLIC_BASE:-http://localhost:7001}
+      ADDON_PUBLIC_BASE: ${ADDON_PUBLIC_BASE:-${CATALOGGY_ADDON_PUBLIC:-http://localhost:7001}}
     ports:
       - "7001:7001"
     depends_on:
@@ -70,7 +71,7 @@ services:
     env_file:
       - .env
     environment:
-      VITE_API_BASE: ${VITE_API_BASE:-http://api:7000}
+      VITE_API_BASE: ${VITE_API_BASE:-${CATALOGGY_API_PUBLIC:-http://localhost:7000}}
     ports:
       - "7002:7002"
     depends_on:


### PR DESCRIPTION
### Motivation

- Allow browser clients on the same LAN (e.g. an iPhone on Wi‑Fi) to reach the web app and API using host LAN IPs. 
- Use environment defaults that point at externally reachable URLs instead of only internal Docker hostnames. 
- Ensure services expose the web UI on port `7002` and that healthchecks are present for `api`, `addon`, and `web` so composing and orchestration can wait for readiness.

### Description

- Updated `docker-compose.yml` to wire public/LAN variables into runtime defaults: `CATALOGGY_ALLOWED_ORIGINS` now falls back to `CATALOGGY_WEB_PUBLIC`, `ADDON_PUBLIC_BASE` falls back to `CATALOGGY_ADDON_PUBLIC`, and `VITE_API_BASE` falls back to `CATALOGGY_API_PUBLIC`.
- Confirmed `web` service is exposed on `7002:7002` and that healthchecks exist for `api`, `addon`, and `web` to allow `depends_on` health conditions to work.
- Extended the root `.env.example` with LAN/public URL examples: `CATALOGGY_PUBLIC_BASE`, `CATALOGGY_API_PUBLIC`, `CATALOGGY_ADDON_PUBLIC`, `CATALOGGY_WEB_PUBLIC`, and set `VITE_API_BASE=${CATALOGGY_API_PUBLIC}` so browser clients use the externally reachable API URL.

### Testing

- Ran `docker compose config` to validate the compose file but it failed because `docker` is not installed in the runner environment, so runtime validation could not be completed. 
- Inspected the produced diffs with `git diff -- .env.example docker-compose.yml` and verified file contents, which succeeded. 
- Confirmed working tree changes with `git status --short` and reviewed file contents with `nl`/`sed` outputs to validate the resulting configuration files, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5c49867608325ba60bb56a97b9cb2)