### PR TITLE
Only set Content-Type header when request has a body

### DIFF
--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -127,12 +127,15 @@ export type ItemListMembership = {
   addedAt: string;
 };
 
-const authHeaders = () => {
+const authHeaders = (hasBody: boolean) => {
   const token = runtimeConfig.getToken();
-  return {
-    Authorization: `Bearer ${token}`,
-    "Content-Type": "application/json"
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${token}`
   };
+  if (hasBody) {
+    headers["Content-Type"] = "application/json";
+  }
+  return headers;
 };
 
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
@@ -145,7 +148,7 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
       ...init,
       signal: controller.signal,
       headers: {
-        ...authHeaders(),
+        ...authHeaders(init?.body != null),
         ...(init?.headers ?? {})
       }
     });


### PR DESCRIPTION
## Summary
Modified the `authHeaders()` function to conditionally include the `Content-Type: application/json` header only when the request contains a body, rather than always including it.

## Key Changes
- Updated `authHeaders()` to accept a `hasBody` parameter that determines whether to include the `Content-Type` header
- Changed the function to build headers conditionally based on whether the request has a body
- Updated the `request()` function to pass `init?.body != null` when calling `authHeaders()`

## Implementation Details
This change ensures that requests without a body (such as GET requests) don't unnecessarily include a `Content-Type` header, which is more semantically correct and follows HTTP best practices. The header is now only added for requests that actually contain a body (POST, PUT, PATCH, etc.).

https://claude.ai/code/session_01ByMvzcm3HrDSi5CKv2VPsb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved API request header handling to ensure proper Content-Type formatting for requests with payloads, enhancing compatibility and consistency across API calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->