### PR TITLE
Unwrap nested response objects in series and watch history APIs

### DIFF
--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -192,11 +192,13 @@ export const api = {
       request<{ metas: CatalogMeta[] }>("/recent?type=movie&limit=10")
     ]);
   },
-  getSeriesProgress() {
-    return request<SeriesProgress[]>("/series/progress");
+  async getSeriesProgress() {
+    const res = await request<{ progress: SeriesProgress[] }>("/series/progress");
+    return res.progress;
   },
-  getWatchHistory(limit = 10) {
-    return request<WatchEvent[]>(`/watch/history?limit=${limit}`);
+  async getWatchHistory(limit = 10) {
+    const res = await request<{ history: WatchEvent[] }>(`/watch/history?limit=${limit}`);
+    return res.history;
   },
   getWatchStats() {
     return request<WatchStats>("/watch/stats");


### PR DESCRIPTION
## Summary
Updated the `getSeriesProgress()` and `getWatchHistory()` API methods to unwrap nested response objects, simplifying the return types for consumers.

## Key Changes
- Modified `getSeriesProgress()` to extract `progress` array from the nested response object and return it directly
- Modified `getWatchHistory()` to extract `history` array from the nested response object and return it directly
- Converted both methods to async/await syntax for consistency and clarity
- Updated response type annotations to reflect the actual API response structure with nested objects

## Implementation Details
Both methods now follow a consistent pattern:
1. Await the API request with the full response type (including the wrapper object)
2. Extract the relevant data property from the response
3. Return only the extracted data to callers

This change reduces boilerplate for API consumers who previously had to access nested properties themselves.

https://claude.ai/code/session_01Qs9mLjJgDVBrmj7VLrwygm