### PR TITLE
Disable implicit type inclusion in addon tsconfig

### DIFF
--- a/apps/addon/tsconfig.json
+++ b/apps/addon/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",
-    "noEmit": false
+    "noEmit": false,
+    "types": []
   },
   "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
Updated the TypeScript configuration for the addon package to explicitly disable implicit type inclusion by setting `types: []` in the compiler options.

## Key Changes
- Added `"types": []` to `compilerOptions` in `apps/addon/tsconfig.json`

## Details
This change prevents TypeScript from automatically including type definitions from `node_modules/@types/*` packages. This provides more explicit control over which type definitions are used in the addon package and can help avoid unintended type conflicts or dependencies on ambient type declarations.

https://claude.ai/code/session_01WR6LSfgPjuFpUVmjjkckje