### PR TITLE
Add /settings page for runtime API base and token overrides

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -3,6 +3,7 @@ import { InstallButton } from "./components/InstallButton";
 import { DashboardPage } from "./pages/DashboardPage";
 import { ListsPage } from "./pages/ListsPage";
 import { SearchPage } from "./pages/SearchPage";
+import { SettingsPage } from "./pages/SettingsPage";
 
 const navClass = ({ isActive }: { isActive: boolean }) =>
   `rounded-md px-3 py-2 text-sm font-medium ${isActive ? "bg-sky-500/20 text-sky-200" : "text-slate-300 hover:bg-slate-800"}`;
@@ -26,6 +27,9 @@ export function App() {
             <NavLink to="/lists" className={navClass}>
               Lists
             </NavLink>
+            <NavLink to="/settings" className={navClass}>
+              Settings
+            </NavLink>
           </nav>
         </div>
       </header>
@@ -35,6 +39,7 @@ export function App() {
           <Route path="/" element={<DashboardPage />} />
           <Route path="/search" element={<SearchPage />} />
           <Route path="/lists/*" element={<ListsPage />} />
+          <Route path="/settings" element={<SettingsPage />} />
         </Routes>
       </main>
     </div>

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -1,5 +1,39 @@
-const API_BASE = import.meta.env.VITE_API_BASE ?? "http://localhost:7000";
+const API_BASE_DEFAULT = import.meta.env.VITE_API_BASE ?? "http://localhost:7000";
+const API_BASE_OVERRIDE_KEY = "cataloggy_api_base_override";
 const TOKEN_KEY = "cataloggy_token";
+
+export const runtimeConfig = {
+  apiBaseDefault: API_BASE_DEFAULT,
+  apiBaseOverrideKey: API_BASE_OVERRIDE_KEY,
+  tokenKey: TOKEN_KEY,
+  getApiBaseOverride() {
+    return window.localStorage.getItem(API_BASE_OVERRIDE_KEY)?.trim() ?? "";
+  },
+  setApiBaseOverride(value: string) {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      window.localStorage.removeItem(API_BASE_OVERRIDE_KEY);
+      return;
+    }
+
+    window.localStorage.setItem(API_BASE_OVERRIDE_KEY, trimmed);
+  },
+  getApiBase() {
+    return runtimeConfig.getApiBaseOverride() || API_BASE_DEFAULT;
+  },
+  getToken() {
+    return window.localStorage.getItem(TOKEN_KEY) ?? "";
+  },
+  setToken(value: string) {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      window.localStorage.removeItem(TOKEN_KEY);
+      return;
+    }
+
+    window.localStorage.setItem(TOKEN_KEY, trimmed);
+  }
+};
 
 export type MediaType = "movie" | "series";
 
@@ -35,7 +69,7 @@ export type CatalogMeta = {
 };
 
 const authHeaders = () => {
-  const token = window.localStorage.getItem(TOKEN_KEY) ?? "";
+  const token = runtimeConfig.getToken();
   return {
     Authorization: `Bearer ${token}`,
     "Content-Type": "application/json"
@@ -43,7 +77,7 @@ const authHeaders = () => {
 };
 
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
-  const response = await fetch(`${API_BASE}${path}`, {
+  const response = await fetch(`${runtimeConfig.getApiBase()}${path}`, {
     ...init,
     headers: {
       ...authHeaders(),

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -1,0 +1,66 @@
+import { FormEvent, useState } from "react";
+import { runtimeConfig } from "../api";
+
+export function SettingsPage() {
+  const [apiBaseOverride, setApiBaseOverride] = useState(runtimeConfig.getApiBaseOverride());
+  const [token, setToken] = useState(runtimeConfig.getToken());
+  const [message, setMessage] = useState<string | null>(null);
+
+  const saveSettings = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    runtimeConfig.setApiBaseOverride(apiBaseOverride);
+    runtimeConfig.setToken(token);
+    setMessage("Settings saved.");
+  };
+
+  const clearOverride = () => {
+    setApiBaseOverride("");
+    runtimeConfig.setApiBaseOverride("");
+    setMessage("API base override cleared.");
+  };
+
+  return (
+    <div className="max-w-3xl space-y-4 rounded-lg border border-slate-800 bg-slate-900 p-4">
+      <h2 className="text-xl font-semibold">Settings</h2>
+      <p className="text-sm text-slate-300">
+        Env default API base: <span className="font-mono text-sky-300">{runtimeConfig.apiBaseDefault}</span>
+      </p>
+      <p className="text-sm text-slate-300">
+        Effective API base: <span className="font-mono text-emerald-300">{runtimeConfig.getApiBase()}</span>
+      </p>
+
+      <form onSubmit={saveSettings} className="space-y-4">
+        <label className="block space-y-1">
+          <span className="text-sm text-slate-300">API base URL override (localStorage: cataloggy_api_base_override)</span>
+          <input
+            value={apiBaseOverride}
+            onChange={(event) => setApiBaseOverride(event.target.value)}
+            placeholder="http://192.168.1.50:7000"
+            className="w-full rounded border border-slate-700 bg-slate-950 px-3 py-2"
+          />
+        </label>
+
+        <label className="block space-y-1">
+          <span className="text-sm text-slate-300">Cataloggy token (localStorage: cataloggy_token)</span>
+          <input
+            value={token}
+            onChange={(event) => setToken(event.target.value)}
+            placeholder="Paste API token"
+            className="w-full rounded border border-slate-700 bg-slate-950 px-3 py-2"
+          />
+        </label>
+
+        <div className="flex gap-2">
+          <button type="submit" className="rounded bg-sky-600 px-4 py-2 text-sm font-medium">
+            Save settings
+          </button>
+          <button type="button" onClick={clearOverride} className="rounded bg-slate-700 px-4 py-2 text-sm font-medium">
+            Clear API override
+          </button>
+        </div>
+      </form>
+
+      {message && <p className="text-sm text-emerald-300">{message}</p>}
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Provide a way to change the API base URL at runtime so users can recover from LAN IP changes without rebuilding the frontend.
- Persist an API base override and auth token in `localStorage` so the UI and API calls use runtime values.
- Surface the env default (`VITE_API_BASE`) and the currently effective base URL in the UI for clarity.

### Description
- Introduce `runtimeConfig` in `apps/web/src/api.ts` that exposes `getApiBaseOverride`, `setApiBaseOverride`, `getApiBase`, `getToken`, and `setToken`, and stores keys `cataloggy_api_base_override` and `cataloggy_token` in `localStorage`.
- Update API request logic to use `runtimeConfig.getApiBase()` instead of a compile-time constant, and read auth token via `runtimeConfig.getToken()` so all calls use `override ?? envDefault` at runtime.
- Add a new `SettingsPage` component at `apps/web/src/pages/SettingsPage.tsx` that displays the env default API base, effective API base, and allows editing/clearing the API base override and token; saved values are persisted to `localStorage`.
- Wire the Settings page into navigation and routing by importing it in `apps/web/src/App.tsx`, adding a top-nav link and a `/settings` route.

### Testing
- Attempted `pnpm -C apps/web build`, but the build failed in this environment due to missing node modules and registry access constraints (dependency install blocked).
- Attempted `pnpm install` and `npm -C apps/web install`, both blocked by registry `403 Forbidden` errors, so no full build or runtime tests could be performed here.
- Changes were committed (`apps/web/src/api.ts`, `apps/web/src/App.tsx`, and new `apps/web/src/pages/SettingsPage.tsx`) and are ready for CI/maintainer verification in a network-enabled environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5c535f6a08325b8759f6a1f427651)