### PR TITLE
Update TypeScript configuration for addon package

### DIFF
--- a/apps/addon/tsconfig.json
+++ b/apps/addon/tsconfig.json
@@ -4,7 +4,9 @@
     "rootDir": "src",
     "outDir": "dist",
     "noEmit": false,
-    "types": []
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "types": ["node"]
   },
   "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
Updated the TypeScript configuration in the addon package to improve module resolution and type checking capabilities.

## Key Changes
- Set `module` to `ES2022` to target modern ECMAScript module output
- Changed `moduleResolution` to `Bundler` for improved module resolution with bundlers
- Added `node` to the `types` array to include Node.js type definitions

## Implementation Details
These configuration changes align the addon package with modern TypeScript best practices and ensure proper type resolution for Node.js APIs when needed. The `Bundler` module resolution strategy is particularly useful for packages that will be consumed by bundlers like webpack, esbuild, or Vite.

https://claude.ai/code/session_01WqH6rjgZzWcmcAba1rEev4