### PR TITLE
Add Trakt OAuth redirect URI configuration and validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,9 @@ ADDON_PUBLIC_BASE=
 # Trakt integration (optional; required only for /trakt/import and /trakt/poll)
 TRAKT_CLIENT_ID=
 TRAKT_CLIENT_SECRET=
+# Override the OAuth redirect URI if it differs from CATALOGGY_API_PUBLIC + /trakt/oauth/callback
+# This must exactly match the Redirect URI in your Trakt app settings.
+# TRAKT_REDIRECT_URI=http://192.168.1.20:7000/trakt/oauth/callback
 
 # TMDB integration (optional; required for /search and /meta/:type/:imdbId)
 TMDB_API_KEY=

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -5,5 +5,6 @@ API_TOKEN=dev-token
 CATALOGGY_ALLOWED_ORIGINS=http://localhost:7002
 TRAKT_CLIENT_ID=
 TRAKT_CLIENT_SECRET=
+# TRAKT_REDIRECT_URI=http://localhost:7000/trakt/oauth/callback
 
 TMDB_API_KEY=

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1860,10 +1860,12 @@ app.post("/trakt/import", async (request, reply) => {
 app.get("/trakt/status", async (_request, reply) => {
   const token = await prisma.traktToken.findUnique({ where: { id: "default" } });
   const configured = !!(process.env.TRAKT_CLIENT_ID && process.env.TRAKT_CLIENT_SECRET);
+  const redirectUri = process.env.TRAKT_REDIRECT_URI ?? `${process.env.CATALOGGY_API_PUBLIC ?? "http://localhost:7000"}/trakt/oauth/callback`;
   return reply.send({
     connected: !!token,
     configured,
-    expiresAt: token?.expiresAt ?? null
+    expiresAt: token?.expiresAt ?? null,
+    redirectUri
   });
 });
 
@@ -1874,7 +1876,7 @@ app.get("/trakt/oauth/authorize", async (_request, reply) => {
     return reply.code(500).send({ error: "TRAKT_CLIENT_ID is not configured" });
   }
   const url = `https://trakt.tv/oauth/authorize?response_type=code&client_id=${encodeURIComponent(clientId)}&redirect_uri=${encodeURIComponent(redirectUri)}`;
-  return reply.send({ url });
+  return reply.send({ url, redirectUri });
 });
 
 app.get("/trakt/oauth/callback", async (request, reply) => {

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -234,7 +234,7 @@ export const api = {
     });
   },
   getTraktStatus() {
-    return request<{ connected: boolean; configured: boolean; expiresAt: string | null }>("/trakt/status");
+    return request<{ connected: boolean; configured: boolean; expiresAt: string | null; redirectUri: string }>("/trakt/status");
   },
   getTraktOAuthUrl() {
     return request<{ url: string }>("/trakt/oauth/authorize");

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -119,7 +119,7 @@ function ApiTokenSection() {
 }
 
 function TraktSection() {
-  const [status, setStatus] = useState<{ connected: boolean; configured: boolean } | null>(null);
+  const [status, setStatus] = useState<{ connected: boolean; configured: boolean; redirectUri?: string } | null>(null);
   const [loading, setLoading] = useState(true);
   const [importing, setImporting] = useState(false);
   const [importResult, setImportResult] = useState<string | null>(null);
@@ -185,6 +185,18 @@ function TraktSection() {
           <span className="text-xs text-amber-400">Trakt credentials not configured on the server</span>
         )}
       </div>
+
+      {status?.redirectUri && !status.connected && status.configured && (
+        <div className="rounded-xl border border-slate-800/40 bg-slate-950/50 px-4 py-3 space-y-1">
+          <p className="text-xs text-slate-400">
+            Your Trakt app's <strong className="text-slate-300">Redirect URI</strong> must be set to:
+          </p>
+          <code className="block text-sm text-red-400 break-all select-all">{status.redirectUri}</code>
+          <p className="text-xs text-slate-500">
+            Set this at trakt.tv under Settings &gt; Your API Apps &gt; Edit. A mismatch causes an OAuth error.
+          </p>
+        </div>
+      )}
 
       <div className="flex flex-wrap gap-2">
         {!status?.connected && (

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,8 @@ services:
       DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@db:5432/${POSTGRES_DB:-cataloggy}
       PORT: 7000
       CATALOGGY_ALLOWED_ORIGINS: ${CATALOGGY_ALLOWED_ORIGINS:-${CATALOGGY_WEB_PUBLIC:-http://localhost:7002}}
+      CATALOGGY_API_PUBLIC: ${CATALOGGY_API_PUBLIC:-http://localhost:7000}
+      TRAKT_REDIRECT_URI: ${TRAKT_REDIRECT_URI:-}
     ports:
       - "7000:7000"
     depends_on:


### PR DESCRIPTION
## Summary
This PR adds support for configuring and displaying the Trakt OAuth redirect URI, allowing users to properly set up their Trakt app credentials when the API is hosted at a non-standard URL.

## Key Changes
- **Backend API**: Modified `/trakt/status` endpoint to return the configured redirect URI (either from `TRAKT_REDIRECT_URI` env var or derived from `CATALOGGY_API_PUBLIC`)
- **Backend API**: Updated `/trakt/oauth/authorize` endpoint to return the redirect URI alongside the authorization URL
- **Frontend**: Added UI component to display the required redirect URI when Trakt is configured but not connected, helping users troubleshoot OAuth setup
- **Configuration**: Added `TRAKT_REDIRECT_URI` environment variable support with documentation explaining its purpose and format
- **Type Safety**: Updated TypeScript types in `api.ts` to include the new `redirectUri` field in API responses
- **Docker Compose**: Added `CATALOGGY_API_PUBLIC` and `TRAKT_REDIRECT_URI` environment variables to the service configuration

## Implementation Details
- The redirect URI is calculated as: `TRAKT_REDIRECT_URI` (if set) or `${CATALOGGY_API_PUBLIC}/trakt/oauth/callback` (defaults to `http://localhost:7000`)
- The frontend displays a helpful message with the exact redirect URI that must be configured in the Trakt app settings when OAuth is not yet connected
- The UI component only shows when the app is configured but not connected, providing clear guidance for setup
- Environment variable documentation includes examples for both standard and custom deployment scenarios

https://claude.ai/code/session_01TVuT5gonD2jyRMgnUqXhSB