### PR TITLE
Fix Docker builds by using hoisted node-linker for pnpm

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+node-linker=hoisted

--- a/apps/addon/Dockerfile
+++ b/apps/addon/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 RUN corepack enable
 RUN apk add --no-cache wget
 
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json eslint.config.mjs ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json eslint.config.mjs .npmrc ./
 COPY apps/addon/package.json ./apps/addon/package.json
 COPY apps/api/package.json ./apps/api/package.json
 COPY apps/web/package.json ./apps/web/package.json

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 RUN corepack enable
 RUN apk add --no-cache wget
 
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json eslint.config.mjs ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json eslint.config.mjs .npmrc ./
 COPY apps/api/package.json ./apps/api/package.json
 COPY apps/addon/package.json ./apps/addon/package.json
 COPY apps/web/package.json ./apps/web/package.json

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 RUN corepack enable
 RUN apk add --no-cache wget
 
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json eslint.config.mjs ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json eslint.config.mjs .npmrc ./
 COPY apps/web/package.json ./apps/web/package.json
 COPY apps/api/package.json ./apps/api/package.json
 COPY apps/addon/package.json ./apps/addon/package.json


### PR DESCRIPTION
pnpm's default symlink-based node_modules layout doesn't work reliably with Docker's overlayfs, causing tsc to fail finding modules like fastify and @prisma/client during Docker builds.

Add .npmrc with node-linker=hoisted to create a flat node_modules structure, and update all Dockerfiles to copy .npmrc into the build context.

https://claude.ai/code/session_012xGVPnNy7wjrxS2vjpxLDB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated npm configuration and Docker build setup to optimize dependency resolution across services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->