### PR TITLE
Fix Prisma generate to run from workspace root

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -15,7 +15,7 @@ RUN pnpm install --frozen-lockfile
 COPY apps/api ./apps/api
 COPY packages/shared ./packages/shared
 
-RUN pnpm --filter @cataloggy/api exec prisma generate
+RUN pnpm exec prisma generate --schema=apps/api/prisma/schema.prisma
 RUN pnpm --filter @cataloggy/api build
 RUN addgroup -S app && adduser -S app -G app && chown -R app:app /app
 USER app


### PR DESCRIPTION
The prisma CLI is hoisted to the root node_modules in pnpm workspaces, so `pnpm --filter @cataloggy/api exec prisma` fails with MODULE_NOT_FOUND. Run `pnpm exec prisma generate --schema=...` from the workspace root instead.

https://claude.ai/code/session_01PtaSANVBuwCioEvtDQWvhL