### PR TITLE
Add metadata sync endpoint with freshness-based caching

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -225,6 +225,27 @@ const fetchMetadata = async (type: MetadataType, imdbId: string): Promise<Metada
   return metadata;
 };
 
+const METADATA_FRESHNESS_MS = 7 * 24 * 60 * 60 * 1000;
+
+const syncMetadata = async (imdbId: string, type: MetadataType) => {
+  const existing = await prisma.metadata.findUnique({
+    where: { imdbId_type: { imdbId, type } }
+  });
+
+  if (existing && Date.now() - existing.updatedAt.getTime() < METADATA_FRESHNESS_MS) {
+    return existing;
+  }
+
+  const tmdb = TmdbClient.fromEnv();
+  const payload = await tmdb.findByImdbId(type, imdbId);
+
+  if (!payload) {
+    return existing ?? null;
+  }
+
+  return upsertMetadata(payload);
+};
+
 const parseCatalogLimit = (rawLimit: unknown) => {
   if (rawLimit === undefined) {
     return DEFAULT_STREMIO_LIMIT;
@@ -729,6 +750,31 @@ app.get<{ Params: { type: string; imdbId: string } }>("/meta/:type/:imdbId", asy
   } catch (error) {
     request.log.error(error, "Metadata fetch failed");
     return reply.code(500).send({ error: "Metadata fetch failed" });
+  }
+});
+
+app.post<{ Body: unknown }>("/metadata/sync", async (request, reply) => {
+  const body = request.body as Record<string, unknown> | null;
+  const imdbId = typeof body?.imdbId === "string" ? body.imdbId.trim() : "";
+  if (!imdbId) {
+    return reply.code(400).send({ error: "imdbId is required" });
+  }
+
+  const type = getMetadataType(body?.type as string | undefined);
+  if (!type) {
+    return reply.code(400).send({ error: "type must be one of: movie, series" });
+  }
+
+  try {
+    const metadata = await syncMetadata(imdbId, type);
+    if (!metadata) {
+      return reply.code(404).send({ error: "Metadata not found on TMDB" });
+    }
+
+    return metadata;
+  } catch (error) {
+    request.log.error(error, "Metadata sync failed");
+    return reply.code(500).send({ error: "Metadata sync failed" });
   }
 });
 


### PR DESCRIPTION
## Summary
This PR adds a new POST endpoint `/metadata/sync` that allows explicit synchronization of metadata from TMDB, with intelligent caching to avoid unnecessary API calls.

## Key Changes
- **New `syncMetadata` function**: Implements freshness-based caching logic that:
  - Returns cached metadata if it's less than 7 days old
  - Fetches fresh data from TMDB if cache is stale or missing
  - Falls back to existing cached data if TMDB lookup fails
  
- **New `/metadata/sync` POST endpoint**: Provides an API to trigger metadata synchronization with:
  - Request validation for required `imdbId` parameter
  - Type validation (must be "movie" or "series")
  - Proper error handling and HTTP status codes (400 for validation errors, 404 if not found on TMDB, 500 for sync failures)
  - Structured error responses

## Implementation Details
- Metadata freshness threshold set to 7 days (604,800,000 ms)
- Uses existing `upsertMetadata` function to persist synced data
- Leverages `TmdbClient.fromEnv()` for TMDB API integration
- Follows existing error handling patterns with request logging

https://claude.ai/code/session_01TnpCUEZEsFv2spmNWuWFd1