### PR TITLE
Add list items endpoints: GET, POST (409 on dup), DELETE with query param

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -965,23 +965,25 @@ app.post<{ Params: { listId: string }; Body: unknown }>("/lists/:listId/items", 
 
   const itemType = type as ItemType;
 
-  await prisma.item.upsert({
-    where: { type_imdbId: { type: itemType, imdbId } },
-    create: {
-      type: itemType,
-      imdbId,
-      title: body.title?.trim() ? body.title.trim() : undefined
-    },
-    update: body.title?.trim() ? { title: body.title.trim() } : {}
-  });
-
   try {
-    const listItem = await prisma.listItem.create({
-      data: {
-        listId: request.params.listId,
-        type,
-        imdbId
-      }
+    const listItem = await prisma.$transaction(async (tx) => {
+      await tx.item.upsert({
+        where: { type_imdbId: { type: itemType, imdbId } },
+        create: {
+          type: itemType,
+          imdbId,
+          title: body.title?.trim() ? body.title.trim() : undefined
+        },
+        update: body.title?.trim() ? { title: body.title.trim() } : {}
+      });
+
+      return tx.listItem.create({
+        data: {
+          listId: request.params.listId,
+          type,
+          imdbId
+        }
+      });
     });
 
     return reply.code(201).send({ listItem });
@@ -1029,6 +1031,14 @@ app.delete<{ Params: { listId: string; imdbId: string }; Querystring: { type?: s
       return reply.code(400).send({ error: "type must be one of: movie, series" });
     }
     where.type = request.query.type as ListItemType;
+  } else {
+    const count = await prisma.listItem.count({ where });
+    if (count === 0) {
+      return reply.code(404).send({ error: "List item not found" });
+    }
+    if (count > 1) {
+      return reply.code(400).send({ error: "Multiple items match this imdbId; provide ?type=movie or ?type=series to disambiguate" });
+    }
   }
 
   const removed = await prisma.listItem.deleteMany({ where });


### PR DESCRIPTION
- POST /lists/:listId/items: Use create instead of upsert, catch P2002
  and return 409 when item already exists in the list
- DELETE /lists/:listId/items/:imdbId: New endpoint that accepts optional
  ?type= query param to disambiguate movie vs series
- GET /lists/:listId/items: Return all items in a list joined with their
  Metadata (name, poster, year) when available

https://claude.ai/code/session_01Fwdg1tevVkKjn9TtK61H8v

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added endpoint to retrieve all items in a list with associated metadata.
  * Added endpoint to delete individual items from a list.
  * Improved error handling for duplicate items—now returns a 409 status code instead of replacing existing items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->