### PR TITLE
Handle trailing-slash proxy prefixes in addon URL rewriting

### DIFF
--- a/apps/addon/src/index.ts
+++ b/apps/addon/src/index.ts
@@ -5,7 +5,8 @@ const parseProxyPathPrefixes = (raw: string | undefined, fallback: readonly stri
     .split(",")
     .map((prefix) => prefix.trim())
     .filter(Boolean)
-    .map((prefix) => (prefix.startsWith("/") ? prefix : `/${prefix}`));
+    .map((prefix) => (prefix.startsWith("/") ? prefix : `/${prefix}`))
+    .map((prefix) => (prefix.length > 1 ? prefix.replace(/\/+$/, "") : prefix));
 
   return parsed.length > 0 ? parsed : [...fallback];
 };


### PR DESCRIPTION
### Motivation
- Ensure the addon still resolves internal routes like `/manifest.json`, `/catalog/...`, and `/meta/...` when mounted behind a proxy that may configure the prefix with or without a trailing slash (e.g. `/addon` vs `/addon/`).

### Description
- Normalize entries in `PROXY_PATH_PREFIXES` by trimming trailing slashes (except for root `/`) in `apps/addon/src/index.ts` so configured prefixes behave identically whether they include a trailing slash or not.

### Testing
- Ran `pnpm --filter @cataloggy/addon typecheck` and `pnpm --filter @cataloggy/addon lint`, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5c94ea2708325b3e08181c758ad36)