### PR TITLE
Add smoke tests and explicit Docker network configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
       interval: 5s
       timeout: 5s
       retries: 10
+    networks:
+      - cataloggy
 
   api:
     build:
@@ -40,6 +42,8 @@ services:
       timeout: 5s
       retries: 10
       start_period: 10s
+    networks:
+      - cataloggy
 
   addon:
     build:
@@ -63,6 +67,8 @@ services:
       timeout: 5s
       retries: 10
       start_period: 10s
+    networks:
+      - cataloggy
 
   web:
     build:
@@ -83,6 +89,12 @@ services:
       timeout: 5s
       retries: 10
       start_period: 10s
+    networks:
+      - cataloggy
 
 volumes:
   pgdata:
+
+networks:
+  cataloggy:
+    driver: bridge

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -1,0 +1,99 @@
+const apiBase = process.env.API_BASE ?? "http://localhost:7000";
+const addonBase = process.env.ADDON_BASE ?? "http://localhost:7001";
+const apiToken = process.env.API_TOKEN ?? "dev-token";
+
+let failed = false;
+
+const check = async (name: string, run: () => Promise<void>): Promise<void> => {
+  process.stdout.write(`• ${name}... `);
+  try {
+    await run();
+    process.stdout.write("PASS\n");
+  } catch (error) {
+    const details = error instanceof Error ? error.message : String(error);
+    process.stdout.write(`FAIL (${details})\n`);
+    failed = true;
+  }
+};
+
+const getJson = async (url: string, init?: RequestInit): Promise<{ response: Response; body: unknown }> => {
+  const response = await fetch(url, init);
+  const text = await response.text();
+  let body: unknown;
+  try {
+    body = text ? JSON.parse(text) : null;
+  } catch {
+    throw new Error(`Invalid JSON from ${url}: ${text.slice(0, 200)}`);
+  }
+  return { response, body };
+};
+
+// 1. GET /health on API — expect 200
+await check("API /health", async () => {
+  const { response, body } = await getJson(`${apiBase}/health`);
+  if (response.status !== 200) {
+    throw new Error(`Expected 200, got ${response.status}`);
+  }
+  if ((body as Record<string, unknown>)?.status !== "ok") {
+    throw new Error(`Unexpected body: ${JSON.stringify(body)}`);
+  }
+});
+
+// 2. GET /manifest.json on addon — expect 200 with valid JSON containing a catalogs array
+type Manifest = { catalogs?: Array<{ type: string; id: string; name: string }> };
+let manifest: Manifest | null = null;
+
+await check("Addon /manifest.json", async () => {
+  const { response, body } = await getJson(`${addonBase}/manifest.json`);
+  if (response.status !== 200) {
+    throw new Error(`Expected 200, got ${response.status}`);
+  }
+  const m = body as Manifest;
+  if (!Array.isArray(m?.catalogs)) {
+    throw new Error(`Response missing catalogs array: ${JSON.stringify(body)}`);
+  }
+  manifest = m;
+});
+
+// 3. If TRAKT_CLIENT_ID is set, POST /trakt/import — expect 200 with { imported: { movies, episodes } }
+if (process.env.TRAKT_CLIENT_ID) {
+  await check("POST /trakt/import", async () => {
+    const { response, body } = await getJson(`${apiBase}/trakt/import`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${apiToken}` },
+    });
+    if (response.status !== 200) {
+      throw new Error(`Expected 200, got ${response.status}`);
+    }
+    const b = body as { imported?: { movies?: unknown; episodes?: unknown } };
+    if (!b?.imported || !("movies" in b.imported) || !("episodes" in b.imported)) {
+      throw new Error(`Expected { imported: { movies, episodes } }, got: ${JSON.stringify(body)}`);
+    }
+  });
+
+  // 4. GET /catalog/movie/{first catalog id}.json — expect { metas: [...] }
+  const firstMovieCatalog = manifest?.catalogs?.find((c) => c.type === "movie");
+  if (firstMovieCatalog) {
+    await check(`Catalog /catalog/movie/${firstMovieCatalog.id}.json`, async () => {
+      const { response, body } = await getJson(`${addonBase}/catalog/movie/${firstMovieCatalog.id}.json`);
+      if (response.status !== 200) {
+        throw new Error(`Expected 200, got ${response.status}`);
+      }
+      const b = body as { metas?: unknown[] };
+      if (!Array.isArray(b?.metas)) {
+        throw new Error(`Expected { metas: [...] }, got: ${JSON.stringify(body)}`);
+      }
+    });
+  } else {
+    process.stdout.write("• Catalog movie check... SKIP (no movie catalog in manifest)\n");
+  }
+} else {
+  process.stdout.write("• Trakt checks... SKIP (TRAKT_CLIENT_ID not set)\n");
+}
+
+if (failed) {
+  process.stdout.write("\nSome smoke checks failed.\n");
+  process.exit(1);
+} else {
+  process.stdout.write("\nAll smoke checks passed.\n");
+}


### PR DESCRIPTION
## Summary
This PR adds a smoke test suite to validate the health and functionality of the API and addon services, and explicitly configures Docker Compose services to use a named bridge network for improved service isolation and reliability.

## Key Changes

- **New smoke test script** (`scripts/smoke.ts`):
  - Validates API `/health` endpoint returns 200 with `status: "ok"`
  - Validates addon `/manifest.json` endpoint returns 200 with valid catalogs array
  - Conditionally tests Trakt import functionality when `TRAKT_CLIENT_ID` is set
  - Tests catalog endpoints for movie data when available
  - Provides clear pass/fail output with error details
  - Supports environment variable configuration for API/addon base URLs and API token

- **Docker Compose network configuration**:
  - Added explicit `cataloggy` bridge network definition
  - Connected all services (postgres, api, addon, web) to the named network
  - Improves service discovery and isolation compared to the default bridge network

## Implementation Details

- The smoke test uses a helper `check()` function to standardize test execution and error reporting
- JSON parsing includes error handling with truncated response preview for debugging
- Tests are conditional based on environment variables (e.g., Trakt tests only run if `TRAKT_CLIENT_ID` is set)
- Exit code 1 on test failure, 0 on success for CI/CD integration
- All services maintain their existing port mappings and health check configurations

https://claude.ai/code/session_01NGBfMYFYgXFzszhcnqscsr