### PR TITLE
Fix Prisma generation in API Docker build

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -15,7 +15,7 @@ RUN pnpm install --frozen-lockfile
 COPY apps/api ./apps/api
 COPY packages/shared ./packages/shared
 
-RUN pnpm --filter @cataloggy/api prisma generate
+RUN pnpm --filter @cataloggy/api exec prisma generate
 RUN pnpm --filter @cataloggy/api build
 RUN addgroup -S app && adduser -S app -G app && chown -R app:app /app
 USER app


### PR DESCRIPTION
## Summary
Updated the Prisma code generation command in the API Dockerfile to use the correct pnpm execution method.

## Changes
- Changed `pnpm --filter @cataloggy/api prisma generate` to `pnpm --filter @cataloggy/api exec prisma generate`
- This ensures Prisma CLI is properly executed within the filtered workspace context during Docker build

## Details
The `exec` subcommand is the correct way to run binaries from dependencies within a filtered pnpm workspace. This fix ensures that the Prisma schema is properly generated during the Docker build process for the API service.

https://claude.ai/code/session_01PtaSANVBuwCioEvtDQWvhL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build process consistency by aligning Prisma generation invocation with the workspace build workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->