### PR TITLE
Fix web CMD to use absolute path to hoisted vite binary

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -19,4 +19,4 @@ USER app
 
 EXPOSE 7002
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s CMD wget -q --spider http://127.0.0.1:7002/ || exit 1
-CMD ["sh", "-c", "pnpm exec vite build --root apps/web && pnpm exec vite preview --host 0.0.0.0 --port 7002 --root apps/web"]
+CMD ["sh", "-c", "cd apps/web && /app/node_modules/.bin/vite build && /app/node_modules/.bin/vite preview --host 0.0.0.0 --port 7002"]


### PR DESCRIPTION
Vite preview doesn't support --root flag. Instead, cd into apps/web and reference the vite binary via absolute path at /app/node_modules/.bin/vite where pnpm hoists it.

https://claude.ai/code/session_01PtaSANVBuwCioEvtDQWvhL