### PR TITLE
Fix runtime prisma command in API Dockerfile

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -22,4 +22,4 @@ USER app
 
 EXPOSE 7000
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s CMD wget -q --spider http://127.0.0.1:7000/health || exit 1
-CMD ["pnpm", "--filter", "@cataloggy/api", "start"]
+CMD ["sh", "-c", "pnpm exec prisma migrate deploy --schema=apps/api/prisma/schema.prisma && node apps/api/dist/index.js"]


### PR DESCRIPTION
The start script calls `prisma migrate deploy` but the prisma binary is hoisted to the workspace root node_modules by pnpm. Changed CMD to run from the workspace root using `pnpm exec prisma` with explicit schema path, then start the Node.js server directly.

https://claude.ai/code/session_01PtaSANVBuwCioEvtDQWvhL