### PR TITLE
docs: add LAN setup guidance for phone, PWA, and Apple TV Omni install

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,45 @@ cataloggy/
 - Web: http://localhost:7002
 - Postgres: `localhost:5432` (`postgres` / `postgres`, db `cataloggy`)
 
+
+## Use on Your Local Network (Phone + Apple TV)
+
+### Find your LAN IP (brief)
+
+Your LAN IP is your computer's local network address (usually like `192.168.x.x` or `10.0.x.x`).
+
+- **macOS:** System Settings → Network → select active connection → look for **IP Address**
+- **Windows:** Command Prompt → `ipconfig` → look for **IPv4 Address**
+- **Linux:** Terminal → `hostname -I`
+
+### Open CataLoggy on your phone
+
+On your phone (connected to the same Wi-Fi), open:
+
+```text
+http://LAN-IP:7002
+```
+
+Example:
+
+```text
+http://192.168.1.25:7002
+```
+
+### Install as a PWA
+
+- **iOS Safari:** **Share** → **Add to Home Screen**
+
+### Install Omni add-on on Apple TV
+
+Use this add-on URL in Omni:
+
+```text
+http://LAN-IP:7001/manifest.json
+```
+
+> **Important:** Apple TV cannot use `localhost` URLs. The add-on URL must be reachable on your LAN from Apple TV.
+
 ## Useful Commands
 
 - Run apps in dev mode from root:


### PR DESCRIPTION
### Motivation
- Make it easy for a non-developer to access CataLoggy from phone and Apple TV by documenting how to find the LAN IP, how to open the web UI, how to install the PWA on iOS, and how to add the Omni add-on on Apple TV.

### Description
- Added a new "Use on Your Local Network (Phone + Apple TV)" section to `README.md` that includes brief LAN IP discovery steps for macOS/Windows/Linux, the phone access URL `http://LAN-IP:7002`, iOS PWA install instructions, the Omni add-on URL `http://LAN-IP:7001/manifest.json`, and an explicit note that Apple TV cannot use `localhost`.

### Testing
- Verified the change by inspecting the diff with `git diff -- README.md`, printing the updated file with `sed -n '1,280p' README.md`, and checking repository status with `git status --short`, and all checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5c62d9220832593415bea9f2b0e62)