### PR TITLE
Refactor Trakt import to use watched history instead of watchlist

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1365,149 +1365,125 @@ app.post("/trakt/import", async (request, reply) => {
     return reply.code(500).send({ error: "Trakt integration is not configured" });
   }
 
-  const watchlist = await getDefaultWatchlist();
-
-  const [watchlistMovies, watchlistShows, movieHistory, episodeHistory] = await Promise.all([
-    client.fetchWatchlistMovies(request.log),
-    client.fetchWatchlistShows(request.log),
-    client.fetchMovieHistory(request.log),
-    client.fetchEpisodeHistory(request.log)
+  const [watchedMovies, watchedShows] = await Promise.all([
+    client.fetchWatchedMovies(request.log),
+    client.fetchWatchedShows(request.log)
   ]);
 
-  const importedWatchlist = { movies: 0, series: 0 };
-  const importedWatchEvents = { movies: 0, episodes: 0 };
+  const imported = { movies: 0, episodes: 0 };
   const seriesProgressByImdb = new Map<string, SeriesProgressCandidate>();
 
-  for (const entry of watchlistMovies) {
+  for (const entry of watchedMovies) {
     const imdbId = entry.movie?.ids?.imdb;
-    if (!imdbId) {
-      continue;
-    }
-
-    const title = entry.movie?.title?.trim();
-    await prisma.item.upsert({
-      where: { type_imdbId: { type: ItemType.movie, imdbId } },
-      create: { type: ItemType.movie, imdbId, title: title || undefined },
-      update: title ? { title } : {}
-    });
-
-    await prisma.listItem.upsert({
-      where: { listId_type_imdbId: { listId: watchlist.id, type: ListItemType.movie, imdbId } },
-      create: { listId: watchlist.id, type: ListItemType.movie, imdbId },
-      update: {}
-    });
-    importedWatchlist.movies += 1;
-  }
-
-  for (const entry of watchlistShows) {
-    const imdbId = entry.show?.ids?.imdb;
-    if (!imdbId) {
-      continue;
-    }
-
-    const title = entry.show?.title?.trim();
-    await prisma.item.upsert({
-      where: { type_imdbId: { type: ItemType.series, imdbId } },
-      create: { type: ItemType.series, imdbId, title: title || undefined },
-      update: title ? { title } : {}
-    });
-
-    await prisma.listItem.upsert({
-      where: { listId_type_imdbId: { listId: watchlist.id, type: ListItemType.series, imdbId } },
-      create: { listId: watchlist.id, type: ListItemType.series, imdbId },
-      update: {}
-    });
-    importedWatchlist.series += 1;
-  }
-
-  for (const entry of movieHistory) {
-    const imdbId = entry.movie?.ids?.imdb;
-    const watchedAt = entry.watched_at;
+    const watchedAt = entry.last_watched_at;
 
     if (!imdbId || !watchedAt) {
       continue;
     }
 
-    const title = entry.movie?.title?.trim();
-    if (title) {
-      await prisma.item.upsert({
-        where: { type_imdbId: { type: ItemType.movie, imdbId } },
-        create: { type: ItemType.movie, imdbId, title },
-        update: { title }
+    const existing = await prisma.watchEvent.findFirst({
+      where: { type: "movie", imdbId }
+    });
+
+    if (existing) {
+      await prisma.watchEvent.update({
+        where: { id: existing.id },
+        data: {
+          watchedAt: new Date(watchedAt),
+          plays: entry.plays ?? 1
+        }
+      });
+    } else {
+      await prisma.watchEvent.create({
+        data: {
+          type: "movie",
+          imdbId,
+          watchedAt: new Date(watchedAt),
+          plays: entry.plays ?? 1
+        }
       });
     }
 
-    await prisma.watchEvent.create({
-      data: {
-        type: "movie",
-        imdbId,
-        watchedAt: new Date(watchedAt),
-        plays: 1
-      }
-    });
-
-    importedWatchEvents.movies += 1;
+    imported.movies += 1;
   }
 
-  for (const entry of episodeHistory) {
-    const episodeImdbId = entry.episode?.ids?.imdb;
+  for (const entry of watchedShows) {
     const seriesImdbId = entry.show?.ids?.imdb;
-    const watchedAt = entry.watched_at;
-    const season = entry.episode?.season;
-    const episode = entry.episode?.number;
-
-    if (!episodeImdbId || !seriesImdbId || !watchedAt || season === undefined || episode === undefined) {
+    if (!seriesImdbId) {
       continue;
     }
 
-    const seriesTitle = entry.show?.title?.trim();
-    if (seriesTitle) {
-      await prisma.item.upsert({
-        where: { type_imdbId: { type: ItemType.series, imdbId: seriesImdbId } },
-        create: { type: ItemType.series, imdbId: seriesImdbId, title: seriesTitle },
-        update: { title: seriesTitle }
-      });
-    }
-
-    await prisma.watchEvent.create({
-      data: {
-        type: "episode",
-        imdbId: episodeImdbId,
-        seriesImdbId,
-        season,
-        episode,
-        watchedAt: new Date(watchedAt),
-        plays: 1
+    for (const season of entry.seasons ?? []) {
+      const seasonNumber = season.number;
+      if (seasonNumber === undefined) {
+        continue;
       }
-    });
 
-    const watchedAtDate = new Date(watchedAt);
-    const existing = seriesProgressByImdb.get(seriesImdbId);
-    if (
-      !existing ||
-      watchedAtDate.getTime() > existing.lastWatchedAt.getTime() ||
-      (watchedAtDate.getTime() === existing.lastWatchedAt.getTime() &&
-        (season > existing.lastSeason || (season === existing.lastSeason && episode > existing.lastEpisode)))
-    ) {
-      seriesProgressByImdb.set(seriesImdbId, {
-        lastSeason: season,
-        lastEpisode: episode,
-        lastWatchedAt: watchedAtDate
-      });
+      for (const ep of season.episodes ?? []) {
+        const episodeNumber = ep.number;
+        const watchedAt = ep.last_watched_at;
+
+        if (episodeNumber === undefined || !watchedAt) {
+          continue;
+        }
+
+        const existing = await prisma.watchEvent.findFirst({
+          where: {
+            type: "episode",
+            seriesImdbId,
+            season: seasonNumber,
+            episode: episodeNumber
+          }
+        });
+
+        if (existing) {
+          await prisma.watchEvent.update({
+            where: { id: existing.id },
+            data: {
+              watchedAt: new Date(watchedAt),
+              plays: ep.plays ?? 1
+            }
+          });
+        } else {
+          await prisma.watchEvent.create({
+            data: {
+              type: "episode",
+              imdbId: seriesImdbId,
+              seriesImdbId,
+              season: seasonNumber,
+              episode: episodeNumber,
+              watchedAt: new Date(watchedAt),
+              plays: ep.plays ?? 1
+            }
+          });
+        }
+
+        const watchedAtDate = new Date(watchedAt);
+        const existingProgress = seriesProgressByImdb.get(seriesImdbId);
+        if (
+          !existingProgress ||
+          watchedAtDate.getTime() > existingProgress.lastWatchedAt.getTime() ||
+          (watchedAtDate.getTime() === existingProgress.lastWatchedAt.getTime() &&
+            (seasonNumber > existingProgress.lastSeason ||
+              (seasonNumber === existingProgress.lastSeason && episodeNumber > existingProgress.lastEpisode)))
+        ) {
+          seriesProgressByImdb.set(seriesImdbId, {
+            lastSeason: seasonNumber,
+            lastEpisode: episodeNumber,
+            lastWatchedAt: watchedAtDate
+          });
+        }
+
+        imported.episodes += 1;
+      }
     }
-
-    importedWatchEvents.episodes += 1;
   }
 
   for (const [seriesImdbId, progress] of seriesProgressByImdb.entries()) {
     await upsertSeriesProgressIfNewer(seriesImdbId, progress);
   }
 
-  return reply.code(200).send({
-    importedWatchlist,
-    importedWatchEvents,
-    updatedSeriesProgress: seriesProgressByImdb.size
-  });
+  return reply.code(200).send({ imported });
 });
 
 app.post("/trakt/poll", async (request, reply) => {

--- a/apps/api/src/trakt.ts
+++ b/apps/api/src/trakt.ts
@@ -47,6 +47,32 @@ type TraktMovieHistoryPayload = {
   };
 };
 
+type TraktWatchedMoviePayload = {
+  plays?: number;
+  last_watched_at?: string;
+  movie?: {
+    title?: string;
+    ids?: TraktIds;
+  };
+};
+
+type TraktWatchedShowPayload = {
+  plays?: number;
+  last_watched_at?: string;
+  show?: {
+    title?: string;
+    ids?: TraktIds;
+  };
+  seasons?: Array<{
+    number?: number;
+    episodes?: Array<{
+      number?: number;
+      plays?: number;
+      last_watched_at?: string;
+    }>;
+  }>;
+};
+
 type TraktTokenResponse = {
   access_token: string;
   refresh_token: string;
@@ -105,6 +131,14 @@ export class TraktClient {
 
   async fetchWatchlistShows(logger: FastifyBaseLogger): Promise<TraktShowPayload[]> {
     return this.fetchAllPages<TraktShowPayload>("/sync/watchlist/shows", logger);
+  }
+
+  async fetchWatchedMovies(logger: FastifyBaseLogger): Promise<TraktWatchedMoviePayload[]> {
+    return this.fetchAllPages<TraktWatchedMoviePayload>("/sync/watched/movies", logger);
+  }
+
+  async fetchWatchedShows(logger: FastifyBaseLogger): Promise<TraktWatchedShowPayload[]> {
+    return this.fetchAllPages<TraktWatchedShowPayload>("/sync/watched/shows", logger);
   }
 
   async fetchMovieHistory(logger: FastifyBaseLogger, startAt?: string): Promise<TraktMovieHistoryPayload[]> {
@@ -263,4 +297,4 @@ export class TraktClient {
   }
 }
 
-export type { TraktEpisodeHistoryPayload, TraktMovieHistoryPayload, TraktMoviePayload, TraktShowPayload };
+export type { TraktEpisodeHistoryPayload, TraktMovieHistoryPayload, TraktMoviePayload, TraktShowPayload, TraktWatchedMoviePayload, TraktWatchedShowPayload };


### PR DESCRIPTION
## Summary
This PR refactors the Trakt import endpoint to use the `/sync/watched/` API endpoints instead of combining watchlist and history endpoints. This simplifies the import logic and provides more accurate watch tracking with play counts and last watched timestamps.

## Key Changes
- **Replaced API calls**: Changed from fetching watchlist + history to fetching watched movies/shows directly
  - Removed `fetchWatchlistMovies()`, `fetchWatchlistShows()`, `fetchMovieHistory()`, and `fetchEpisodeHistory()` calls
  - Added `fetchWatchedMovies()` and `fetchWatchedShows()` calls
  
- **Simplified data model**: Consolidated import tracking from separate watchlist and watch event counters to a single `imported` counter tracking movies and episodes

- **Removed watchlist management**: Eliminated all `listItem` and `watchlist` database operations, focusing purely on watch event tracking

- **Enhanced watch event creation**: Now properly handles:
  - Play counts from Trakt data (defaults to 1 if not provided)
  - Last watched timestamps for accurate watch history
  - Upsert logic to update existing watch events instead of always creating new ones

- **Improved episode tracking**: Restructured episode import to iterate through seasons and episodes from the watched shows payload, maintaining series progress tracking

- **Added new Trakt types**: Introduced `TraktWatchedMoviePayload` and `TraktWatchedShowPayload` types to match the watched API response structure

## Implementation Details
- Watch events are now upserted (created or updated) based on existing records, preserving data integrity
- Series progress tracking logic remains unchanged but now operates on the restructured episode data
- Response payload simplified to return only `{ imported: { movies, episodes } }` instead of separate watchlist and watch event counts

https://claude.ai/code/session_01Ek23jVsq8BYeQT6RuxHFEv