### PR TITLE
Fix Trakt import, Stremio manifest URL, missing posters, and dashboard UX

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -2404,6 +2404,51 @@ app.get("/series/progress", async () => {
     watchedBySeriesId.set(row.seriesImdbId, (watchedBySeriesId.get(row.seriesImdbId) ?? 0) + 1);
   }
 
+  // Fetch TMDB metadata for any series without cached metadata.
+  // Sync up to 10 at once (covers most dashboards); fire the rest in the background.
+  const SYNC_INLINE_LIMIT = 10;
+  const missingMetaIds = imdbIds.filter((id) => !metaByImdbId.has(id));
+  if (missingMetaIds.length > 0) {
+    const inlineBatch = missingMetaIds.slice(0, SYNC_INLINE_LIMIT);
+    const backgroundBatch = missingMetaIds.slice(SYNC_INLINE_LIMIT);
+
+    try {
+      const tmdb = await getTmdb();
+      const freshMeta = await Promise.allSettled(
+        inlineBatch.map(async (id) => {
+          const payload = await tmdb.findByImdbId(MetadataType.series, id);
+          if (payload) {
+            await upsertMetadata(payload);
+            return payload;
+          }
+          return null;
+        })
+      );
+      for (const result of freshMeta) {
+        if (result.status === "fulfilled" && result.value) {
+          metaByImdbId.set(result.value.imdbId, {
+            imdbId: result.value.imdbId,
+            name: result.value.name,
+            poster: result.value.poster,
+            totalSeasons: result.value.totalSeasons,
+            totalEpisodes: result.value.totalEpisodes,
+          });
+        }
+      }
+
+      if (backgroundBatch.length > 0) {
+        void (async () => {
+          for (const id of backgroundBatch) {
+            try {
+              const payload = await tmdb.findByImdbId(MetadataType.series, id);
+              if (payload) await upsertMetadata(payload);
+            } catch { /* skip */ }
+          }
+        })();
+      }
+    } catch { /* TMDB unavailable – return what we have */ }
+  }
+
   const progress = progressRows.map((row) => {
     const meta = metaByImdbId.get(row.seriesImdbId);
     return {
@@ -2411,6 +2456,8 @@ app.get("/series/progress", async () => {
       seriesImdbId: row.seriesImdbId,
       lastSeason: row.lastSeason,
       lastEpisode: row.lastEpisode,
+      nextSeason: row.lastSeason,
+      nextEpisode: row.lastEpisode + 1,
       lastWatchedAt: row.lastWatchedAt,
       updatedAt: row.updatedAt,
       name: meta?.name ?? row.seriesImdbId,
@@ -2422,6 +2469,39 @@ app.get("/series/progress", async () => {
   });
 
   return { progress };
+});
+
+app.post<{ Params: { imdbId: string } }>("/series/:imdbId/watch-next", async (request, reply) => {
+  const { imdbId } = request.params;
+
+  const row = await prisma.seriesProgress.findUnique({ where: { seriesImdbId: imdbId } });
+  if (!row) {
+    return reply.code(404).send({ error: "No progress found for this series" });
+  }
+
+  const nextEpisode = row.lastEpisode + 1;
+  const nextSeason = row.lastSeason;
+  const watchedAt = new Date();
+
+  await prisma.watchEvent.create({
+    data: {
+      type: "episode",
+      imdbId,
+      seriesImdbId: imdbId,
+      season: nextSeason,
+      episode: nextEpisode,
+      watchedAt,
+      plays: 1,
+    },
+  });
+
+  await upsertSeriesProgressIfNewer(imdbId, {
+    lastSeason: nextSeason,
+    lastEpisode: nextEpisode,
+    lastWatchedAt: watchedAt,
+  });
+
+  return reply.code(204).send();
 });
 
 app.get<{ Params: { imdbId: string } }>("/series/progress/:imdbId", async (request, reply) => {
@@ -2645,12 +2725,61 @@ app.post("/trakt/import", async (request, reply) => {
     return reply.code(500).send({ error: "Trakt integration is not configured" });
   }
 
-  const [watchedMovies, watchedShows] = await Promise.all([
+  const [watchedMovies, watchedShows, watchlistMovies, watchlistShows] = await Promise.all([
     client.fetchWatchedMovies(request.log),
-    client.fetchWatchedShows(request.log)
+    client.fetchWatchedShows(request.log),
+    client.fetchWatchlistMovies(request.log),
+    client.fetchWatchlistShows(request.log),
   ]);
 
-  const imported = { movies: 0, episodes: 0 };
+  const imported = { movies: 0, episodes: 0, watchlistMovies: 0, watchlistShows: 0 };
+
+  // ── Import Trakt watchlist into the default watchlist ──
+  const watchlist = await getDefaultWatchlist();
+
+  for (const entry of watchlistMovies) {
+    const imdbId = entry.movie?.ids?.imdb;
+    const title = entry.movie?.title?.trim();
+    if (!imdbId) continue;
+
+    await prisma.item.upsert({
+      where: { type_imdbId: { type: ItemType.movie, imdbId } },
+      create: { type: ItemType.movie, imdbId, title: title || undefined },
+      update: title ? { title } : {}
+    });
+
+    try {
+      await prisma.listItem.create({
+        data: { listId: watchlist.id, type: ListItemType.movie, imdbId }
+      });
+      imported.watchlistMovies += 1;
+    } catch (error) {
+      if (!(error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002")) throw error;
+      // already in watchlist – skip
+    }
+  }
+
+  for (const entry of watchlistShows) {
+    const imdbId = entry.show?.ids?.imdb;
+    const title = entry.show?.title?.trim();
+    if (!imdbId) continue;
+
+    await prisma.item.upsert({
+      where: { type_imdbId: { type: ItemType.series, imdbId } },
+      create: { type: ItemType.series, imdbId, title: title || undefined },
+      update: title ? { title } : {}
+    });
+
+    try {
+      await prisma.listItem.create({
+        data: { listId: watchlist.id, type: ListItemType.series, imdbId }
+      });
+      imported.watchlistShows += 1;
+    } catch (error) {
+      if (!(error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002")) throw error;
+      // already in watchlist – skip
+    }
+  }
   const seriesProgressByImdb = new Map<string, SeriesProgressCandidate>();
 
   for (const entry of watchedMovies) {
@@ -2762,6 +2891,42 @@ app.post("/trakt/import", async (request, reply) => {
   for (const [seriesImdbId, progress] of seriesProgressByImdb.entries()) {
     await upsertSeriesProgressIfNewer(seriesImdbId, progress);
   }
+
+  // ── Background metadata fetch for all imported series & movies ──
+  // Collect all IMDb IDs that were just imported and kick off TMDB syncs
+  // in the background so posters are available on the next dashboard load.
+  const movieImdbIds = watchedMovies
+    .map((e) => e.movie?.ids?.imdb)
+    .filter((id): id is string => !!id);
+  const seriesImdbIds = [
+    ...new Set([
+      ...watchedShows.map((e) => e.show?.ids?.imdb).filter((id): id is string => !!id),
+      ...watchlistShows.map((e) => e.show?.ids?.imdb).filter((id): id is string => !!id),
+    ]),
+  ];
+  const watchlistMovieImdbIds = watchlistMovies
+    .map((e) => e.movie?.ids?.imdb)
+    .filter((id): id is string => !!id);
+
+  const allMovieIds = [...new Set([...movieImdbIds, ...watchlistMovieImdbIds])];
+
+  void (async () => {
+    try {
+      const tmdb = await getTmdb();
+      for (const id of allMovieIds) {
+        try {
+          const payload = await tmdb.findByImdbId(MetadataType.movie, id);
+          if (payload) await upsertMetadata(payload);
+        } catch { /* skip individual failures */ }
+      }
+      for (const id of seriesImdbIds) {
+        try {
+          const payload = await tmdb.findByImdbId(MetadataType.series, id);
+          if (payload) await upsertMetadata(payload);
+        } catch { /* skip individual failures */ }
+      }
+    } catch { /* TMDB unavailable */ }
+  })();
 
   return reply.code(200).send({ imported });
 });
@@ -3167,6 +3332,180 @@ app.post("/trakt/poll", async (request, reply) => {
     return reply.code(500).send({ error: "Trakt poll failed" });
   }
 });
+
+// ─── Stremio Addon ───
+// These routes are public (no auth) – see the auth bypass hook above.
+
+const STREMIO_ADDON_ID = "com.cataloggy.addon";
+const STREMIO_ADDON_VERSION = "1.0.0";
+
+// The static catalog IDs that are always available (watchlist / history)
+const CORE_STREMIO_CATALOGS = [
+  { id: "my_watchlist_movies", type: "movie" as const, name: "My Watchlist – Movies" },
+  { id: "my_watchlist_series", type: "series" as const, name: "My Watchlist – Series" },
+  { id: "my_recent_movies", type: "movie" as const, name: "Recently Watched Movies" },
+  { id: "my_continue_series", type: "series" as const, name: "Continue Watching" },
+];
+
+// Map from addon catalog ID to discovery catalog ID used by the discovery endpoints
+const DISCOVERY_CATALOG_MAP: Record<string, { endpoint: string; type: StremioMetaType }> = {
+  "cataloggy-trending-movie":     { endpoint: "trending:movie:week",     type: "movie" },
+  "cataloggy-trending-series":    { endpoint: "trending:series:week",    type: "series" },
+  "cataloggy-popular-movie":      { endpoint: "popular:movie",           type: "movie" },
+  "cataloggy-popular-series":     { endpoint: "popular:series",          type: "series" },
+  "cataloggy-recommended-movie":  { endpoint: "recommended:movie",       type: "movie" },
+  "cataloggy-recommended-series": { endpoint: "recommended:series",      type: "series" },
+  "cataloggy-anime-series":       { endpoint: "anime:series",            type: "series" },
+  "cataloggy-anime-movie":        { endpoint: "anime:movie",             type: "movie" },
+  "cataloggy-netflix-movie":      { endpoint: "streaming:netflix:movie", type: "movie" },
+  "cataloggy-netflix-series":     { endpoint: "streaming:netflix:series",type: "series" },
+  "cataloggy-disney-movie":       { endpoint: "streaming:disney:movie",  type: "movie" },
+  "cataloggy-disney-series":      { endpoint: "streaming:disney:series", type: "series" },
+  "cataloggy-amazon-movie":       { endpoint: "streaming:amazon:movie",  type: "movie" },
+  "cataloggy-amazon-series":      { endpoint: "streaming:amazon:series", type: "series" },
+  "cataloggy-apple-movie":        { endpoint: "streaming:apple:movie",   type: "movie" },
+  "cataloggy-apple-series":       { endpoint: "streaming:apple:series",  type: "series" },
+  "cataloggy-max-movie":          { endpoint: "streaming:max:movie",     type: "movie" },
+  "cataloggy-max-series":         { endpoint: "streaming:max:series",    type: "series" },
+};
+
+const DISCOVERY_CATALOG_LABELS: Record<string, string> = {
+  "cataloggy-trending-movie":     "Trending Movies",
+  "cataloggy-trending-series":    "Trending Series",
+  "cataloggy-popular-movie":      "Popular Movies",
+  "cataloggy-popular-series":     "Popular Series",
+  "cataloggy-recommended-movie":  "Recommended Movies",
+  "cataloggy-recommended-series": "Recommended Series",
+  "cataloggy-anime-series":       "Anime",
+  "cataloggy-anime-movie":        "Anime Movies",
+  "cataloggy-netflix-movie":      "Netflix Movies",
+  "cataloggy-netflix-series":     "Netflix Series",
+  "cataloggy-disney-movie":       "Disney+ Movies",
+  "cataloggy-disney-series":      "Disney+ Series",
+  "cataloggy-amazon-movie":       "Prime Video Movies",
+  "cataloggy-amazon-series":      "Prime Video Series",
+  "cataloggy-apple-movie":        "Apple TV+ Movies",
+  "cataloggy-apple-series":       "Apple TV+ Series",
+  "cataloggy-max-movie":          "Max Movies",
+  "cataloggy-max-series":         "Max Series",
+};
+
+app.get("/addon/stremio/manifest.json", async () => {
+  const config = await getAddonConfig();
+
+  const catalogs: { id: string; type: string; name: string }[] = [
+    ...CORE_STREMIO_CATALOGS.map((c) => ({ id: c.id, type: c.type, name: c.name })),
+    ...config.enabledCatalogs
+      .filter((id) => DISCOVERY_CATALOG_MAP[id])
+      .map((id) => ({
+        id,
+        type: DISCOVERY_CATALOG_MAP[id].type,
+        name: DISCOVERY_CATALOG_LABELS[id] ?? id,
+      })),
+  ];
+
+  return {
+    id: STREMIO_ADDON_ID,
+    version: STREMIO_ADDON_VERSION,
+    name: "Cataloggy",
+    description: "Your personal media tracker – watchlists, history, and discovery catalogs.",
+    logo: "",
+    background: "",
+    resources: ["catalog"],
+    types: ["movie", "series"],
+    catalogs,
+    behaviorHints: { configurable: false, configurationRequired: false },
+  };
+});
+
+// Stremio-compatible catalog handler: /addon/stremio/:type/catalog/:id.json
+app.get<{ Params: { type: string; id: string }; Querystring: { skip?: string } }>(
+  "/addon/stremio/:type/catalog/:id.json",
+  async (request, reply) => {
+    const { type: rawType, id: catalogId } = request.params;
+    const type = parseMetaType(rawType);
+    if (!type) return reply.code(400).send({ metas: [] });
+
+    const limit = parseCatalogLimit(undefined);
+
+    // Core / personal catalogs
+    if (catalogId === "my_watchlist_movies") {
+      const metas = await getWatchlistMetas("movie", limit);
+      return { metas };
+    }
+    if (catalogId === "my_watchlist_series") {
+      const metas = await getWatchlistMetas("series", limit);
+      return { metas };
+    }
+    if (catalogId === "my_recent_movies") {
+      const metas = await getRecentMetas("movie", limit);
+      return { metas };
+    }
+    if (catalogId === "my_continue_series") {
+      const metas = await getContinueMetas(limit);
+      return { metas };
+    }
+
+    // Discovery catalogs
+    const discovery = DISCOVERY_CATALOG_MAP[catalogId];
+    if (!discovery) return reply.code(404).send({ metas: [] });
+
+    const cacheKey = discovery.endpoint;
+    const cached = trendingCacheGet(cacheKey);
+    if (cached) return { metas: cached.data };
+
+    // Fetch from the appropriate source
+    try {
+      const tmdb = await getTmdb();
+      const metaType = discovery.type === "movie" ? MetadataType.movie : MetadataType.series;
+      let results: MetadataPayload[];
+
+      if (cacheKey.startsWith("trending:")) {
+        const window = cacheKey.endsWith(":day") ? "day" as const : "week" as const;
+        results = await tmdb.trending(metaType, window);
+      } else if (cacheKey.startsWith("popular:")) {
+        results = await tmdb.popular(metaType);
+      } else if (cacheKey.startsWith("recommended:")) {
+        const recentItems = metaType === MetadataType.movie
+          ? (await prisma.watchEvent.findMany({ where: { type: "movie" }, orderBy: { watchedAt: "desc" }, take: 3, distinct: ["imdbId"], select: { imdbId: true } })).map((r) => r.imdbId)
+          : (await prisma.seriesProgress.findMany({ orderBy: { lastWatchedAt: "desc" }, take: 3, select: { seriesImdbId: true } })).map((r) => r.seriesImdbId);
+        if (recentItems.length === 0) return { metas: [] };
+        const seedMetas = await prisma.metadata.findMany({ where: { imdbId: { in: recentItems }, type: metaType }, select: { tmdbId: true } });
+        const tmdbIds = seedMetas.filter((m) => m.tmdbId).map((m) => m.tmdbId as number);
+        if (tmdbIds.length === 0) return { metas: [] };
+        const recs = await tmdb.recommendations(metaType, tmdbIds[0]);
+        results = recs;
+      } else if (cacheKey.startsWith("anime:")) {
+        results = await tmdb.discoverAnime(metaType);
+      } else if (cacheKey.startsWith("streaming:")) {
+        const parts = cacheKey.split(":");
+        const providerKey = parts[1];
+        const provider = STREAMING_PROVIDERS[providerKey];
+        if (!provider) return { metas: [] };
+        const region = await getRegionSetting();
+        results = await tmdb.discoverByProvider(metaType, provider.id, region);
+      } else {
+        return { metas: [] };
+      }
+
+      await Promise.all(results.map((r) => upsertMetadata(r)));
+      const metas: StremioMetaPreview[] = results.map((r) => ({
+        id: r.imdbId,
+        type: discovery.type,
+        name: r.name,
+        poster: r.poster ?? undefined,
+        year: r.year ?? undefined,
+        description: r.description ?? undefined,
+        genres: r.genres,
+        rating: r.rating ?? undefined,
+      }));
+      trendingCacheSet(cacheKey, { data: metas, expiry: Date.now() + TRENDING_CACHE_TTL_MS });
+      return { metas };
+    } catch {
+      return { metas: [] };
+    }
+  }
+);
 
 const start = async () => {
   const port = Number(process.env.PORT ?? 7000);

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -2456,6 +2456,8 @@ app.get("/series/progress", async () => {
       seriesImdbId: row.seriesImdbId,
       lastSeason: row.lastSeason,
       lastEpisode: row.lastEpisode,
+      // nextEpisode is an approximation — we don't store per-season episode counts,
+      // so we always advance within the same season. The watch-next endpoint mirrors this.
       nextSeason: row.lastSeason,
       nextEpisode: row.lastEpisode + 1,
       lastWatchedAt: row.lastWatchedAt,
@@ -3428,20 +3430,24 @@ app.get<{ Params: { type: string; id: string }; Querystring: { skip?: string } }
 
     const limit = parseCatalogLimit(undefined);
 
-    // Core / personal catalogs
+    // Core / personal catalogs — validate URL type matches the catalog's expected type
     if (catalogId === "my_watchlist_movies") {
+      if (type !== "movie") return reply.code(400).send({ metas: [] });
       const metas = await getWatchlistMetas("movie", limit);
       return { metas };
     }
     if (catalogId === "my_watchlist_series") {
+      if (type !== "series") return reply.code(400).send({ metas: [] });
       const metas = await getWatchlistMetas("series", limit);
       return { metas };
     }
     if (catalogId === "my_recent_movies") {
+      if (type !== "movie") return reply.code(400).send({ metas: [] });
       const metas = await getRecentMetas("movie", limit);
       return { metas };
     }
     if (catalogId === "my_continue_series") {
+      if (type !== "series") return reply.code(400).send({ metas: [] });
       const metas = await getContinueMetas(limit);
       return { metas };
     }
@@ -3449,6 +3455,9 @@ app.get<{ Params: { type: string; id: string }; Querystring: { skip?: string } }
     // Discovery catalogs
     const discovery = DISCOVERY_CATALOG_MAP[catalogId];
     if (!discovery) return reply.code(404).send({ metas: [] });
+
+    // Validate that the URL type matches the catalog's declared type
+    if (discovery.type !== type) return reply.code(400).send({ metas: [] });
 
     const cacheKey = discovery.endpoint;
     const cached = trendingCacheGet(cacheKey);
@@ -3473,8 +3482,19 @@ app.get<{ Params: { type: string; id: string }; Querystring: { skip?: string } }
         const seedMetas = await prisma.metadata.findMany({ where: { imdbId: { in: recentItems }, type: metaType }, select: { tmdbId: true } });
         const tmdbIds = seedMetas.filter((m) => m.tmdbId).map((m) => m.tmdbId as number);
         if (tmdbIds.length === 0) return { metas: [] };
-        const recs = await tmdb.recommendations(metaType, tmdbIds[0]);
-        results = recs;
+        // Fetch from up to 3 seeds, merge and deduplicate by imdbId
+        const seen = new Set<string>();
+        const merged: MetadataPayload[] = [];
+        for (const seedId of tmdbIds.slice(0, 3)) {
+          const recs = await tmdb.recommendations(metaType, seedId);
+          for (const r of recs) {
+            if (!seen.has(r.imdbId)) {
+              seen.add(r.imdbId);
+              merged.push(r);
+            }
+          }
+        }
+        results = merged;
       } else if (cacheKey.startsWith("anime:")) {
         results = await tmdb.discoverAnime(metaType);
       } else if (cacheKey.startsWith("streaming:")) {

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -100,7 +100,7 @@ export type SeriesProgress = {
 export type WatchEvent = {
   id: string;
   imdbId: string;
-  type: MediaType;
+  type: "movie" | "episode";
   name: string;
   poster?: string;
   season?: number;

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -447,12 +447,20 @@ export function DashboardPage() {
                   : null;
               return (
                 <div key={s.imdbId} className="flex-none group" style={{ width: "11rem" }}>
-                  {/* IMDb link wraps the poster only so the mark-next button stays functional */}
                   <div className="relative overflow-hidden rounded-xl shadow-lg ring-1 ring-white/10 transition-all duration-300 group-hover:shadow-card-hover group-hover:ring-white/20" style={{ aspectRatio: "2 / 3" }}>
                     <Poster
                       src={s.poster}
                       alt={s.name}
                       className="h-full w-full"
+                    />
+                    {/* Stretch link covers the poster; the gradient overlay below renders on top via DOM order */}
+                    <a
+                      href={`https://www.imdb.com/title/${s.imdbId}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="absolute inset-0"
+                      aria-label={`Open ${s.name} on IMDb`}
+                      tabIndex={-1}
                     />
                     {/* Bottom gradient overlay with episode info + mark button */}
                     <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black via-black/80 to-transparent px-3 pb-3 pt-16">

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -138,7 +138,13 @@ type DiscoveryItem = {
 
 function DiscoveryCard({ item, badge }: { item: DiscoveryItem; badge?: React.ReactNode }) {
   return (
-    <div className="flex-none group" style={{ width: "11rem" }}>
+    <a
+      href={`https://www.imdb.com/title/${item.id}`}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="flex-none group"
+      style={{ width: "11rem" }}
+    >
       <div className="relative overflow-hidden rounded-xl shadow-lg ring-1 ring-white/10 transition-all duration-300 group-hover:shadow-card-hover group-hover:ring-white/20" style={{ aspectRatio: "2 / 3" }}>
         <Poster src={item.poster} alt={item.name} className="h-full w-full" />
         {item.rating != null && item.rating > 0 && (
@@ -164,7 +170,7 @@ function DiscoveryCard({ item, badge }: { item: DiscoveryItem; badge?: React.Rea
       <p className="text-2xs text-slate-500">
         {item.year ?? ""}{item.type ? ` ${item.type === "movie" ? "Movie" : "Series"}` : ""}
       </p>
-    </div>
+    </a>
   );
 }
 
@@ -441,6 +447,7 @@ export function DashboardPage() {
                   : null;
               return (
                 <div key={s.imdbId} className="flex-none group" style={{ width: "11rem" }}>
+                  {/* IMDb link wraps the poster only so the mark-next button stays functional */}
                   <div className="relative overflow-hidden rounded-xl shadow-lg ring-1 ring-white/10 transition-all duration-300 group-hover:shadow-card-hover group-hover:ring-white/20" style={{ aspectRatio: "2 / 3" }}>
                     <Poster
                       src={s.poster}
@@ -491,9 +498,14 @@ export function DashboardPage() {
                       </button>
                     </div>
                   </div>
-                  <p className="mt-2.5 truncate text-sm font-semibold text-slate-200">
+                  <a
+                    href={`https://www.imdb.com/title/${s.imdbId}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="mt-2.5 block truncate text-sm font-semibold text-slate-200 hover:text-white transition-colors"
+                  >
                     {s.name}
-                  </p>
+                  </a>
                   {progressPct !== null && (
                     <p className="text-2xs text-slate-500">
                       {s.watchedEpisodes} of {s.totalEpisodes} episodes
@@ -530,7 +542,14 @@ export function DashboardPage() {
             className="flex gap-4 overflow-x-auto pb-2 scroll-smooth scrollbar-hide"
           >
             {history.map((event) => (
-              <div key={event.id} className="flex-none group" style={{ width: "11rem" }}>
+              <a
+                key={event.id}
+                href={`https://www.imdb.com/title/${event.imdbId}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex-none group"
+                style={{ width: "11rem" }}
+              >
                 <div className="relative overflow-hidden rounded-xl shadow-lg ring-1 ring-white/10 transition-all duration-300 group-hover:shadow-card-hover group-hover:ring-white/20" style={{ aspectRatio: "2 / 3" }}>
                   <Poster
                     src={event.poster}
@@ -539,7 +558,7 @@ export function DashboardPage() {
                   />
                   {/* Bottom gradient with metadata */}
                   <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black via-black/70 to-transparent px-3 pb-3 pt-12">
-                    {event.type === "series" &&
+                    {event.type === "episode" &&
                     event.season != null &&
                     event.episode != null ? (
                       <span className="inline-block rounded bg-white/10 px-2 py-0.5 text-xs font-semibold text-white backdrop-blur-sm">
@@ -562,7 +581,7 @@ export function DashboardPage() {
                   {event.name}
                 </p>
                 <p className="text-2xs text-slate-500">
-                  {event.type === "series" &&
+                  {event.type === "episode" &&
                   event.season != null &&
                   event.episode != null
                     ? `Season ${event.season}, Episode ${event.episode}`
@@ -570,7 +589,7 @@ export function DashboardPage() {
                       ? "Movie"
                       : ""}
                 </p>
-              </div>
+              </a>
             ))}
           </div>
         )}

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -390,12 +390,16 @@ const CATALOG_LABELS: Record<string, string> = {
 
 function AddonManifestUrl() {
   const [copied, setCopied] = useState(false);
+  const [copyError, setCopyError] = useState(false);
   const manifestUrl = `${runtimeConfig.getApiBase()}/addon/stremio/manifest.json`;
 
   const copy = () => {
-    void navigator.clipboard.writeText(manifestUrl).then(() => {
+    navigator.clipboard.writeText(manifestUrl).then(() => {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
+    }).catch(() => {
+      setCopyError(true);
+      setTimeout(() => setCopyError(false), 3000);
     });
   };
 
@@ -415,11 +419,13 @@ function AddonManifestUrl() {
           className={`flex-none inline-flex items-center gap-1.5 rounded-lg px-3 py-2 text-xs font-semibold transition-all ${
             copied
               ? "bg-emerald-500/15 text-emerald-400 ring-1 ring-emerald-500/20"
-              : "bg-slate-800 text-slate-300 hover:bg-slate-700 border border-slate-700/60"
+              : copyError
+                ? "bg-red-500/15 text-red-400 ring-1 ring-red-500/20"
+                : "bg-slate-800 text-slate-300 hover:bg-slate-700 border border-slate-700/60"
           }`}
           aria-label="Copy manifest URL"
         >
-          {copied ? <><Check size={13} /> Copied</> : <><Copy size={13} /> Copy</>}
+          {copied ? <><Check size={13} /> Copied</> : copyError ? <>Failed</> : <><Copy size={13} /> Copy</>}
         </button>
         <a
           href={manifestUrl}

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -1,6 +1,6 @@
 import { FormEvent, ReactNode, useCallback, useEffect, useId, useRef, useState } from "react";
 import { api, runtimeConfig } from "../api";
-import { ChevronDown, Key, Link, Database, Info, Eye, EyeOff, Loader2, Check, AlertCircle, Unplug, Clapperboard, Image, Globe, Shield } from "lucide-react";
+import { ChevronDown, Key, Link, Database, Info, Eye, EyeOff, Loader2, Check, AlertCircle, Unplug, Clapperboard, Image, Globe, Shield, Copy, ExternalLink } from "lucide-react";
 
 declare const __APP_VERSION__: string;
 const APP_VERSION = typeof __APP_VERSION__ !== "undefined" ? __APP_VERSION__ : "unknown";
@@ -388,6 +388,56 @@ const CATALOG_LABELS: Record<string, string> = {
   "cataloggy-max-series": "Max Series",
 };
 
+function AddonManifestUrl() {
+  const [copied, setCopied] = useState(false);
+  const manifestUrl = `${runtimeConfig.getApiBase()}/addon/stremio/manifest.json`;
+
+  const copy = () => {
+    void navigator.clipboard.writeText(manifestUrl).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
+
+  return (
+    <div className="rounded-xl border border-slate-700/60 bg-slate-950/60 p-4 space-y-3">
+      <p className="text-sm font-medium text-slate-300">Manifest URL</p>
+      <p className="text-xs text-slate-400 leading-relaxed">
+        Copy this URL and paste it into Stremio under <strong className="text-slate-300">Add-ons &rarr; Install from URL</strong>.
+      </p>
+      <div className="flex items-center gap-2">
+        <code className="flex-1 overflow-x-auto rounded-lg bg-slate-900 px-3 py-2 text-xs text-red-400 select-all whitespace-nowrap scrollbar-hide">
+          {manifestUrl}
+        </code>
+        <button
+          type="button"
+          onClick={copy}
+          className={`flex-none inline-flex items-center gap-1.5 rounded-lg px-3 py-2 text-xs font-semibold transition-all ${
+            copied
+              ? "bg-emerald-500/15 text-emerald-400 ring-1 ring-emerald-500/20"
+              : "bg-slate-800 text-slate-300 hover:bg-slate-700 border border-slate-700/60"
+          }`}
+          aria-label="Copy manifest URL"
+        >
+          {copied ? <><Check size={13} /> Copied</> : <><Copy size={13} /> Copy</>}
+        </button>
+        <a
+          href={manifestUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex-none inline-flex items-center gap-1.5 rounded-lg bg-slate-800 border border-slate-700/60 px-3 py-2 text-xs font-semibold text-slate-300 hover:bg-slate-700 transition-colors"
+          aria-label="Open manifest URL"
+        >
+          <ExternalLink size={13} />
+        </a>
+      </div>
+      <p className="text-xs text-slate-500">
+        The URL points to your local API server. Stremio must be able to reach it on your network.
+      </p>
+    </div>
+  );
+}
+
 function AddonConfigSection() {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -437,6 +487,7 @@ function AddonConfigSection() {
 
   return (
     <div className="space-y-4">
+      <AddonManifestUrl />
       <p className="text-sm text-slate-400 leading-relaxed">
         Choose which catalogs appear in Stremio. Changes take effect after the manifest cache refreshes (~60s).
       </p>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,11 +30,11 @@ services:
       # Optional integrations — set these in a .env file or export them.
       # Leaving them unset is safe; the API validates at startup/request time
       # and returns clear error messages if they are missing when needed.
-      TRAKT_CLIENT_ID: ${TRAKT_CLIENT_ID:-6dfb7aff9fcb7d4cfdcbc3395216eb7ba184909cf27f1e286d3c106acd6a7074}
-      TRAKT_CLIENT_SECRET: ${TRAKT_CLIENT_SECRET:-01e2a98cb7b90ca5b88179a65e8900cc8b2f0e4fcf24de47190c3c5be99a37a0}
+      TRAKT_CLIENT_ID: ${TRAKT_CLIENT_ID}
+      TRAKT_CLIENT_SECRET: ${TRAKT_CLIENT_SECRET}
       TRAKT_REDIRECT_URI: ${TRAKT_REDIRECT_URI:-http://192.168.1.20:7000/trakt/oauth/callback}
       TRAKT_POLL_INTERVAL_SEC: ${TRAKT_POLL_INTERVAL_SEC:-300}
-      TMDB_API_KEY: ${TMDB_API_KEY:-e8b4fa576a0bb32a503915f57cf9b462}
+      TMDB_API_KEY: ${TMDB_API_KEY}
     ports:
       - "7000:7000"
     depends_on:


### PR DESCRIPTION
## Summary

- **Trakt watchlist import** — `Run Import` now also pulls watchlist movies & TV shows and adds them to your Watchlist list; a background TMDB metadata fetch runs immediately after so posters are ready on the next dashboard load
- **Stremio manifest URL** — Added public `GET /addon/stremio/manifest.json` and `/addon/stremio/:type/catalog/:id.json` endpoints; Settings › Stremio Addon now shows a one-click copyable manifest URL to paste into Stremio
- **Missing posters (Continue Watching)** — `/series/progress` now auto-fetches TMDB metadata inline for any series without a cached poster (up to 10 in parallel per request); remaining series are synced in the background
- **Recently Watched episode info** — Fixed `WatchEvent.type` (`"episode"` not `"series"`) so TV episode badges (`S2:E4`) and subtitles now display correctly
- **Series progress next episode** — `/series/progress` now returns `nextSeason`/`nextEpisode`; added `POST /series/:imdbId/watch-next` endpoint used by the Mark Next button
- **Clickable cards** — Trending, Recommended, Recently Watched, and Continue Watching cards now link to IMDb

## Test plan

- [ ] Run Trakt import and verify watchlist movies + shows appear in the Watchlist list
- [ ] Check that posters load on Continue Watching after import (may need one refresh)
- [ ] Open Settings › Stremio Addon, copy the manifest URL, and install in Stremio
- [ ] Confirm Recently Watched TV entries show `S1:E3`-style badges
- [ ] Click a trending card and confirm it opens IMDb

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Watch Next" action to create a next-episode watch event and advance series progress.
  * Stremio addon support: manifest and discoverable catalogs.
  * Settings page: copy/open addon manifest URL control.

* **Improvements**
  * Series progress shows upcoming season/episode.
  * Trakt import now includes watchlist movies and shows and triggers background metadata sync.
  * Discovery and recent items link directly to IMDb and improve episode metadata display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->