### PR TITLE
docs: add Nginx Proxy Manager setup section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,23 @@ http://LAN-IP:7001/manifest.json
 
 > **Important:** Apple TV cannot use `localhost` URLs. The add-on URL must be reachable on your LAN from Apple TV.
 
+## Nginx Proxy Manager Setup
+
+Configure Nginx Proxy Manager with one Proxy Host for your domain (for example, `cataloggy.domain.com`):
+
+- **Proxy Host target:** web service on port `7002`
+- **Advanced locations:**
+  - `/api/` → port `7000`
+  - `/addon/` → port `7001`
+
+Use this Omni add-on URL to install when accessing through your domain:
+
+```text
+https://cataloggy.domain.com/addon/manifest.json
+```
+
+LAN development URLs stay available, so you can continue using direct local access like `http://LAN-IP:7002` and `http://LAN-IP:7001/manifest.json` on your network.
+
 ## Useful Commands
 
 - Run apps in dev mode from root:


### PR DESCRIPTION
### Motivation
- Provide concise instructions for configuring Nginx Proxy Manager to expose the web and addon services under a domain while preserving LAN development access.

### Description
- Added a `Nginx Proxy Manager Setup` section to `README.md` that documents setting a Proxy Host to the web service on port `7002`, configuring advanced locations `/api/` → port `7000` and `/addon/` → port `7001`, the Omni add-on install URL `https://cataloggy.domain.com/addon/manifest.json`, and a note that LAN development URLs such as `http://LAN-IP:7002` and `http://LAN-IP:7001/manifest.json` remain available.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5ca896cd483259ad456994b63c3f4)