### PR TITLE
fix: resolve three docker compose install blockers

### DIFF
--- a/apps/addon/Dockerfile
+++ b/apps/addon/Dockerfile
@@ -13,9 +13,10 @@ RUN pnpm install --frozen-lockfile
 COPY apps/addon ./apps/addon
 COPY packages/shared ./packages/shared
 
+RUN pnpm --filter @cataloggy/addon build
 RUN addgroup -S app && adduser -S app -G app && chown -R app:app /app
 USER app
 
 EXPOSE 7001
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s CMD wget -q --spider http://127.0.0.1:7001/health || exit 1
-CMD ["sh", "-c", "pnpm --filter @cataloggy/addon build && pnpm --filter @cataloggy/addon start"]
+CMD ["pnpm", "--filter", "@cataloggy/addon", "start"]

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "tsx watch src/index.ts",
-    "start": "node dist/index.js",
+    "start": "prisma migrate deploy && node dist/index.js",
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "eslint src",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,7 @@ services:
     environment:
       PORT: 7001
       CATALOGGY_API_BASE: ${CATALOGGY_API_BASE:-http://api:7000}
-      CATALOGGY_API_TOKEN: ${CATALOGGY_API_TOKEN:-dev-token}
+      CATALOGGY_API_TOKEN: ${CATALOGGY_API_TOKEN:-${API_TOKEN:-dev-token}}
       ADDON_PUBLIC_BASE: ${ADDON_PUBLIC_BASE:-${CATALOGGY_ADDON_PUBLIC:-http://localhost:7001}}
     ports:
       - "7001:7001"


### PR DESCRIPTION
- api: run `prisma migrate deploy` before starting the server so the database schema is applied on first boot (previously the DB had no tables and the API crashed immediately)
- docker-compose: default CATALOGGY_API_TOKEN to API_TOKEN so the addon can always authenticate to the API when the user changes their token
- addon Dockerfile: move the TypeScript build to image-build time (matching the api pattern) instead of running it on every container startup

https://claude.ai/code/session_01UJNoJ6F6sydyCG54VJ6akn