### PR TITLE
Add search functionality to catalog endpoints

### DIFF
--- a/apps/addon/src/index.ts
+++ b/apps/addon/src/index.ts
@@ -71,8 +71,8 @@ const fetchAllLists = async (): Promise<CataloggyList[]> => {
 
 const buildManifest = (lists: CataloggyList[]) => {
   const catalogs = lists.flatMap((list) => [
-    { type: "movie" as const, id: `cataloggy-${list.id}-movie`, name: list.name },
-    { type: "series" as const, id: `cataloggy-${list.id}-series`, name: list.name }
+    { type: "movie" as const, id: `cataloggy-${list.id}-movie`, name: list.name, extra: [{ name: "search", isRequired: false }] },
+    { type: "series" as const, id: `cataloggy-${list.id}-series`, name: list.name, extra: [{ name: "search", isRequired: false }] }
   ]);
 
   return {
@@ -107,37 +107,109 @@ app.get("/manifest.json", async (request: FastifyRequest, reply: FastifyReply) =
   }
 });
 
-app.get<{ Params: { type: string; id: string } }>("/catalog/:type/:id.json", async (request, reply) => {
-  reply.header("Access-Control-Allow-Origin", "*");
+type ListItemResponse = {
+  imdbId: string;
+  type: string;
+  metadata: { name: string; poster: string | null; year: number | null } | null;
+};
 
-  const { type, id } = request.params;
+type StremioMetaPreview = {
+  id: string;
+  type: string;
+  name: string;
+  poster?: string;
+  posterShape: "poster";
+};
+
+const parseCatalogId = (id: string) => {
   const match = id.match(/^cataloggy-([0-9a-f-]+)-(movie|series)$/i);
+  if (!match) return null;
+  return { listId: match[1], catalogType: match[2] };
+};
 
-  if (!match) {
-    return reply.code(404).send({ error: "Catalog not found" });
-  }
-
-  const listId = match[1];
-  const catalogType = match[2];
-
-  if (type !== catalogType) {
-    return reply.code(404).send({ error: "Catalog not found" });
-  }
-
-  const apiUrl = new URL(`/stremio/list/${encodeURIComponent(listId)}`, CATALOGGY_API_BASE);
-  apiUrl.searchParams.set("type", catalogType);
-
-  const upstreamResponse = await fetch(apiUrl, {
+const fetchListItems = async (listId: string): Promise<ListItemResponse[]> => {
+  const apiUrl = new URL(`/lists/${encodeURIComponent(listId)}/items`, CATALOGGY_API_BASE);
+  const response = await fetch(apiUrl, {
     headers: CATALOGGY_API_TOKEN ? { Authorization: `Bearer ${CATALOGGY_API_TOKEN}` } : {}
   });
 
-  const payload = await upstreamResponse.json().catch(() => ({ metas: [] }));
-
-  if (!upstreamResponse.ok) {
-    return reply.code(upstreamResponse.status).send(payload);
+  if (!response.ok) {
+    throw new Error(`API responded with ${response.status}`);
   }
 
-  return reply.send(payload);
+  const payload = (await response.json()) as { items?: ListItemResponse[] };
+  return payload.items ?? [];
+};
+
+const itemsToMetas = (items: ListItemResponse[], type: string): StremioMetaPreview[] =>
+  items
+    .filter((item) => item.type === type)
+    .map((item) => ({
+      id: item.imdbId,
+      type: item.type,
+      name: item.metadata?.name ?? item.imdbId,
+      ...(item.metadata?.poster ? { poster: item.metadata.poster } : {}),
+      posterShape: "poster" as const
+    }));
+
+const parseExtra = (extra: string): Record<string, string> => {
+  const params: Record<string, string> = {};
+  for (const pair of extra.split("&")) {
+    const [key, ...rest] = pair.split("=");
+    if (key) {
+      params[decodeURIComponent(key)] = decodeURIComponent(rest.join("="));
+    }
+  }
+  return params;
+};
+
+app.get<{ Params: { type: string; id: string } }>("/catalog/:type/:id.json", async (request, reply) => {
+  reply.header("Access-Control-Allow-Origin", "*");
+  reply.header("Content-Type", "application/json");
+
+  const { type, id } = request.params;
+  const parsed = parseCatalogId(id);
+
+  if (!parsed || type !== parsed.catalogType) {
+    return reply.code(200).send({ metas: [] });
+  }
+
+  try {
+    const items = await fetchListItems(parsed.listId);
+    const metas = itemsToMetas(items, type);
+    return reply.send({ metas });
+  } catch (error) {
+    request.log.error(error, "Failed to fetch catalog items");
+    return reply.send({ metas: [] });
+  }
+});
+
+app.get<{ Params: { type: string; id: string; extra: string } }>("/catalog/:type/:id/:extra.json", async (request, reply) => {
+  reply.header("Access-Control-Allow-Origin", "*");
+  reply.header("Content-Type", "application/json");
+
+  const { type, id, extra } = request.params;
+  const parsed = parseCatalogId(id);
+
+  if (!parsed || type !== parsed.catalogType) {
+    return reply.send({ metas: [] });
+  }
+
+  try {
+    const items = await fetchListItems(parsed.listId);
+    let metas = itemsToMetas(items, type);
+
+    const extraParams = parseExtra(extra);
+    if (extraParams.search) {
+      const query = extraParams.search.toLowerCase();
+      metas = metas.filter((m) => m.name.toLowerCase().includes(query));
+    }
+
+    return reply.send({ metas });
+  } catch (error) {
+    request.log.error(error, "Failed to fetch catalog items");
+    return reply.send({ metas: [] });
+  }
 });
 
 app.get<{ Params: { type: string; id: string } }>("/meta/:type/:id.json", async (request, reply) => {


### PR DESCRIPTION
## Summary
This PR adds search capability to the Stremio catalog endpoints by implementing support for the `search` extra parameter in the manifest and adding a new catalog endpoint that handles search queries.

## Key Changes
- **Manifest Update**: Added `extra: [{ name: "search", isRequired: false }]` to both movie and series catalog entries to advertise search support to Stremio
- **Refactored Catalog Logic**: Extracted catalog ID parsing and item fetching into reusable helper functions (`parseCatalogId`, `fetchListItems`, `itemsToMetas`, `parseExtra`)
- **New Search Endpoint**: Added `/catalog/:type/:id/:extra.json` route that handles search queries by filtering items based on the search parameter
- **Improved Error Handling**: Changed error responses to return empty metas array (HTTP 200) instead of error codes for better Stremio compatibility
- **API Changes**: Switched from the `/stremio/list/:id` endpoint to `/lists/:id/items` for fetching catalog items
- **Type Definitions**: Added `ListItemResponse` and `StremioMetaPreview` types for better type safety

## Implementation Details
- The search functionality filters catalog items by name using case-insensitive substring matching
- Extra parameters are parsed from URL-encoded strings in the catalog route
- Both catalog endpoints (with and without search) share the same item fetching and transformation logic
- Added `Content-Type: application/json` header to all catalog responses

https://claude.ai/code/session_01DUf4sap9NBLZVXDjCpfSLM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added search filtering capability to catalog endpoints, enabling users to search within catalog results.
  * Enhanced catalog entries with improved metadata structure for better data compatibility.

* **Bug Fixes**
  * Improved error handling for invalid catalog requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->