### PR TITLE
Fix VITE_API_BASE in .env.example breaking API URL resolution

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,5 +32,6 @@ TRAKT_CLIENT_SECRET=
 # TMDB integration (optional; required for /search and /meta/:type/:imdbId)
 TMDB_API_KEY=
 
-# Web runtime (optional; docker-compose sets internal defaults)
-VITE_API_BASE=${CATALOGGY_API_PUBLIC}
+# Web runtime (optional; docker-compose resolves this from CATALOGGY_API_PUBLIC)
+# Do NOT use variable references here – .env files do not support interpolation.
+VITE_API_BASE=


### PR DESCRIPTION
Docker .env files do not support variable interpolation, so VITE_API_BASE=${CATALOGGY_API_PUBLIC} was passed as a literal string to the web container. This prevented the docker-compose fallback chain from resolving the actual API URL, causing the web app to embed an invalid URL and fail to connect to the API server.

Leave VITE_API_BASE empty so docker-compose properly resolves it from CATALOGGY_API_PUBLIC.

https://claude.ai/code/session_01BswBGPXwEU2YSqkimsiDtz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated environment configuration documentation and setup guidance to provide clearer instructions for API endpoint configuration, specifically explaining the detailed process of how configuration values are properly resolved during application deployment and initialization phases, along with comprehensive explanatory notes on how environment variables are handled throughout the setup workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->