### PR TITLE
docs: add compose-first install workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,23 +21,29 @@ cataloggy/
 - pnpm 9+
 - Docker + Docker Compose
 
-## Setup
+## Docker Compose install (recommended)
 
-1. Install dependencies from the repository root:
-
-   ```bash
-   pnpm install
-   ```
-
-2. Prepare environment file:
+1. Prepare environment file:
 
    ```bash
    cp .env.example .env
    ```
 
-   Set `TMDB_API_KEY` in `.env` if you plan to use the search/meta endpoints.
+2. Set only the values you care about in `.env`:
 
-3. Start everything with Docker Compose:
+   - Required: `API_TOKEN`
+   - Optional but recommended for LAN devices (phone/Apple TV):
+     - `CATALOGGY_PUBLIC_BASE`
+     - `CATALOGGY_API_PUBLIC`
+     - `CATALOGGY_ADDON_PUBLIC`
+     - `CATALOGGY_WEB_PUBLIC`
+   - Optional integrations:
+     - `TMDB_API_KEY`
+     - Trakt variables (`TRAKT_CLIENT_ID`, `TRAKT_CLIENT_SECRET`, `TRAKT_ACCESS_TOKEN`, `TRAKT_REFRESH_TOKEN`)
+
+   Everything else already has defaults in `docker-compose.yml`, so you can leave them blank.
+
+3. Start everything:
 
    ```bash
    docker compose up --build
@@ -50,6 +56,20 @@ cataloggy/
    ```
 
    This validates API and add-on health endpoints and (when all Trakt env vars are configured) runs `/trakt/import` and verifies a catalog response contains a `metas` array.
+
+## Local development without Docker
+
+1. Install dependencies from the repository root:
+
+   ```bash
+   pnpm install
+   ```
+
+2. Start local dev services:
+
+   ```bash
+   pnpm dev
+   ```
 
 ## Services
 


### PR DESCRIPTION
### Motivation

- Make the project easier to start by encouraging a Docker Compose-first install path that centralizes runtime variables in `.env` and `docker-compose.yml`.
- Reduce confusion about which environment variables are required for a minimal run versus optional integrations or LAN/public URLs.

### Description

- Rewrote the previous "Setup" section into a Docker Compose-focused workflow and added `cp .env.example .env` as the first step with `docker compose up --build` as the recommended start command.
- Documented which `.env` variables are required (`API_TOKEN`) and which are optional (LAN/public URL variables, `TMDB_API_KEY`, and Trakt credentials), and clarified that most other runtime values have defaults in `docker-compose.yml`.
- Moved local development instructions (`pnpm install` and `pnpm dev`) into a separate "Local development without Docker" section.

### Testing

- Attempted `docker compose config` to validate the compose file, but the command failed because Docker is not installed in the execution environment (`docker: command not found`).
- No automated project tests were modified or executed as part of this docs-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a645243af88325a4b06c40dea9ceaa)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized setup instructions with clearer Docker Compose workflow and separate local development option
  * Expanded environment variable documentation with explicit required and optional configurations
  * Added smoke checks step to Docker Compose setup process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->