### PR TITLE
fix: resolve five search/watchlist UI issues

### DIFF
--- a/apps/web/src/pages/SearchPage.tsx
+++ b/apps/web/src/pages/SearchPage.tsx
@@ -4,9 +4,10 @@ import { api, CatalogList, MediaType, SearchResult } from "../api";
 export function SearchPage() {
   const [query, setQuery] = useState("");
   const [type, setType] = useState<MediaType>("movie");
-  const [results, setResults] = useState<SearchResult[]>([]);
+  const [results, setResults] = useState<SearchResult[] | null>(null);
+  const [isSearching, setIsSearching] = useState(false);
   const [lists, setLists] = useState<CatalogList[]>([]);
-  const [selectedListId, setSelectedListId] = useState<string>("");
+  const [selectedListIds, setSelectedListIds] = useState<Record<string, string>>({});
   const [pendingAdds, setPendingAdds] = useState<Record<string, boolean>>({});
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -16,7 +17,6 @@ export function SearchPage() {
       try {
         const { lists: loaded } = await api.getLists();
         setLists(loaded);
-        setSelectedListId(loaded[0]?.id ?? "");
       } catch (err) {
         console.error(err);
         setError(err instanceof Error ? err.message : "Failed to load lists");
@@ -26,35 +26,52 @@ export function SearchPage() {
 
   const watchlistId = useMemo(() => lists.find((list) => list.kind === "watchlist")?.id, [lists]);
 
+  const watchlistImdbIds = useMemo(() => {
+    const watchlist = lists.find((l) => l.kind === "watchlist");
+    return new Set(watchlist?.items.map((i) => i.imdbId) ?? []);
+  }, [lists]);
+
   const submitSearch = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     setMessage(null);
     setError(null);
+    setIsSearching(true);
+    setSelectedListIds({});
 
     try {
       const response = await api.search(type, query);
       setResults(response);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Search failed");
+    } finally {
+      setIsSearching(false);
     }
   };
 
   const handleAdd = async (listId: string, result: SearchResult) => {
-    if (pendingAdds[listId]) {
-      return;
-    }
+    const key = `${listId}:${result.imdbId}`;
+    if (pendingAdds[key]) return;
 
     setMessage(null);
     setError(null);
-    setPendingAdds((current) => ({ ...current, [listId]: true }));
+    setPendingAdds((current) => ({ ...current, [key]: true }));
 
     try {
       await api.addToList(listId, { type: result.type, imdbId: result.imdbId, title: result.name });
       setMessage(`Added ${result.name}`);
+      if (listId === watchlistId) {
+        setLists((prev) =>
+          prev.map((l) =>
+            l.id === listId
+              ? { ...l, items: [...l.items, { listId, type: result.type, imdbId: result.imdbId, addedAt: new Date().toISOString() }] }
+              : l
+          )
+        );
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : "Unable to add item");
     } finally {
-      setPendingAdds((current) => ({ ...current, [listId]: false }));
+      setPendingAdds((current) => ({ ...current, [key]: false }));
     }
   };
 
@@ -80,57 +97,77 @@ export function SearchPage() {
             </button>
           ))}
         </div>
-        <button type="submit" className="rounded bg-sky-600 px-4 py-2 font-medium">
-          Search
+        <button type="submit" disabled={isSearching} className="rounded bg-sky-600 px-4 py-2 font-medium disabled:opacity-50">
+          {isSearching ? "Searching…" : "Search"}
         </button>
       </form>
 
       {error && <p className="text-rose-300">{error}</p>}
       {message && <p className="text-emerald-300">{message}</p>}
 
+      {results !== null && results.length === 0 && (
+        <p className="text-slate-400">No results found.</p>
+      )}
+
       <ul className="space-y-3">
-        {results.map((result) => (
-          <li key={`${result.type}:${result.imdbId}`} className="flex flex-col gap-3 rounded-lg border border-slate-800 bg-slate-900 p-4 md:flex-row">
-            <img
-              src={result.poster ?? "https://placehold.co/120x180?text=No+Poster"}
-              alt={result.name}
-              className="h-36 w-24 rounded object-cover"
-            />
-            <div className="flex-1">
-              <p className="text-lg font-semibold">{result.name}</p>
-              <p className="text-sm text-slate-400">{result.year ?? "Unknown year"}</p>
-              <div className="mt-3 flex flex-wrap items-center gap-2">
-                <button
-                  type="button"
-                  disabled={!watchlistId || (watchlistId ? pendingAdds[watchlistId] : false)}
-                  onClick={() => watchlistId && handleAdd(watchlistId, result)}
-                  className="rounded bg-sky-600 px-3 py-2 text-sm disabled:opacity-50"
-                >
-                  Add to Watchlist
-                </button>
-                <select
-                  value={selectedListId}
-                  onChange={(event) => setSelectedListId(event.target.value)}
-                  className="rounded border border-slate-700 bg-slate-950 px-2 py-2 text-sm"
-                >
-                  {lists.map((list) => (
-                    <option key={list.id} value={list.id}>
-                      {list.name}
-                    </option>
-                  ))}
-                </select>
-                <button
-                  type="button"
-                  disabled={!selectedListId || pendingAdds[selectedListId]}
-                  onClick={() => selectedListId && handleAdd(selectedListId, result)}
-                  className="rounded bg-violet-600 px-3 py-2 text-sm disabled:opacity-50"
-                >
-                  Add to List…
-                </button>
+        {(results ?? []).map((result) => {
+          const inWatchlist = watchlistImdbIds.has(result.imdbId);
+          const resultListId = selectedListIds[result.imdbId] ?? lists[0]?.id ?? "";
+          const watchlistPendingKey = `${watchlistId}:${result.imdbId}`;
+          const listPendingKey = `${resultListId}:${result.imdbId}`;
+
+          return (
+            <li key={`${result.type}:${result.imdbId}`} className="flex flex-col gap-3 rounded-lg border border-slate-800 bg-slate-900 p-4 md:flex-row">
+              <img
+                src={result.poster ?? "https://placehold.co/120x180?text=No+Poster"}
+                alt={result.name}
+                className="h-36 w-24 rounded object-cover"
+              />
+              <div className="flex-1">
+                <div className="flex flex-wrap items-center gap-2">
+                  <p className="text-lg font-semibold">{result.name}</p>
+                  {inWatchlist && (
+                    <span className="rounded-full bg-emerald-900/60 px-2 py-0.5 text-xs text-emerald-300">
+                      In Watchlist
+                    </span>
+                  )}
+                </div>
+                <p className="text-sm text-slate-400">{result.year ?? "Unknown year"}</p>
+                <div className="mt-3 flex flex-wrap items-center gap-2">
+                  <button
+                    type="button"
+                    disabled={!watchlistId || inWatchlist || pendingAdds[watchlistPendingKey]}
+                    onClick={() => watchlistId && handleAdd(watchlistId, result)}
+                    className="rounded bg-sky-600 px-3 py-2 text-sm disabled:opacity-50"
+                  >
+                    {inWatchlist ? "In Watchlist" : "Add to Watchlist"}
+                  </button>
+                  <select
+                    value={resultListId}
+                    onChange={(event) =>
+                      setSelectedListIds((prev) => ({ ...prev, [result.imdbId]: event.target.value }))
+                    }
+                    className="rounded border border-slate-700 bg-slate-950 px-2 py-2 text-sm"
+                  >
+                    {lists.map((list) => (
+                      <option key={list.id} value={list.id}>
+                        {list.name}
+                      </option>
+                    ))}
+                  </select>
+                  <button
+                    type="button"
+                    disabled={!resultListId || pendingAdds[listPendingKey]}
+                    onClick={() => resultListId && handleAdd(resultListId, result)}
+                    className="rounded bg-violet-600 px-3 py-2 text-sm disabled:opacity-50"
+                  >
+                    Add to List…
+                  </button>
+                </div>
               </div>
-            </div>
-          </li>
-        ))}
+            </li>
+          );
+        })}
       </ul>
     </div>
   );


### PR DESCRIPTION
- Key pendingAdds by `${listId}:${imdbId}` so adding one item does not disable buttons for all other results
- Track selectedListId per result (Record<imdbId, listId>) so changing the custom-list dropdown for one card does not affect others
- Add isSearching state: Search button shows "Searching…" and is disabled while the request is in flight
- Show "No results found." when a search returns an empty list
- Derive watchlistImdbIds set from lists state; show an "In Watchlist" badge on matching results and disable/relabel their watchlist button; optimistically update lists state after a successful watchlist add

https://claude.ai/code/session_012qeg7XjzvBv6qktuASnmbD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added watchlist awareness with "In Watchlist" badge for items already saved
  * Improved per-result list selection for independent control over each search result

* **UI/UX Improvements**
  * Search button now shows "Searching…" and disables during active searches
  * Added "No results found" message for empty search results
  * Streamlined result controls with updated button layout

<!-- end of auto-generated comment: release notes by coderabbit.ai -->