### PR TITLE
Add OMDB ratings, enriched detail panel, watch management, recommenda…

### DIFF
--- a/apps/api/prisma/migrations/20260319200000_add_omdb_ratings/migration.sql
+++ b/apps/api/prisma/migrations/20260319200000_add_omdb_ratings/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "Metadata" ADD COLUMN "imdbRating" DOUBLE PRECISION,
+                        ADD COLUMN "rtScore"    INTEGER,
+                        ADD COLUMN "mcScore"    INTEGER;

--- a/apps/api/prisma/migrations/20260319210000_add_detail_fields/migration.sql
+++ b/apps/api/prisma/migrations/20260319210000_add_detail_fields/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+ALTER TABLE "Metadata" ADD COLUMN "runtime"       INTEGER,
+                        ADD COLUMN "certification" TEXT,
+                        ADD COLUMN "status"        TEXT,
+                        ADD COLUMN "network"       TEXT,
+                        ADD COLUMN "releaseDate"   TEXT;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -143,6 +143,14 @@ model Metadata {
   voteCount     Int?
   totalSeasons  Int?
   totalEpisodes Int?
+  imdbRating    Float?
+  rtScore       Int?
+  mcScore       Int?
+  runtime       Int?
+  certification String?
+  status        String?
+  network       String?
+  releaseDate   String?
   updatedAt     DateTime     @updatedAt @db.Timestamptz(6)
 
   @@unique([imdbId, type])

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -2,7 +2,7 @@ import { createHash, timingSafeEqual } from "node:crypto";
 import Fastify, { FastifyReply, FastifyRequest } from "fastify";
 import { ItemType, ListItemType, ListKind, MetadataType, Prisma, PrismaClient, ScrobbleStatus, WatchEventType } from "@prisma/client";
 import { TraktClient, computeTokenExpiresAt } from "./trakt.js";
-import { MetadataPayload, STREAMING_PROVIDERS, TmdbClient } from "./tmdb.js";
+import { CastMember, MetadataPayload, SeasonInfo, STREAMING_PROVIDERS, TmdbClient } from "./tmdb.js";
 
 const prisma = new PrismaClient();
 
@@ -233,7 +233,9 @@ const getMetadataType = (rawType: string): MetadataType | null => {
 };
 
 const upsertMetadata = async (metadata: MetadataPayload) => {
-  const isDetailedPayload = metadata.totalSeasons !== null || metadata.totalEpisodes !== null;
+  const isDetailedPayload = metadata.totalSeasons !== null || metadata.totalEpisodes !== null
+    || metadata.runtime !== null || metadata.certification !== null
+    || metadata.status !== null || metadata.network !== null;
 
   const update: Record<string, unknown> = {
     tmdbId: metadata.tmdbId,
@@ -254,6 +256,11 @@ const upsertMetadata = async (metadata: MetadataPayload) => {
     update.updatedAt = new Date();
     update.totalSeasons = metadata.totalSeasons;
     update.totalEpisodes = metadata.totalEpisodes;
+    update.runtime = metadata.runtime;
+    update.certification = metadata.certification;
+    update.status = metadata.status;
+    update.network = metadata.network;
+    update.releaseDate = metadata.releaseDate;
   }
 
   return prisma.metadata.upsert({
@@ -277,6 +284,16 @@ const fetchMetadata = async (type: MetadataType, imdbId: string): Promise<Metada
   }
 
   await upsertMetadata(metadata);
+
+  // Best-effort OMDB enrichment
+  try {
+    const omdbKey = await getOmdbApiKey();
+    if (omdbKey) {
+      const omdb = await fetchOmdbRatings(imdbId, omdbKey);
+      await upsertOmdbRatings(imdbId, type, omdb);
+    }
+  } catch { /* ignore */ }
+
   return metadata;
 };
 
@@ -288,6 +305,16 @@ const syncMetadata = async (imdbId: string, type: MetadataType) => {
   });
 
   if (existing && Date.now() - existing.updatedAt.getTime() < METADATA_FRESHNESS_MS) {
+    // Still refresh OMDB if not yet populated
+    if (existing.imdbRating === null && existing.rtScore === null && existing.mcScore === null) {
+      try {
+        const omdbKey = await getOmdbApiKey();
+        if (omdbKey) {
+          const omdb = await fetchOmdbRatings(imdbId, omdbKey);
+          return upsertOmdbRatings(imdbId, type, omdb);
+        }
+      } catch { /* ignore */ }
+    }
     return existing;
   }
 
@@ -298,7 +325,17 @@ const syncMetadata = async (imdbId: string, type: MetadataType) => {
     return existing ?? null;
   }
 
-  return upsertMetadata(payload);
+  const row = await upsertMetadata(payload);
+
+  try {
+    const omdbKey = await getOmdbApiKey();
+    if (omdbKey) {
+      const omdb = await fetchOmdbRatings(imdbId, omdbKey);
+      return upsertOmdbRatings(imdbId, type, omdb);
+    }
+  } catch { /* ignore */ }
+
+  return row;
 };
 
 const parseCatalogLimit = (rawLimit: unknown) => {
@@ -386,31 +423,17 @@ const buildMetasFromIds = async (ids: string[], type: StremioMetaType): Promise<
 
   const itemType = type === "movie" ? ItemType.movie : ItemType.series;
   const metadataType = type === "movie" ? MetadataType.movie : MetadataType.series;
-  const items = await prisma.item.findMany({
-    where: {
-      type: itemType,
-      imdbId: { in: ids }
-    },
-    select: {
-      imdbId: true,
-      title: true
-    }
-  });
-  const metadata = await prisma.metadata.findMany({
-    where: {
-      imdbId: { in: ids },
-      type: metadataType
-    },
-    select: {
-      imdbId: true,
-      name: true,
-      poster: true,
-      year: true,
-      description: true,
-      genres: true,
-      rating: true,
-    }
-  });
+  const [items, metadata, rpdbKey] = await Promise.all([
+    prisma.item.findMany({
+      where: { type: itemType, imdbId: { in: ids } },
+      select: { imdbId: true, title: true }
+    }),
+    prisma.metadata.findMany({
+      where: { imdbId: { in: ids }, type: metadataType },
+      select: { imdbId: true, name: true, poster: true, year: true, description: true, genres: true, rating: true }
+    }),
+    getRpdbApiKey(),
+  ]);
 
   const titleByImdbId = new Map(items.map((item) => [item.imdbId, item.title?.trim() ?? ""]));
   const metadataByImdbId = new Map(metadata.map((entry) => [entry.imdbId, entry]));
@@ -422,7 +445,7 @@ const buildMetasFromIds = async (ids: string[], type: StremioMetaType): Promise<
       id,
       type,
       name: titleByImdbId.get(id) || meta?.name || id,
-      poster: meta?.poster ?? undefined,
+      poster: withRpdbPoster(id, meta?.poster, rpdbKey) ?? undefined,
       year: meta?.year ?? undefined,
       description: meta?.description ?? undefined,
       genres: meta?.genres ?? [],
@@ -774,10 +797,13 @@ app.get<{ Querystring: { type?: string; query?: string; q?: string } }>("/search
   const imdbIds = results.map((r) => r.imdbId);
   const resultTypes = [...new Set(results.map((r) => r.type as ListItemType))];
 
-  const listItems = await prisma.listItem.findMany({
-    where: { imdbId: { in: imdbIds }, type: { in: resultTypes } },
-    include: { list: { select: { id: true, name: true, kind: true } } }
-  });
+  const [listItems, rpdbKey] = await Promise.all([
+    prisma.listItem.findMany({
+      where: { imdbId: { in: imdbIds }, type: { in: resultTypes } },
+      include: { list: { select: { id: true, name: true, kind: true } } }
+    }),
+    getRpdbApiKey(),
+  ]);
 
   const listInfoKey = (imdbId: string, mediaType: string) => `${mediaType}:${imdbId}`;
   const listInfoByKey = new Map<string, { inWatchlist: boolean; lists: string[] }>();
@@ -801,7 +827,7 @@ app.get<{ Querystring: { type?: string; query?: string; q?: string } }>("/search
       type: result.type,
       name: result.name,
       year: result.year,
-      poster: result.poster,
+      poster: withRpdbPoster(result.imdbId, result.poster, rpdbKey),
       description: result.description,
       genres: result.genres,
       rating: result.rating,
@@ -822,17 +848,13 @@ app.get<{ Params: { type: string; imdbId: string } }>("/meta/:type/:imdbId", asy
     return reply.code(400).send({ error: "imdbId is required" });
   }
 
-  const existing = await prisma.metadata.findUnique({
-    where: {
-      imdbId_type: {
-        imdbId,
-        type
-      }
-    }
-  });
+  const [existing, rpdbKey] = await Promise.all([
+    prisma.metadata.findUnique({ where: { imdbId_type: { imdbId, type } } }),
+    getRpdbApiKey(),
+  ]);
 
   if (existing) {
-    return existing;
+    return { ...existing, poster: withRpdbPoster(imdbId, existing.poster, rpdbKey) };
   }
 
   try {
@@ -840,8 +862,11 @@ app.get<{ Params: { type: string; imdbId: string } }>("/meta/:type/:imdbId", asy
     if (!metadata) {
       return reply.code(404).send({ error: "Metadata not found" });
     }
-
-    return metadata;
+    // After fetch, return the enriched DB row (includes OMDB ratings)
+    const fresh = await prisma.metadata.findUnique({ where: { imdbId_type: { imdbId, type } } });
+    return fresh
+      ? { ...fresh, poster: withRpdbPoster(imdbId, fresh.poster, rpdbKey) }
+      : { ...metadata, poster: withRpdbPoster(imdbId, metadata.poster, rpdbKey) };
   } catch (error) {
     request.log.error(error, "Metadata fetch failed");
     return reply.code(500).send({ error: "Metadata fetch failed" });
@@ -871,6 +896,167 @@ app.post<{ Body: unknown }>("/metadata/sync", async (request, reply) => {
     request.log.error(error, "Metadata sync failed");
     return reply.code(500).send({ error: "Metadata sync failed" });
   }
+});
+
+// ─── Cast & Seasons (on-demand, in-memory cached) ───
+
+const CAST_CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+type CastCacheEntry = { data: CastMember[]; expiry: number };
+const castCache = new Map<string, CastCacheEntry>();
+
+type SeasonsCacheEntry = { data: SeasonInfo[]; expiry: number };
+const seasonsCache = new Map<string, SeasonsCacheEntry>();
+
+app.get<{ Params: { type: string; imdbId: string } }>("/meta/:type/:imdbId/cast", async (request, reply) => {
+  const type = getMetadataType(request.params.type);
+  if (!type) return reply.code(400).send({ error: "type must be one of: movie, series" });
+
+  const imdbId = request.params.imdbId.trim();
+  const cacheKey = `cast:${type}:${imdbId}`;
+  const now = Date.now();
+  const cached = castCache.get(cacheKey);
+  if (cached && now < cached.expiry) return { cast: cached.data };
+
+  const meta = await prisma.metadata.findUnique({
+    where: { imdbId_type: { imdbId, type } },
+    select: { tmdbId: true },
+  });
+
+  if (!meta?.tmdbId) return { cast: [] };
+
+  try {
+    const tmdb = await getTmdb();
+    const cast = await tmdb.getCast(type, meta.tmdbId);
+    castCache.set(cacheKey, { data: cast, expiry: now + CAST_CACHE_TTL_MS });
+    return { cast };
+  } catch {
+    return { cast: [] };
+  }
+});
+
+app.get<{ Params: { imdbId: string } }>("/meta/series/:imdbId/seasons", async (request, reply) => {
+  const imdbId = request.params.imdbId.trim();
+  const cacheKey = `seasons:${imdbId}`;
+  const now = Date.now();
+  const cached = seasonsCache.get(cacheKey);
+  if (cached && now < cached.expiry) return { seasons: cached.data };
+
+  const meta = await prisma.metadata.findUnique({
+    where: { imdbId_type: { imdbId, type: "series" } },
+    select: { tmdbId: true },
+  });
+
+  if (!meta?.tmdbId) return { seasons: [] };
+
+  try {
+    const tmdb = await getTmdb();
+    const seasons = await tmdb.getSeasons(meta.tmdbId);
+    seasonsCache.set(cacheKey, { data: seasons, expiry: now + CAST_CACHE_TTL_MS });
+    return { seasons };
+  } catch {
+    return { seasons: [] };
+  }
+});
+
+// ─── Drop Show ───
+
+const DROPPED_KEY = (imdbId: string) => `dropped:series:${imdbId}`;
+
+app.get<{ Params: { imdbId: string } }>("/show/:imdbId/dropped", async (request) => {
+  const row = await prisma.kV.findUnique({ where: { key: DROPPED_KEY(request.params.imdbId) } });
+  return { dropped: !!row };
+});
+
+app.post<{ Params: { imdbId: string } }>("/show/:imdbId/drop", async (request) => {
+  await prisma.kV.upsert({
+    where: { key: DROPPED_KEY(request.params.imdbId) },
+    create: { key: DROPPED_KEY(request.params.imdbId), value: "true", updatedAt: new Date() },
+    update: { value: "true", updatedAt: new Date() },
+  });
+  return { dropped: true };
+});
+
+app.delete<{ Params: { imdbId: string } }>("/show/:imdbId/drop", async (request) => {
+  await prisma.kV.deleteMany({ where: { key: DROPPED_KEY(request.params.imdbId) } });
+  return { dropped: false };
+});
+
+// ─── Delete Watch Event ───
+
+app.delete<{ Params: { eventId: string } }>("/watch/:eventId", async (request, reply) => {
+  const { eventId } = request.params;
+  try {
+    await prisma.watchEvent.delete({ where: { id: eventId } });
+    return reply.code(204).send();
+  } catch {
+    return reply.code(404).send({ error: "Watch event not found" });
+  }
+});
+
+// ─── Check-in ───
+
+const CHECKIN_KV_KEY = "checkin:active";
+
+type CheckInData = {
+  type: "movie" | "episode";
+  imdbId: string;
+  seriesImdbId?: string;
+  name: string;
+  poster?: string;
+  season?: number;
+  episode?: number;
+  startedAt: string;
+  expiresAt?: string;
+};
+
+app.get("/checkin", async () => {
+  const row = await prisma.kV.findUnique({ where: { key: CHECKIN_KV_KEY } });
+  if (!row) return { checkin: null };
+  try {
+    return { checkin: JSON.parse(row.value) as CheckInData };
+  } catch {
+    return { checkin: null };
+  }
+});
+
+app.post<{ Body: { type: "movie" | "episode"; imdbId: string; seriesImdbId?: string; name: string; poster?: string; season?: number; episode?: number; runtime?: number } }>(
+  "/checkin",
+  async (request) => {
+    const { type, imdbId, seriesImdbId, name, poster, season, episode, runtime } = request.body;
+    const startedAt = new Date().toISOString();
+    const expiresAt = runtime ? new Date(Date.now() + runtime * 60 * 1000).toISOString() : undefined;
+    const checkin: CheckInData = { type, imdbId, seriesImdbId, name, poster, season, episode, startedAt, expiresAt };
+    await prisma.kV.upsert({
+      where: { key: CHECKIN_KV_KEY },
+      create: { key: CHECKIN_KV_KEY, value: JSON.stringify(checkin), updatedAt: new Date() },
+      update: { value: JSON.stringify(checkin), updatedAt: new Date() },
+    });
+    return { checkin };
+  }
+);
+
+app.delete<{ Querystring: { log?: string } }>("/checkin", async (request, reply) => {
+  const row = await prisma.kV.findUnique({ where: { key: CHECKIN_KV_KEY } });
+  if (row && request.query.log === "true") {
+    try {
+      const checkin = JSON.parse(row.value) as CheckInData;
+      await prisma.watchEvent.create({
+        data: {
+          type: checkin.type,
+          imdbId: checkin.type === "movie" ? checkin.imdbId : (checkin.seriesImdbId ?? checkin.imdbId),
+          ...(checkin.type === "episode" && {
+            seriesImdbId: checkin.seriesImdbId ?? checkin.imdbId,
+            season: checkin.season ?? null,
+            episode: checkin.episode ?? null,
+          }),
+          watchedAt: new Date(),
+          plays: 1,
+        },
+      });
+    } catch { /* best-effort */ }
+  }
+  await prisma.kV.deleteMany({ where: { key: CHECKIN_KV_KEY } });
+  return reply.code(204).send();
 });
 
 // ─── Trending / Popular (TMDB) ───
@@ -908,8 +1094,8 @@ app.get<{ Querystring: { type?: string; window?: string } }>("/trending", async 
   const timeWindow = request.query.window === "day" ? "day" as const : "week" as const;
   const cacheKey = `trending:${rawType}:${timeWindow}`;
   const now = Date.now();
-  const cached = trendingCacheGet(cacheKey);
-  if (cached && now < cached.expiry) return { metas: cached.data };
+  const [cached, rpdbKey] = await Promise.all([Promise.resolve(trendingCacheGet(cacheKey)), getRpdbApiKey()]);
+  if (cached && now < cached.expiry) return { metas: applyRpdbToMetaList(cached.data, rpdbKey) };
 
   try {
     const tmdb = await getTmdb();
@@ -927,7 +1113,7 @@ app.get<{ Querystring: { type?: string; window?: string } }>("/trending", async 
       rating: r.rating ?? undefined,
     }));
     trendingCacheSet(cacheKey, { data: metas, expiry: now + TRENDING_CACHE_TTL_MS });
-    return { metas };
+    return { metas: applyRpdbToMetaList(metas, rpdbKey) };
   } catch (error) {
     request.log.error(error, "Trending fetch failed");
     return reply.code(500).send({ error: "Failed to fetch trending content" });
@@ -941,8 +1127,8 @@ app.get<{ Querystring: { type?: string } }>("/popular", async (request, reply) =
 
   const cacheKey = `popular:${rawType}`;
   const now = Date.now();
-  const cached = trendingCacheGet(cacheKey);
-  if (cached && now < cached.expiry) return { metas: cached.data };
+  const [cached, rpdbKey] = await Promise.all([Promise.resolve(trendingCacheGet(cacheKey)), getRpdbApiKey()]);
+  if (cached && now < cached.expiry) return { metas: applyRpdbToMetaList(cached.data, rpdbKey) };
 
   try {
     const tmdb = await getTmdb();
@@ -959,7 +1145,7 @@ app.get<{ Querystring: { type?: string } }>("/popular", async (request, reply) =
       rating: r.rating ?? undefined,
     }));
     trendingCacheSet(cacheKey, { data: metas, expiry: now + TRENDING_CACHE_TTL_MS });
-    return { metas };
+    return { metas: applyRpdbToMetaList(metas, rpdbKey) };
   } catch (error) {
     request.log.error(error, "Popular fetch failed");
     return reply.code(500).send({ error: "Failed to fetch popular content" });
@@ -1056,8 +1242,8 @@ app.get<{ Querystring: { imdbId?: string; type?: string } }>("/recommendations",
 
   const cacheKey = `recs:${rawType}:${imdbId}`;
   const now = Date.now();
-  const cached = trendingCacheGet(cacheKey);
-  if (cached && now < cached.expiry) return { metas: cached.data };
+  const [cached, rpdbKeyRec] = await Promise.all([Promise.resolve(trendingCacheGet(cacheKey)), getRpdbApiKey()]);
+  if (cached && now < cached.expiry) return { metas: applyRpdbToMetaList(cached.data, rpdbKeyRec) };
 
   // Look up tmdbId from metadata
   const meta = await prisma.metadata.findUnique({
@@ -1095,7 +1281,8 @@ async function getRecommendations(rawType: string, type: MetadataType, tmdbId: n
       rating: r.rating ?? undefined,
     }));
     trendingCacheSet(cacheKey, { data: metas, expiry: now + TRENDING_CACHE_TTL_MS });
-    return { metas };
+    const rpdbKey = await getRpdbApiKey();
+    return { metas: applyRpdbToMetaList(metas, rpdbKey) };
   } catch {
     return { metas: [] };
   }
@@ -1208,7 +1395,8 @@ app.get<{ Querystring: { type?: string; limit?: string } }>("/recommendations/pe
     }
   }
 
-  return { metas: allRecs.slice(0, limit) };
+  const rpdbKeyPersonal = await getRpdbApiKey();
+  return { metas: applyRpdbToMetaList(allRecs.slice(0, limit), rpdbKeyPersonal) };
 });
 
 // ─── Plex / Jellyfin Webhooks ───
@@ -1571,8 +1759,8 @@ app.get<{ Querystring: { type?: string; provider?: string; region?: string } }>(
   const provider = STREAMING_PROVIDERS[providerKey];
   const cacheKey = `streaming:${providerKey}:${rawType}:${region}`;
   const now = Date.now();
-  const cached = trendingCacheGet(cacheKey);
-  if (cached && now < cached.expiry) return { metas: cached.data, provider: provider.name };
+  const [cached, rpdbKeyStream] = await Promise.all([Promise.resolve(trendingCacheGet(cacheKey)), getRpdbApiKey()]);
+  if (cached && now < cached.expiry) return { metas: applyRpdbToMetaList(cached.data, rpdbKeyStream), provider: provider.name };
 
   try {
     const tmdb = await getTmdb();
@@ -1589,7 +1777,7 @@ app.get<{ Querystring: { type?: string; provider?: string; region?: string } }>(
       rating: r.rating ?? undefined,
     }));
     trendingCacheSet(cacheKey, { data: metas, expiry: now + TRENDING_CACHE_TTL_MS });
-    return { metas, provider: provider.name };
+    return { metas: applyRpdbToMetaList(metas, rpdbKeyStream), provider: provider.name };
   } catch (error) {
     request.log.error(error, "Streaming catalog fetch failed");
     return reply.code(500).send({ error: "Failed to fetch streaming catalog" });
@@ -1611,8 +1799,8 @@ app.get<{ Querystring: { type?: string } }>("/anime", async (request, reply) => 
 
   const cacheKey = `anime:${rawType}`;
   const now = Date.now();
-  const cached = trendingCacheGet(cacheKey);
-  if (cached && now < cached.expiry) return { metas: cached.data };
+  const [cached, rpdbKeyAnime] = await Promise.all([Promise.resolve(trendingCacheGet(cacheKey)), getRpdbApiKey()]);
+  if (cached && now < cached.expiry) return { metas: applyRpdbToMetaList(cached.data, rpdbKeyAnime) };
 
   try {
     const tmdb = await getTmdb();
@@ -1629,7 +1817,7 @@ app.get<{ Querystring: { type?: string } }>("/anime", async (request, reply) => 
       rating: r.rating ?? undefined,
     }));
     trendingCacheSet(cacheKey, { data: metas, expiry: now + TRENDING_CACHE_TTL_MS });
-    return { metas };
+    return { metas: applyRpdbToMetaList(metas, rpdbKeyAnime) };
   } catch (error) {
     request.log.error(error, "Anime catalog fetch failed");
     return reply.code(500).send({ error: "Failed to fetch anime catalog" });
@@ -2659,6 +2847,89 @@ app.post<{ Body: unknown }>("/addon/config", async (request, reply) => {
   return { config };
 });
 
+// ─── OMDB (Open Movie Database) ───
+
+const OMDB_API_KEY_KV = "omdb:apiKey";
+
+const getOmdbApiKey = async (): Promise<string | null> => {
+  const row = await prisma.kV.findUnique({ where: { key: OMDB_API_KEY_KV } });
+  return row?.value?.trim() || null;
+};
+
+type OmdbRatings = {
+  imdbRating: number | null;
+  rtScore: number | null;
+  mcScore: number | null;
+};
+
+const fetchOmdbRatings = async (imdbId: string, apiKey: string): Promise<OmdbRatings> => {
+  const url = `https://www.omdbapi.com/?i=${encodeURIComponent(imdbId)}&apikey=${encodeURIComponent(apiKey)}`;
+  const res = await fetch(url, { signal: AbortSignal.timeout(8000) });
+  if (!res.ok) return { imdbRating: null, rtScore: null, mcScore: null };
+  const data = await res.json() as {
+    Response?: string;
+    imdbRating?: string;
+    Ratings?: Array<{ Source: string; Value: string }>;
+  };
+  if (data.Response !== "True") return { imdbRating: null, rtScore: null, mcScore: null };
+
+  const rawImdb = data.imdbRating && data.imdbRating !== "N/A" ? parseFloat(data.imdbRating) : NaN;
+  const imdbRating = isNaN(rawImdb) ? null : rawImdb;
+
+  const rtValue = data.Ratings?.find((r) => r.Source === "Rotten Tomatoes")?.Value;
+  const rawRt = rtValue ? parseInt(rtValue.replace("%", ""), 10) : NaN;
+  const rtScore = isNaN(rawRt) ? null : rawRt;
+
+  const mcValue = data.Ratings?.find((r) => r.Source === "Metacritic")?.Value;
+  const rawMc = mcValue ? parseInt(mcValue.split("/")[0], 10) : NaN;
+  const mcScore = isNaN(rawMc) ? null : rawMc;
+
+  return { imdbRating, rtScore, mcScore };
+};
+
+const upsertOmdbRatings = async (imdbId: string, type: MetadataType, ratings: OmdbRatings) => {
+  return prisma.metadata.update({
+    where: { imdbId_type: { imdbId, type } },
+    data: { imdbRating: ratings.imdbRating, rtScore: ratings.rtScore, mcScore: ratings.mcScore },
+  });
+};
+
+app.get("/omdb/status", async () => {
+  const apiKey = await getOmdbApiKey();
+  return { configured: !!apiKey };
+});
+
+app.post<{ Body: unknown }>("/omdb/key", async (request, reply) => {
+  const body = request.body as { apiKey?: unknown } | null;
+  const apiKey = typeof body?.apiKey === "string" ? body.apiKey.trim() : "";
+  if (!apiKey) {
+    await prisma.kV.deleteMany({ where: { key: OMDB_API_KEY_KV } });
+    return { configured: false };
+  }
+  // Validate key against OMDB
+  try {
+    const testUrl = `https://www.omdbapi.com/?i=tt0111161&apikey=${encodeURIComponent(apiKey)}`;
+    const testRes = await fetch(testUrl, { signal: AbortSignal.timeout(8000) });
+    const testData = await testRes.json() as { Response?: string; Error?: string };
+    if (testData.Response === "False") {
+      return reply.code(400).send({ error: testData.Error ?? "Invalid OMDB API key" });
+    }
+  } catch {
+    return reply.code(400).send({ error: "Could not reach OMDB API to validate key" });
+  }
+  await prisma.kV.upsert({
+    where: { key: OMDB_API_KEY_KV },
+    create: { key: OMDB_API_KEY_KV, value: apiKey, updatedAt: new Date() },
+    update: { value: apiKey, updatedAt: new Date() },
+  });
+  return { configured: true };
+});
+
+app.delete("/omdb/key", async () => {
+  await prisma.kV.deleteMany({ where: { key: OMDB_API_KEY_KV } });
+  return { configured: false };
+});
+
 // ─── RPDB (Rating Poster Database) ───
 
 const RPDB_API_KEY_KV = "rpdb:apiKey";
@@ -2671,6 +2942,15 @@ const getRpdbApiKey = async (): Promise<string | null> => {
 
 const buildRpdbPosterUrl = (rpdbKey: string, imdbId: string): string =>
   `${RPDB_BASE_URL}/${rpdbKey}/imdb/poster-default/${imdbId}.jpg`;
+
+// Apply RPDB poster if key is configured, otherwise fall back to existing poster
+const withRpdbPoster = (imdbId: string, fallback: string | null | undefined, rpdbKey: string | null): string | null =>
+  rpdbKey ? buildRpdbPosterUrl(rpdbKey, imdbId) : (fallback ?? null);
+
+const applyRpdbToMetaList = (metas: StremioMetaPreview[], rpdbKey: string | null): StremioMetaPreview[] => {
+  if (!rpdbKey) return metas;
+  return metas.map((m) => ({ ...m, poster: buildRpdbPosterUrl(rpdbKey, m.id) }));
+};
 
 app.get("/rpdb/status", async () => {
   const apiKey = await getRpdbApiKey();
@@ -3087,6 +3367,7 @@ app.post("/metadata/refresh-all", async (request, reply) => {
     request.log.error(error, "TMDB initialization failed for metadata refresh");
     return reply.code(500).send({ error: "TMDB initialization failed" });
   }
+  const omdbKey = await getOmdbApiKey();
   let refreshed = 0;
 
   for (let i = 0; i < allMetadata.length; i += BATCH_SIZE) {
@@ -3096,6 +3377,12 @@ app.post("/metadata/refresh-all", async (request, reply) => {
         const payload = await tmdb.findByImdbId(item.type, item.imdbId);
         if (payload) {
           await upsertMetadata(payload);
+          if (omdbKey) {
+            try {
+              const omdb = await fetchOmdbRatings(item.imdbId, omdbKey);
+              await upsertOmdbRatings(item.imdbId, item.type, omdb);
+            } catch { /* best-effort */ }
+          }
           return true;
         }
         return false;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -853,8 +853,17 @@ app.get<{ Params: { type: string; imdbId: string } }>("/meta/:type/:imdbId", asy
     getRpdbApiKey(),
   ]);
 
-  if (existing) {
-    return { ...existing, poster: withRpdbPoster(imdbId, existing.poster, rpdbKey) };
+  const isDetailComplete = (row: typeof existing) =>
+    row != null &&
+    row.runtime != null &&
+    row.certification != null &&
+    row.status != null &&
+    row.network != null &&
+    row.releaseDate != null &&
+    (row.imdbRating != null || row.rtScore != null || row.mcScore != null);
+
+  if (isDetailComplete(existing)) {
+    return { ...existing, poster: withRpdbPoster(imdbId, existing!.poster, rpdbKey) };
   }
 
   try {
@@ -917,10 +926,15 @@ app.get<{ Params: { type: string; imdbId: string } }>("/meta/:type/:imdbId/cast"
   const cached = castCache.get(cacheKey);
   if (cached && now < cached.expiry) return { cast: cached.data };
 
-  const meta = await prisma.metadata.findUnique({
+  let meta = await prisma.metadata.findUnique({
     where: { imdbId_type: { imdbId, type } },
     select: { tmdbId: true },
   });
+
+  if (!meta?.tmdbId) {
+    await fetchMetadata(type, imdbId).catch(() => {});
+    meta = await prisma.metadata.findUnique({ where: { imdbId_type: { imdbId, type } }, select: { tmdbId: true } });
+  }
 
   if (!meta?.tmdbId) return { cast: [] };
 
@@ -934,17 +948,22 @@ app.get<{ Params: { type: string; imdbId: string } }>("/meta/:type/:imdbId/cast"
   }
 });
 
-app.get<{ Params: { imdbId: string } }>("/meta/series/:imdbId/seasons", async (request, reply) => {
+app.get<{ Params: { imdbId: string } }>("/meta/series/:imdbId/seasons", async (request) => {
   const imdbId = request.params.imdbId.trim();
   const cacheKey = `seasons:${imdbId}`;
   const now = Date.now();
   const cached = seasonsCache.get(cacheKey);
   if (cached && now < cached.expiry) return { seasons: cached.data };
 
-  const meta = await prisma.metadata.findUnique({
+  let meta = await prisma.metadata.findUnique({
     where: { imdbId_type: { imdbId, type: "series" } },
     select: { tmdbId: true },
   });
+
+  if (!meta?.tmdbId) {
+    await fetchMetadata("series", imdbId).catch(() => {});
+    meta = await prisma.metadata.findUnique({ where: { imdbId_type: { imdbId, type: "series" } }, select: { tmdbId: true } });
+  }
 
   if (!meta?.tmdbId) return { seasons: [] };
 
@@ -986,10 +1005,35 @@ app.delete<{ Params: { imdbId: string } }>("/show/:imdbId/drop", async (request)
 app.delete<{ Params: { eventId: string } }>("/watch/:eventId", async (request, reply) => {
   const { eventId } = request.params;
   try {
-    await prisma.watchEvent.delete({ where: { id: eventId } });
+    await prisma.$transaction(async (tx) => {
+      const event = await tx.watchEvent.findUnique({ where: { id: eventId } });
+      if (!event) throw Object.assign(new Error("not found"), { code: "NOT_FOUND" });
+
+      await tx.watchEvent.delete({ where: { id: eventId } });
+
+      // Repair seriesProgress when an episode is deleted
+      if (event.type === "episode" && event.seriesImdbId) {
+        const latest = await tx.watchEvent.findFirst({
+          where: { seriesImdbId: event.seriesImdbId, type: "episode", season: { not: null }, episode: { not: null } },
+          orderBy: { watchedAt: "desc" },
+        });
+
+        if (latest && latest.season != null && latest.episode != null) {
+          await tx.seriesProgress.update({
+            where: { seriesImdbId: event.seriesImdbId },
+            data: { lastSeason: latest.season, lastEpisode: latest.episode, lastWatchedAt: latest.watchedAt, updatedAt: new Date() },
+          });
+        } else {
+          await tx.seriesProgress.deleteMany({ where: { seriesImdbId: event.seriesImdbId } });
+        }
+      }
+    });
     return reply.code(204).send();
-  } catch {
-    return reply.code(404).send({ error: "Watch event not found" });
+  } catch (err: unknown) {
+    if (err instanceof Error && (err as NodeJS.ErrnoException).code === "NOT_FOUND") {
+      return reply.code(404).send({ error: "Watch event not found" });
+    }
+    throw err;
   }
 });
 
@@ -1040,18 +1084,16 @@ app.delete<{ Querystring: { log?: string } }>("/checkin", async (request, reply)
   if (row && request.query.log === "true") {
     try {
       const checkin = JSON.parse(row.value) as CheckInData;
-      await prisma.watchEvent.create({
-        data: {
-          type: checkin.type,
-          imdbId: checkin.type === "movie" ? checkin.imdbId : (checkin.seriesImdbId ?? checkin.imdbId),
-          ...(checkin.type === "episode" && {
-            seriesImdbId: checkin.seriesImdbId ?? checkin.imdbId,
-            season: checkin.season ?? null,
-            episode: checkin.episode ?? null,
-          }),
-          watchedAt: new Date(),
-          plays: 1,
-        },
+      const seriesImdbId = checkin.seriesImdbId ?? checkin.imdbId;
+      await recordWatchEvent({
+        type: checkin.type,
+        imdbId: checkin.type === "movie" ? checkin.imdbId : seriesImdbId,
+        seriesImdbId: checkin.type === "episode" ? seriesImdbId : undefined,
+        season: checkin.type === "episode" ? (checkin.season ?? null) : undefined,
+        episode: checkin.type === "episode" ? (checkin.episode ?? null) : undefined,
+        watchedAt: new Date(),
+        source: "checkin",
+        request,
       });
     } catch { /* best-effort */ }
   }

--- a/apps/api/src/tmdb.ts
+++ b/apps/api/src/tmdb.ts
@@ -21,6 +21,30 @@ type TmdbDetailsResult = TmdbSearchResult & {
   genres?: { id: number; name: string }[];
   number_of_seasons?: number;
   number_of_episodes?: number;
+  runtime?: number | null;
+  episode_run_time?: number[];
+  status?: string;
+  networks?: { id: number; name: string; origin_country: string }[];
+  production_companies?: { id: number; name: string }[];
+  seasons?: {
+    id: number;
+    name: string;
+    season_number: number;
+    episode_count: number;
+    air_date?: string | null;
+    poster_path?: string | null;
+  }[];
+  // append_to_response: release_dates (movie)
+  release_dates?: {
+    results: {
+      iso_3166_1: string;
+      release_dates: { certification: string; type: number }[];
+    }[];
+  };
+  // append_to_response: content_ratings (tv)
+  content_ratings?: {
+    results: { iso_3166_1: string; rating: string }[];
+  };
 };
 
 type TmdbExternalIds = {
@@ -38,6 +62,31 @@ type TmdbFindResponse = {
   tv_results?: TmdbSearchResult[];
 };
 
+type TmdbCreditsResponse = {
+  cast?: {
+    id: number;
+    name: string;
+    character: string;
+    profile_path?: string | null;
+    order: number;
+  }[];
+};
+
+export type CastMember = {
+  name: string;
+  character: string;
+  photo: string | null;
+  order: number;
+};
+
+export type SeasonInfo = {
+  seasonNumber: number;
+  name: string;
+  episodeCount: number;
+  airYear: number | null;
+  poster: string | null;
+};
+
 export type MetadataPayload = {
   imdbId: string;
   type: MetadataType;
@@ -52,6 +101,11 @@ export type MetadataPayload = {
   voteCount: number | null;
   totalSeasons: number | null;
   totalEpisodes: number | null;
+  runtime: number | null;
+  certification: string | null;
+  status: string | null;
+  network: string | null;
+  releaseDate: string | null;
 };
 
 // Standard TMDB genre IDs (movie + TV combined)
@@ -80,6 +134,7 @@ export const STREAMING_PROVIDERS: Record<string, { id: number; name: string }> =
 export class TmdbClient {
   private static readonly baseUrl = "https://api.themoviedb.org/3";
   private static readonly imageBaseUrl = "https://image.tmdb.org/t/p/w500";
+  private static readonly profileBaseUrl = "https://image.tmdb.org/t/p/w185";
 
   private readonly language: string;
 
@@ -286,13 +341,68 @@ export class TmdbClient {
     }
 
     const mediaType = this.toMediaType(type);
-    const details = await this.request<TmdbDetailsResponse>(`/${mediaType}/${result.id}`);
+    const appendFields = mediaType === "movie" ? "release_dates" : "content_ratings";
+    const details = await this.request<TmdbDetailsResponse>(`/${mediaType}/${result.id}`, {
+      append_to_response: appendFields,
+    });
 
     return this.toMetadataPayloadFromDetails(type, details, imdbId);
   }
 
+  async getCast(type: MetadataType, tmdbId: number): Promise<CastMember[]> {
+    const mediaType = this.toMediaType(type);
+    try {
+      const data = await this.request<TmdbCreditsResponse>(`/${mediaType}/${tmdbId}/credits`);
+      return (data.cast ?? [])
+        .sort((a, b) => a.order - b.order)
+        .slice(0, 20)
+        .map((c) => ({
+          name: c.name,
+          character: c.character,
+          photo: c.profile_path ? `${TmdbClient.profileBaseUrl}${c.profile_path}` : null,
+          order: c.order,
+        }));
+    } catch {
+      return [];
+    }
+  }
+
+  async getSeasons(tmdbId: number): Promise<SeasonInfo[]> {
+    try {
+      const data = await this.request<{ seasons?: TmdbDetailsResult["seasons"] }>(`/tv/${tmdbId}`);
+      return (data.seasons ?? [])
+        .filter((s) => s.season_number > 0) // skip "Specials" season 0
+        .map((s) => ({
+          seasonNumber: s.season_number,
+          name: s.name,
+          episodeCount: s.episode_count,
+          airYear: s.air_date ? new Date(s.air_date).getUTCFullYear() : null,
+          poster: s.poster_path ? `${TmdbClient.imageBaseUrl}${s.poster_path}` : null,
+        }));
+    } catch {
+      return [];
+    }
+  }
+
   private async getExternalIds(mediaType: TmdbMediaType, tmdbId: number) {
     return this.request<TmdbExternalIds>(`/${mediaType}/${tmdbId}/external_ids`);
+  }
+
+  private parseCertification(type: MetadataType, details: TmdbDetailsResult): string | null {
+    if (type === MetadataType.movie) {
+      const usEntry = details.release_dates?.results?.find((r) => r.iso_3166_1 === "US");
+      if (usEntry) {
+        // Type 3 = Theatrical, 4 = Digital, 5 = Physical — prefer theatrical
+        const theatrical = usEntry.release_dates.find((d) => d.type === 3 && d.certification);
+        if (theatrical?.certification) return theatrical.certification;
+        const any = usEntry.release_dates.find((d) => d.certification);
+        if (any?.certification) return any.certification;
+      }
+      return null;
+    }
+    // TV
+    const usEntry = details.content_ratings?.results?.find((r) => r.iso_3166_1 === "US");
+    return usEntry?.rating ?? null;
   }
 
   private toMetadataPayload(type: MetadataType, result: TmdbSearchResult, imdbId: string): MetadataPayload {
@@ -316,13 +426,26 @@ export class TmdbClient {
       voteCount: typeof result.vote_count === "number" ? result.vote_count : null,
       totalSeasons: null,
       totalEpisodes: null,
+      runtime: null,
+      certification: null,
+      status: null,
+      network: null,
+      releaseDate: dateValue ?? null,
     };
   }
 
-  private toMetadataPayloadFromDetails(type: MetadataType, result: TmdbDetailsResponse, imdbId: string): MetadataPayload {
+  private toMetadataPayloadFromDetails(type: MetadataType, result: TmdbDetailsResult, imdbId: string): MetadataPayload {
     const name = (type === MetadataType.movie ? result.title : result.name)?.trim() || imdbId;
     const dateValue = type === MetadataType.movie ? result.release_date : result.first_air_date;
     const genres = (result.genres ?? []).map((g) => g.name).filter(Boolean);
+
+    const runtime = type === MetadataType.movie
+      ? (typeof result.runtime === "number" && result.runtime > 0 ? result.runtime : null)
+      : (result.episode_run_time?.[0] ?? null);
+
+    const network = type === MetadataType.series
+      ? (result.networks?.[0]?.name ?? null)
+      : null;
 
     return {
       imdbId,
@@ -338,6 +461,11 @@ export class TmdbClient {
       voteCount: typeof result.vote_count === "number" ? result.vote_count : null,
       totalSeasons: type === MetadataType.series && typeof result.number_of_seasons === "number" ? result.number_of_seasons : null,
       totalEpisodes: type === MetadataType.series && typeof result.number_of_episodes === "number" ? result.number_of_episodes : null,
+      runtime,
+      certification: this.parseCertification(type, result),
+      status: result.status ?? null,
+      network,
+      releaseDate: dateValue ?? null,
     };
   }
 

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -55,6 +55,16 @@ export type SearchResult = {
   rating: number | null;
   inWatchlist: boolean;
   lists: string[];
+  // OMDB ratings — undefined = not yet fetched, null = fetched but unavailable
+  imdbRating?: number | null;
+  rtScore?: number | null;
+  mcScore?: number | null;
+  // Detail fields — undefined = not yet fetched
+  runtime?: number | null;
+  certification?: string | null;
+  status?: string | null;
+  network?: string | null;
+  releaseDate?: string | null;
 };
 
 export type ListItem = {
@@ -149,6 +159,18 @@ export type UserPreferences = {
   language: string;
   region: string;
   spoilerProtection: boolean;
+};
+
+export type CheckIn = {
+  type: "movie" | "episode";
+  imdbId: string;
+  seriesImdbId?: string;
+  name: string;
+  poster?: string;
+  season?: number;
+  episode?: number;
+  startedAt: string;
+  expiresAt?: string;
 };
 
 export type CalendarEntry = {
@@ -309,6 +331,18 @@ export const api = {
   removeRpdbKey() {
     return request<{ configured: boolean }>("/rpdb/key", { method: "DELETE" });
   },
+  getOmdbStatus() {
+    return request<{ configured: boolean }>("/omdb/status");
+  },
+  setOmdbKey(apiKey: string) {
+    return request<{ configured: boolean }>("/omdb/key", {
+      method: "POST",
+      body: JSON.stringify({ apiKey })
+    });
+  },
+  removeOmdbKey() {
+    return request<{ configured: boolean }>("/omdb/key", { method: "DELETE" });
+  },
   getDetailedStats() {
     return request<DetailedWatchStats>("/watch/stats/detailed");
   },
@@ -373,7 +407,51 @@ export const api = {
     return request<{ metas: TrendingMeta[] }>(`/anime?type=${type}`);
   },
   getItemMeta(type: MediaType, imdbId: string) {
-    return request<{ imdbId: string; type: string; name: string; year: number | null; poster: string | null; description: string | null; genres: string[]; rating: number | null }>(`/meta/${type}/${encodeURIComponent(imdbId)}`);
+    return request<{
+      imdbId: string; type: string; name: string; year: number | null; poster: string | null;
+      description: string | null; genres: string[]; rating: number | null;
+      imdbRating: number | null; rtScore: number | null; mcScore: number | null;
+      runtime: number | null; certification: string | null;
+      status: string | null; network: string | null; releaseDate: string | null;
+    }>(`/meta/${type}/${encodeURIComponent(imdbId)}`);
+  },
+  getCast(type: MediaType, imdbId: string) {
+    return request<{ cast: Array<{ name: string; character: string; photo: string | null; order: number }> }>(
+      `/meta/${type}/${encodeURIComponent(imdbId)}/cast`
+    );
+  },
+  getSeasons(imdbId: string) {
+    return request<{ seasons: Array<{ seasonNumber: number; name: string; episodeCount: number; airYear: number | null; poster: string | null }> }>(
+      `/meta/series/${encodeURIComponent(imdbId)}/seasons`
+    );
+  },
+  getDropped(imdbId: string) {
+    return request<{ dropped: boolean }>(`/show/${encodeURIComponent(imdbId)}/dropped`);
+  },
+  dropShow(imdbId: string) {
+    return request<{ dropped: boolean }>(`/show/${encodeURIComponent(imdbId)}/drop`, { method: "POST" });
+  },
+  undropShow(imdbId: string) {
+    return request<{ dropped: boolean }>(`/show/${encodeURIComponent(imdbId)}/drop`, { method: "DELETE" });
+  },
+  deleteWatchEvent(eventId: string) {
+    return request<void>(`/watch/${encodeURIComponent(eventId)}`, { method: "DELETE" });
+  },
+  logWatch(payload: { type: "movie" | "episode"; imdbId: string; seriesImdbId?: string; season?: number; episode?: number; watchedAt: string }) {
+    return request<{ watchEvent: { id: string } }>("/watch", { method: "POST", body: JSON.stringify(payload) });
+  },
+  // Check-in
+  getCheckin() {
+    return request<{ checkin: CheckIn | null }>("/checkin");
+  },
+  startCheckin(payload: { type: "movie" | "episode"; imdbId: string; seriesImdbId?: string; name: string; poster?: string; season?: number; episode?: number; runtime?: number | null }) {
+    return request<{ checkin: CheckIn }>("/checkin", {
+      method: "POST",
+      body: JSON.stringify(payload),
+    });
+  },
+  endCheckin(logWatch = false) {
+    return request<void>(`/checkin?log=${logWatch}`, { method: "DELETE" });
   },
   // Preferences (language, region, spoiler protection)
   getPreferences() {

--- a/apps/web/src/components/MediaDetailPanel.tsx
+++ b/apps/web/src/components/MediaDetailPanel.tsx
@@ -1,17 +1,376 @@
-import { useCallback, useEffect, useState } from "react";
-import { Check, ChevronRight, Clock, Film, Star, Tv, X } from "lucide-react";
-import { api, ApiError, CatalogList, MediaType, SearchResult, WatchEvent } from "../api";
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  Calendar, Check, ChevronRight, Clock, Film, Radio, Star, Trash2, Tv, TvMinimalPlay, User, X,
+} from "lucide-react";
+import { api, ApiError, CatalogList, CheckIn, MediaType, SearchResult, WatchEvent } from "../api";
+
+/* ─── Rating Source Logos ─────────────────────────────────── */
+
+function ImdbLogo() {
+  return (
+    <span
+      className="inline-flex items-center justify-center rounded px-1.5 py-0.5 text-[11px] font-black leading-none text-black"
+      style={{ background: "#F5C518", fontFamily: "Arial Black, Arial, sans-serif" }}
+    >
+      IMDb
+    </span>
+  );
+}
+
+function RtLogo({ score }: { score: number }) {
+  const isFresh = score >= 60;
+  return (
+    <svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg" aria-label="Rotten Tomatoes">
+      {isFresh ? (
+        <>
+          <circle cx="9" cy="11" r="6.5" fill="#FA320A" />
+          <ellipse cx="9" cy="4.5" rx="1" ry="2" fill="#00C300" transform="rotate(-15 9 4.5)" />
+          <ellipse cx="11" cy="3.5" rx="0.8" ry="1.8" fill="#00C300" transform="rotate(15 11 3.5)" />
+          <ellipse cx="7" cy="3.5" rx="0.8" ry="1.8" fill="#00C300" transform="rotate(-15 7 3.5)" />
+          <circle cx="7" cy="9" r="1.5" fill="#FA6040" opacity="0.5" />
+          <circle cx="11.5" cy="11.5" r="1" fill="#FA6040" opacity="0.4" />
+        </>
+      ) : (
+        <>
+          <circle cx="9" cy="10" r="6" fill="#69BE28" opacity="0.9" />
+          <path d="M6 7 L12 13 M12 7 L6 13" stroke="#3a7a00" strokeWidth="1.5" strokeLinecap="round" />
+          <circle cx="9" cy="10" r="3" fill="#69BE28" />
+        </>
+      )}
+    </svg>
+  );
+}
+
+function McIcon({ score }: { score: number }) {
+  const color = score >= 61 ? "#6ac045" : score >= 40 ? "#ffbd3f" : "#ff4444";
+  return (
+    <svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg" aria-label="Metacritic">
+      <rect width="18" height="18" rx="3" fill={color} />
+      <text x="9" y="13" textAnchor="middle" fontSize="11" fontWeight="900" fill="white" fontFamily="Arial Black, Arial, sans-serif">M</text>
+    </svg>
+  );
+}
+
+/* ─── Helpers ─────────────────────────────────────────────── */
+
+function formatRuntime(minutes: number): string {
+  if (minutes < 60) return `${minutes}m`;
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  return m > 0 ? `${h}h ${m}m` : `${h}h`;
+}
+
+function statusColor(status: string): string {
+  const s = status.toLowerCase();
+  if (s.includes("return") || s.includes("ongoing")) return "text-green-400 bg-green-500/10 ring-green-500/20";
+  if (s.includes("ended") || s.includes("cancel")) return "text-rose-400 bg-rose-500/10 ring-rose-500/20";
+  if (s.includes("production") || s.includes("planned")) return "text-amber-400 bg-amber-500/10 ring-amber-500/20";
+  return "text-slate-400 bg-slate-800/60 ring-slate-700/40";
+}
+
+/* ─── Watch Date Modal ────────────────────────────────────── */
+
+type WatchLogTarget =
+  | { kind: "movie"; imdbId: string; releaseDate: string | null | undefined }
+  | { kind: "episode"; seriesImdbId: string; season: number; episode: number };
+
+function WatchDateModal({
+  target,
+  onLog,
+  onClose,
+}: {
+  target: WatchLogTarget;
+  onLog: (date: string) => Promise<void>;
+  onClose: () => void;
+}) {
+  const [mode, setMode] = useState<"quick" | "custom">("quick");
+  const [customDate, setCustomDate] = useState(() => new Date().toISOString().slice(0, 10));
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // For episode mode: let user pick season+episode
+  const [season, setSeason] = useState(target.kind === "episode" ? target.season : 1);
+  const [episode, setEpisode] = useState(target.kind === "episode" ? target.episode : 1);
+
+  const submit = async (dateIso: string) => {
+    setSaving(true);
+    setError(null);
+    try {
+      await onLog(dateIso);
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to log watch");
+      setSaving(false);
+    }
+  };
+
+  const releaseDate = target.kind === "movie" ? target.releaseDate : null;
+
+  return (
+    <div
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/70 backdrop-blur-sm p-4"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-sm rounded-2xl border border-slate-700/60 bg-slate-900 p-6 shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="mb-5 flex items-center justify-between">
+          <h3 className="text-base font-semibold text-white">When did you watch this?</h3>
+          <button type="button" onClick={onClose} className="rounded-lg p-1 text-slate-400 hover:text-white">
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Episode pickers for series */}
+        {target.kind === "episode" && (
+          <div className="mb-4 flex gap-3">
+            <div className="flex-1">
+              <label className="mb-1 block text-xs text-slate-500">Season</label>
+              <input
+                type="number"
+                min={1}
+                value={season}
+                onChange={(e) => setSeason(Math.max(1, parseInt(e.target.value) || 1))}
+                className="w-full rounded-lg border border-slate-700/60 bg-slate-950 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-red-500/30"
+              />
+            </div>
+            <div className="flex-1">
+              <label className="mb-1 block text-xs text-slate-500">Episode</label>
+              <input
+                type="number"
+                min={1}
+                value={episode}
+                onChange={(e) => setEpisode(Math.max(1, parseInt(e.target.value) || 1))}
+                className="w-full rounded-lg border border-slate-700/60 bg-slate-950 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-red-500/30"
+              />
+            </div>
+          </div>
+        )}
+
+        {mode === "quick" ? (
+          <div className="grid grid-cols-2 gap-2">
+            <button
+              type="button"
+              disabled={saving}
+              onClick={() => void submit(new Date().toISOString())}
+              className="rounded-xl bg-violet-600 px-4 py-3 text-sm font-semibold text-white hover:bg-violet-500 disabled:opacity-50 transition-colors"
+            >
+              Just finished
+            </button>
+            {releaseDate && (
+              <button
+                type="button"
+                disabled={saving}
+                onClick={() => void submit(new Date(releaseDate).toISOString())}
+                className="rounded-xl bg-slate-800 px-4 py-3 text-sm font-semibold text-white hover:bg-slate-700 disabled:opacity-50 transition-colors"
+              >
+                Release date
+              </button>
+            )}
+            <button
+              type="button"
+              disabled={saving}
+              onClick={() => void submit(new Date("2000-01-01T00:00:00.000Z").toISOString())}
+              className="rounded-xl bg-slate-800 px-4 py-3 text-sm font-semibold text-white hover:bg-slate-700 disabled:opacity-50 transition-colors"
+            >
+              Unknown date
+            </button>
+            <button
+              type="button"
+              onClick={() => setMode("custom")}
+              className="rounded-xl bg-slate-800 px-4 py-3 text-sm font-semibold text-white hover:bg-slate-700 transition-colors"
+            >
+              Other date
+            </button>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            <input
+              type="date"
+              value={customDate}
+              max={new Date().toISOString().slice(0, 10)}
+              onChange={(e) => setCustomDate(e.target.value)}
+              className="w-full rounded-xl border border-slate-700/60 bg-slate-950 px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-red-500/30"
+            />
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={() => setMode("quick")}
+                className="flex-1 rounded-xl bg-slate-800 px-4 py-2.5 text-sm font-medium text-slate-300 hover:bg-slate-700 transition-colors"
+              >
+                Back
+              </button>
+              <button
+                type="button"
+                disabled={saving || !customDate}
+                onClick={() => void submit(new Date(customDate).toISOString())}
+                className="flex-1 rounded-xl bg-red-500 px-4 py-2.5 text-sm font-semibold text-white hover:bg-red-600 disabled:opacity-50 transition-colors"
+              >
+                {saving ? "Saving…" : "Log Watch"}
+              </button>
+            </div>
+          </div>
+        )}
+
+        {error && <p className="mt-3 text-xs text-rose-400">{error}</p>}
+      </div>
+    </div>
+  );
+}
+
+/* ─── Check-in Modal (series episode picker) ─────────────── */
+
+function CheckInModal({
+  seriesImdbId,
+  seriesName,
+  poster,
+  runtime,
+  defaultSeason,
+  defaultEpisode,
+  onCheckIn,
+  onClose,
+}: {
+  seriesImdbId: string;
+  seriesName: string;
+  poster?: string;
+  runtime?: number | null;
+  defaultSeason: number;
+  defaultEpisode: number;
+  onCheckIn: (season: number, episode: number) => Promise<void>;
+  onClose: () => void;
+}) {
+  const [season, setSeason] = useState(String(defaultSeason));
+  const [episode, setEpisode] = useState(String(defaultEpisode));
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [onClose]);
+
+  const submit = async () => {
+    const s = parseInt(season, 10);
+    const ep = parseInt(episode, 10);
+    if (!s || !ep || s < 1 || ep < 1) { setError("Enter valid season and episode numbers"); return; }
+    setSaving(true);
+    setError(null);
+    try {
+      await onCheckIn(s, ep);
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to check in");
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/70 backdrop-blur-sm p-4" onClick={onClose}>
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="checkin-modal-title"
+        className="w-full max-w-sm rounded-2xl border border-slate-800/60 bg-slate-950 shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between border-b border-slate-800/60 px-5 py-4">
+          <div className="flex items-center gap-2">
+            <Radio className="h-4 w-4 text-red-400" />
+            <h3 id="checkin-modal-title" className="text-base font-bold">Check In</h3>
+          </div>
+          <button onClick={onClose} aria-label="Close" className="rounded-lg p-1.5 text-slate-400 hover:bg-slate-800 hover:text-slate-200">
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+        <div className="px-5 py-4 space-y-4">
+          <p className="text-sm text-slate-400">Which episode of <span className="font-semibold text-slate-200">{seriesName}</span> are you watching?</p>
+          <div className="flex gap-3">
+            <div className="flex-1">
+              <label className="mb-1.5 block text-xs font-medium text-slate-500">Season</label>
+              <input
+                type="number" min="1" value={season}
+                onChange={(e) => setSeason(e.target.value)}
+                className="w-full rounded-xl border border-slate-700/60 bg-slate-900 px-3 py-2.5 text-sm focus:border-red-500 focus:outline-none focus:ring-2 focus:ring-red-500/15"
+              />
+            </div>
+            <div className="flex-1">
+              <label className="mb-1.5 block text-xs font-medium text-slate-500">Episode</label>
+              <input
+                type="number" min="1" value={episode}
+                onChange={(e) => setEpisode(e.target.value)}
+                className="w-full rounded-xl border border-slate-700/60 bg-slate-900 px-3 py-2.5 text-sm focus:border-red-500 focus:outline-none focus:ring-2 focus:ring-red-500/15"
+              />
+            </div>
+          </div>
+          {error && <p className="text-xs text-rose-400">{error}</p>}
+          <div className="flex gap-3 pt-1">
+            <button
+              type="button" onClick={onClose}
+              className="flex-1 rounded-xl bg-slate-800 px-4 py-2.5 text-sm font-medium text-slate-300 hover:bg-slate-700 transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              type="button" disabled={saving} onClick={() => void submit()}
+              className="flex-1 flex items-center justify-center gap-2 rounded-xl bg-red-500 px-4 py-2.5 text-sm font-semibold text-white hover:bg-red-600 disabled:opacity-50 transition-colors"
+            >
+              <Radio className="h-3.5 w-3.5" />
+              {saving ? "Checking in…" : "Check In"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ─── External Ratings ────────────────────────────────────── */
+
+function ExternalRatings({
+  imdbRating, rtScore, mcScore,
+}: {
+  imdbRating: number | null | undefined;
+  rtScore: number | null | undefined;
+  mcScore: number | null | undefined;
+}) {
+  if (imdbRating == null && rtScore == null && mcScore == null) return null;
+  return (
+    <div>
+      <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-500">Ratings</h3>
+      <div className="flex flex-wrap items-center gap-4">
+        {imdbRating != null && (
+          <div className="flex items-center gap-1.5">
+            <ImdbLogo />
+            <span className="text-sm font-semibold text-slate-200">{imdbRating.toFixed(1)}</span>
+            <span className="text-xs text-slate-500">/10</span>
+          </div>
+        )}
+        {rtScore != null && (
+          <div className="flex items-center gap-1.5">
+            <RtLogo score={rtScore} />
+            <span className={`text-sm font-semibold ${rtScore >= 60 ? "text-green-400" : "text-rose-400"}`}>{rtScore}%</span>
+          </div>
+        )}
+        {mcScore != null && (
+          <div className="flex items-center gap-1.5">
+            <McIcon score={mcScore} />
+            <span className="text-sm font-semibold text-slate-200">{mcScore}</span>
+            <span className="text-xs text-slate-500">/100</span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
 
 /* ─── Star Rating Component ───────────────────────────────── */
 
 export function StarRating({
-  imdbId,
-  type,
-  onError,
+  imdbId, type, onError,
 }: {
-  imdbId: string;
-  type: MediaType;
-  onError?: (message: string) => void;
+  imdbId: string; type: MediaType; onError?: (message: string) => void;
 }) {
   const [userRating, setUserRating] = useState<number | null>(null);
   const [hoverRating, setHoverRating] = useState<number | null>(null);
@@ -20,10 +379,7 @@ export function StarRating({
   const [loadError, setLoadError] = useState<string | null>(null);
 
   useEffect(() => {
-    setUserRating(null);
-    setHoverRating(null);
-    setLoaded(false);
-    setLoadError(null);
+    setUserRating(null); setHoverRating(null); setLoaded(false); setLoadError(null);
     let canceled = false;
     void (async () => {
       try {
@@ -31,9 +387,7 @@ export function StarRating({
         if (!canceled) setUserRating(res.rating.rating);
       } catch (err) {
         if (!canceled) {
-          if (err instanceof ApiError && err.status === 404) {
-            // no rating — leave null
-          } else {
+          if (!(err instanceof ApiError && err.status === 404)) {
             setLoadError(err instanceof Error ? err.message : "Failed to load rating");
           }
         }
@@ -48,84 +402,53 @@ export function StarRating({
     if (saving) return;
     if (userRating === rating) {
       setSaving(true);
-      try {
-        await api.deleteRating(type, imdbId);
-        setUserRating(null);
-        setHoverRating(null);
-      } catch (err) {
-        onError?.(err instanceof Error ? err.message : "Failed to remove rating");
-      } finally {
-        setSaving(false);
-      }
+      try { await api.deleteRating(type, imdbId); setUserRating(null); setHoverRating(null); }
+      catch (err) { onError?.(err instanceof Error ? err.message : "Failed to remove rating"); }
+      finally { setSaving(false); }
       return;
     }
     setSaving(true);
-    try {
-      const res = await api.setRating(imdbId, type, rating);
-      setUserRating(res.rating.rating);
-      setHoverRating(null);
-    } catch (err) {
-      onError?.(err instanceof Error ? err.message : "Failed to save rating");
-    } finally {
-      setSaving(false);
-    }
+    try { const res = await api.setRating(imdbId, type, rating); setUserRating(res.rating.rating); setHoverRating(null); }
+    catch (err) { onError?.(err instanceof Error ? err.message : "Failed to save rating"); }
+    finally { setSaving(false); }
   };
 
   const retryLoadRating = useCallback(() => {
-    setLoadError(null);
-    setLoaded(false);
+    setLoadError(null); setLoaded(false);
     void (async () => {
       try {
         const res = await api.getRating(type, imdbId);
         setUserRating(res.rating.rating);
       } catch (err) {
-        if (err instanceof ApiError && err.status === 404) {
-          // no rating
-        } else {
+        if (!(err instanceof ApiError && err.status === 404)) {
           setLoadError(err instanceof Error ? err.message : "Failed to load rating");
         }
-      } finally {
-        setLoaded(true);
-      }
+      } finally { setLoaded(true); }
     })();
   }, [imdbId, type]);
 
-  if (!loaded) {
-    return <div className="skeleton h-8 w-40 rounded-lg" />;
-  }
+  if (!loaded) return <div className="skeleton h-8 w-40 rounded-lg" />;
 
   const displayRating = hoverRating ?? userRating ?? 0;
-
   return (
     <div>
       <h3 className="mb-2 flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-slate-500">
-        <Star className="h-3.5 w-3.5" />
-        Your Rating
+        <Star className="h-3.5 w-3.5" /> Your Rating
       </h3>
       <div className="flex items-center gap-1">
         {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((star) => (
           <button
-            key={star}
-            type="button"
-            disabled={saving}
+            key={star} type="button" disabled={saving}
             onClick={() => void handleRate(star)}
             onMouseEnter={() => setHoverRating(star)}
             onMouseLeave={() => setHoverRating(null)}
             className="p-0.5 transition-transform hover:scale-125 disabled:opacity-50"
             aria-label={`Rate ${star} out of 10`}
           >
-            <Star
-              className={`h-5 w-5 transition-colors ${
-                star <= displayRating
-                  ? "fill-amber-400 text-amber-400"
-                  : "text-slate-600 hover:text-slate-500"
-              }`}
-            />
+            <Star className={`h-5 w-5 transition-colors ${star <= displayRating ? "fill-amber-400 text-amber-400" : "text-slate-600 hover:text-slate-500"}`} />
           </button>
         ))}
-        {userRating !== null && (
-          <span className="ml-2 text-sm font-semibold text-amber-400">{userRating}/10</span>
-        )}
+        {userRating !== null && <span className="ml-2 text-sm font-semibold text-amber-400">{userRating}/10</span>}
       </div>
       {loadError && (
         <p className="mt-1 flex items-center gap-2 text-xs text-rose-400">
@@ -146,6 +469,7 @@ export function DetailPanel({
   listMap,
   onClose,
   onShowToast,
+  onHistoryChange,
 }: {
   item: SearchResult;
   history: WatchEvent[];
@@ -153,25 +477,157 @@ export function DetailPanel({
   listMap: Map<string, CatalogList>;
   onClose: () => void;
   onShowToast: (message: string, type: "success" | "error" | "info") => void;
+  onHistoryChange: (events: WatchEvent[]) => void;
 }) {
-  const listNames = item.lists
-    .map((id) => listMap.get(id)?.name)
-    .filter(Boolean) as string[];
+  const listNames = item.lists.map((id) => listMap.get(id)?.name).filter(Boolean) as string[];
+
+  // Cast
+  const [cast, setCast] = useState<Array<{ name: string; character: string; photo: string | null }>>([]);
+  const [castLoading, setCastLoading] = useState(true);
+
+  // Seasons (series only)
+  const [seasons, setSeasons] = useState<Array<{ seasonNumber: number; name: string; episodeCount: number; airYear: number | null; poster: string | null }>>([]);
+  const [seasonsLoading, setSeasonsLoading] = useState(item.type === "series");
+
+  // Dropped state (series only)
+  const [isDropped, setIsDropped] = useState(false);
+  const [droppedLoading, setDroppedLoading] = useState(item.type === "series");
+
+  // Check-in
+  const [activeCheckin, setActiveCheckin] = useState<CheckIn | null>(null);
+  const [checkinLoading, setCheckinLoading] = useState(true);
+  const [showCheckinModal, setShowCheckinModal] = useState(false);
+
+  // Watch log modal
+  const [watchTarget, setWatchTarget] = useState<WatchLogTarget | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setCast([]); setCastLoading(true);
+    setSeasons([]); setSeasonsLoading(item.type === "series");
+    setIsDropped(false); setDroppedLoading(item.type === "series");
+    setActiveCheckin(null); setCheckinLoading(true);
+
+    const loads: Promise<void>[] = [
+      api.getCast(item.type, item.imdbId).then((r) => {
+        if (!cancelled) { setCast(r.cast); setCastLoading(false); }
+      }).catch(() => { if (!cancelled) setCastLoading(false); }),
+      api.getCheckin().then((r) => {
+        if (!cancelled) {
+          const c = r.checkin;
+          const isThisItem = c && (c.imdbId === item.imdbId || c.seriesImdbId === item.imdbId);
+          setActiveCheckin(isThisItem ? c : null);
+          setCheckinLoading(false);
+        }
+      }).catch(() => { if (!cancelled) setCheckinLoading(false); }),
+    ];
+
+    if (item.type === "series") {
+      loads.push(
+        api.getSeasons(item.imdbId).then((r) => {
+          if (!cancelled) { setSeasons(r.seasons); setSeasonsLoading(false); }
+        }).catch(() => { if (!cancelled) setSeasonsLoading(false); }),
+        api.getDropped(item.imdbId).then((r) => {
+          if (!cancelled) { setIsDropped(r.dropped); setDroppedLoading(false); }
+        }).catch(() => { if (!cancelled) setDroppedLoading(false); }),
+      );
+    }
+
+    void Promise.all(loads);
+    return () => { cancelled = true; };
+  }, [item.imdbId, item.type]);
+
+  const handleDeleteEvent = async (eventId: string) => {
+    try {
+      await api.deleteWatchEvent(eventId);
+      onHistoryChange(history.filter((e) => e.id !== eventId));
+    } catch {
+      onShowToast("Failed to remove watch event", "error");
+    }
+  };
+
+  const handleToggleDrop = async () => {
+    try {
+      if (isDropped) {
+        await api.undropShow(item.imdbId);
+        setIsDropped(false);
+        onShowToast("Removed from dropped shows", "info");
+      } else {
+        await api.dropShow(item.imdbId);
+        setIsDropped(true);
+        onShowToast("Marked as dropped", "info");
+      }
+    } catch {
+      onShowToast("Failed to update drop status", "error");
+    }
+  };
+
+  const handleCheckin = async (season?: number, episode?: number) => {
+    const runtime = item.runtime ?? undefined;
+    const payload = item.type === "movie"
+      ? { type: "movie" as const, imdbId: item.imdbId, name: item.name, poster: item.poster ?? undefined, runtime }
+      : { type: "episode" as const, imdbId: item.imdbId, seriesImdbId: item.imdbId, name: item.name, poster: item.poster ?? undefined, season, episode, runtime };
+    const res = await api.startCheckin(payload);
+    setActiveCheckin(res.checkin);
+    onShowToast(`Checked in to ${item.name}`, "info");
+  };
+
+  const handleCheckout = async (logWatch: boolean) => {
+    await api.endCheckin(logWatch);
+    setActiveCheckin(null);
+    if (logWatch) {
+      onShowToast("Watch logged!", "success");
+      try {
+        const updated = await api.getWatchHistory(50);
+        onHistoryChange(updated.filter((e) => (e.seriesImdbId ?? e.imdbId) === item.imdbId || e.imdbId === item.imdbId));
+      } catch { /* best-effort */ }
+    } else {
+      onShowToast("Checked out", "info");
+    }
+  };
+
+  const handleLog = async (dateIso: string) => {
+    if (!watchTarget) return;
+    if (watchTarget.kind === "movie") {
+      await api.logWatch({ type: "movie", imdbId: watchTarget.imdbId, watchedAt: dateIso });
+    } else {
+      await api.logWatch({
+        type: "episode",
+        imdbId: watchTarget.seriesImdbId,
+        seriesImdbId: watchTarget.seriesImdbId,
+        season: watchTarget.season,
+        episode: watchTarget.episode,
+        watchedAt: dateIso,
+      });
+    }
+    onShowToast("Watch logged!", "success");
+    // Refresh history via parent
+    try {
+      const updated = await api.getWatchHistory(50);
+      onHistoryChange(updated.filter((e) => (e.seriesImdbId ?? e.imdbId) === item.imdbId || e.imdbId === item.imdbId));
+    } catch { /* best-effort */ }
+  };
+
+  const openWatchModal = () => {
+    if (item.type === "movie") {
+      setWatchTarget({ kind: "movie", imdbId: item.imdbId, releaseDate: item.releaseDate });
+    } else {
+      // Default to next episode after last watched, or S01E01
+      const lastEvent = history.find((e) => e.season != null && e.episode != null);
+      const nextSeason = lastEvent?.season ?? 1;
+      const nextEpisode = lastEvent ? (lastEvent.episode ?? 0) + 1 : 1;
+      setWatchTarget({ kind: "episode", seriesImdbId: item.imdbId, season: nextSeason, episode: nextEpisode });
+    }
+  };
 
   return (
     <>
-      {/* Backdrop */}
-      <div
-        className="fixed inset-0 z-50 bg-black/70 backdrop-blur-sm"
-        onClick={onClose}
-      />
+      <div className="fixed inset-0 z-50 bg-black/70 backdrop-blur-sm" onClick={onClose} />
 
-      {/* Panel */}
       <aside className="fixed right-0 top-0 z-50 flex h-full w-full max-w-lg flex-col overflow-y-auto border-l border-slate-800/60 bg-slate-950 shadow-2xl sm:w-[28rem]">
-        {/* Close button */}
+        {/* Close */}
         <button
-          type="button"
-          onClick={onClose}
+          type="button" onClick={onClose}
           className="absolute right-4 top-4 z-10 flex h-9 w-9 items-center justify-center rounded-full bg-slate-900/80 text-slate-400 backdrop-blur hover:bg-slate-800 hover:text-white transition-colors"
           aria-label="Close detail panel"
         >
@@ -181,11 +637,7 @@ export function DetailPanel({
         {/* Poster */}
         <div className="relative w-full" style={{ aspectRatio: "2 / 3", maxHeight: "50vh" }}>
           {item.poster ? (
-            <img
-              src={item.poster}
-              alt={item.name}
-              className="h-full w-full object-cover"
-            />
+            <img src={item.poster} alt={item.name} className="h-full w-full object-cover" />
           ) : (
             <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-slate-800 to-slate-900">
               <Film className="h-20 w-20 text-slate-700" />
@@ -196,54 +648,115 @@ export function DetailPanel({
 
         {/* Content */}
         <div className="-mt-16 relative z-10 flex-1 space-y-6 px-6 pb-8">
-          {/* Title area */}
+
+          {/* Title + badges */}
           <div>
-            <div className="flex items-center gap-2">
-              <span
-                className={`flex items-center gap-1 rounded-md px-2 py-1 text-xs font-semibold uppercase tracking-wide ${
-                  item.type === "movie"
-                    ? "bg-red-500/90 text-white"
-                    : "bg-violet-600/90 text-white"
-                }`}
-              >
+            <div className="flex flex-wrap items-center gap-2">
+              <span className={`flex items-center gap-1 rounded-md px-2 py-1 text-xs font-semibold uppercase tracking-wide ${item.type === "movie" ? "bg-red-500/90 text-white" : "bg-violet-600/90 text-white"}`}>
                 {item.type === "movie" ? <Film className="h-3 w-3" /> : <Tv className="h-3 w-3" />}
                 {item.type === "movie" ? "Movie" : "Series"}
               </span>
               {item.year && <span className="text-sm text-slate-400">{item.year}</span>}
+              {item.certification && (
+                <span className="rounded-md border border-slate-600/60 px-2 py-0.5 text-xs font-semibold text-slate-300">
+                  {item.certification}
+                </span>
+              )}
+              {item.status && (
+                <span className={`rounded-full px-2.5 py-0.5 text-xs font-semibold ring-1 ${statusColor(item.status)}`}>
+                  {item.status}
+                </span>
+              )}
             </div>
             <h2 className="mt-3 text-2xl font-bold text-white">{item.name}</h2>
-            {((item.rating != null && item.rating > 0) || item.genres.length > 0) && (
-              <div className="mt-2 flex flex-wrap items-center gap-2">
-                {item.rating != null && item.rating > 0 && (
-                  <span className="inline-flex items-center gap-1 rounded-full bg-amber-500/10 px-2.5 py-1 text-xs font-semibold text-amber-400 ring-1 ring-amber-500/20">
-                    <Star className="h-3 w-3 fill-amber-400" />
-                    {item.rating.toFixed(1)}
-                  </span>
-                )}
-                {item.genres.slice(0, 4).map((g) => (
-                  <span key={g} className="rounded-full bg-slate-800/80 px-2.5 py-1 text-xs text-slate-400">{g}</span>
-                ))}
-              </div>
-            )}
+
+            {/* Meta row: rating, runtime, network, genres */}
+            <div className="mt-2 flex flex-wrap items-center gap-2">
+              {item.rating != null && item.rating > 0 && (
+                <span className="inline-flex items-center gap-1 rounded-full bg-amber-500/10 px-2.5 py-1 text-xs font-semibold text-amber-400 ring-1 ring-amber-500/20">
+                  <Star className="h-3 w-3 fill-amber-400" />{item.rating.toFixed(1)}
+                </span>
+              )}
+              {item.runtime != null && item.runtime > 0 && (
+                <span className="inline-flex items-center gap-1 rounded-full bg-slate-800/60 px-2.5 py-1 text-xs text-slate-400">
+                  <Clock className="h-3 w-3" />{formatRuntime(item.runtime)}
+                </span>
+              )}
+              {item.network && (
+                <span className="inline-flex items-center gap-1 rounded-full bg-slate-800/60 px-2.5 py-1 text-xs text-slate-400">
+                  <TvMinimalPlay className="h-3 w-3" />{item.network}
+                </span>
+              )}
+              {item.genres.slice(0, 3).map((g) => (
+                <span key={g} className="rounded-full bg-slate-800/80 px-2.5 py-1 text-xs text-slate-400">{g}</span>
+              ))}
+            </div>
           </div>
 
           {/* Lists */}
           {listNames.length > 0 && (
             <div className="flex flex-wrap gap-2">
               {listNames.map((name) => (
-                <span
-                  key={name}
-                  className="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-3 py-1.5 text-xs font-medium text-emerald-400 ring-1 ring-emerald-500/20"
-                >
-                  <Check className="h-3 w-3" />
-                  {name}
+                <span key={name} className="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-3 py-1.5 text-xs font-medium text-emerald-400 ring-1 ring-emerald-500/20">
+                  <Check className="h-3 w-3" />{name}
                 </span>
               ))}
             </div>
           )}
 
+          {/* External Ratings */}
+          <ExternalRatings imdbRating={item.imdbRating} rtScore={item.rtScore} mcScore={item.mcScore} />
+
           {/* User Rating */}
           <StarRating imdbId={item.imdbId} type={item.type} onError={(msg) => onShowToast(msg, "error")} />
+
+          {/* Check-in / Now Watching */}
+          {!checkinLoading && (
+            activeCheckin ? (
+              <div className="rounded-xl border border-red-500/30 bg-red-500/5 p-4 space-y-3">
+                <div className="flex items-center gap-2">
+                  <span className="relative flex h-2.5 w-2.5">
+                    <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-red-400 opacity-75" />
+                    <span className="relative inline-flex rounded-full h-2.5 w-2.5 bg-red-500" />
+                  </span>
+                  <span className="text-sm font-semibold text-red-400">Now Watching</span>
+                  {activeCheckin.season != null && activeCheckin.episode != null && (
+                    <span className="text-xs text-slate-400">S{String(activeCheckin.season).padStart(2,"0")}:E{String(activeCheckin.episode).padStart(2,"0")}</span>
+                  )}
+                </div>
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    onClick={() => void handleCheckout(false)}
+                    className="flex-1 rounded-xl border border-slate-700/60 bg-slate-800 px-3 py-2 text-xs font-semibold text-slate-300 hover:bg-slate-700 transition-colors"
+                  >
+                    Check Out
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => void handleCheckout(true)}
+                    className="flex-1 rounded-xl bg-red-500 px-3 py-2 text-xs font-semibold text-white hover:bg-red-600 transition-colors"
+                  >
+                    Finished &amp; Log
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <button
+                type="button"
+                onClick={() => {
+                  if (item.type === "series") {
+                    setShowCheckinModal(true);
+                  } else {
+                    void handleCheckin();
+                  }
+                }}
+                className="flex w-full items-center justify-center gap-2 rounded-xl border border-slate-700/60 bg-slate-900/60 px-4 py-2.5 text-sm font-semibold text-slate-300 hover:border-red-500/40 hover:bg-red-500/5 hover:text-red-400 transition-colors"
+              >
+                <Radio className="h-4 w-4" /> Check In
+              </button>
+            )
+          )}
 
           {/* Description */}
           {item.description && (
@@ -253,18 +766,95 @@ export function DetailPanel({
             </div>
           )}
 
-          {/* Watch History */}
-          <div>
-            <h3 className="mb-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-slate-500">
-              <Clock className="h-3.5 w-3.5" />
-              Watch History
-            </h3>
-            {historyLoading ? (
-              <div className="space-y-2">
-                {[1, 2, 3].map((i) => (
-                  <div key={i} className="skeleton h-11 rounded-lg" />
+          {/* Cast */}
+          {castLoading ? (
+            <div>
+              <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-500">Cast</h3>
+              <div className="flex gap-3 overflow-hidden">
+                {[1, 2, 3, 4].map((i) => (
+                  <div key={i} className="flex-none w-16 space-y-1">
+                    <div className="skeleton h-16 w-16 rounded-full" />
+                    <div className="skeleton h-2.5 w-14 rounded" />
+                  </div>
                 ))}
               </div>
+            </div>
+          ) : cast.length > 0 && (
+            <div>
+              <h3 className="mb-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-slate-500">
+                <User className="h-3.5 w-3.5" /> Cast
+              </h3>
+              <div className="flex gap-3 overflow-x-auto pb-1 scrollbar-hide">
+                {cast.map((member) => (
+                  <div key={member.name} className="flex-none w-16 text-center">
+                    {member.photo ? (
+                      <img
+                        src={member.photo}
+                        alt={member.name}
+                        className="h-16 w-16 rounded-full object-cover ring-1 ring-white/10 mx-auto"
+                        loading="lazy"
+                      />
+                    ) : (
+                      <div className="h-16 w-16 rounded-full bg-slate-800 flex items-center justify-center mx-auto ring-1 ring-white/10">
+                        <User className="h-6 w-6 text-slate-600" />
+                      </div>
+                    )}
+                    <p className="mt-1.5 text-2xs font-medium text-slate-300 leading-tight truncate">{member.name}</p>
+                    <p className="text-2xs text-slate-600 truncate">{member.character}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Season Breakdown (series only) */}
+          {item.type === "series" && (
+            seasonsLoading ? (
+              <div>
+                <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-500">Seasons</h3>
+                <div className="grid grid-cols-2 gap-2">
+                  {[1, 2, 3, 4].map((i) => <div key={i} className="skeleton h-10 rounded-xl" />)}
+                </div>
+              </div>
+            ) : seasons.length > 0 && (
+              <div>
+                <h3 className="mb-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-slate-500">
+                  <Tv className="h-3.5 w-3.5" /> Seasons
+                </h3>
+                <div className="grid grid-cols-2 gap-2">
+                  {seasons.map((s) => (
+                    <div key={s.seasonNumber} className="flex items-center gap-2.5 rounded-xl bg-slate-900/60 border border-slate-800/40 px-3 py-2.5">
+                      <div className="flex h-8 w-8 flex-none items-center justify-center rounded-lg bg-slate-800 text-xs font-bold text-slate-300">
+                        {s.seasonNumber}
+                      </div>
+                      <div className="min-w-0">
+                        <p className="text-xs font-medium text-slate-200 truncate">{s.name}</p>
+                        <p className="text-2xs text-slate-500">{s.episodeCount} eps{s.airYear ? ` · ${s.airYear}` : ""}</p>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )
+          )}
+
+          {/* Watch History */}
+          <div>
+            <div className="mb-3 flex items-center justify-between">
+              <h3 className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-slate-500">
+                <Clock className="h-3.5 w-3.5" /> Watch History
+              </h3>
+              <button
+                type="button"
+                onClick={openWatchModal}
+                className="inline-flex items-center gap-1.5 rounded-lg bg-red-500/10 px-2.5 py-1 text-xs font-semibold text-red-400 ring-1 ring-red-500/20 hover:bg-red-500/20 transition-colors"
+              >
+                <Calendar className="h-3 w-3" /> Log a Watch
+              </button>
+            </div>
+
+            {historyLoading ? (
+              <div className="space-y-2">{[1, 2, 3].map((i) => <div key={i} className="skeleton h-11 rounded-lg" />)}</div>
             ) : history.length === 0 ? (
               <p className="rounded-xl bg-slate-900/60 border border-slate-800/40 py-5 text-center text-sm text-slate-500">
                 No watch history yet
@@ -272,40 +862,82 @@ export function DetailPanel({
             ) : (
               <div className="space-y-1.5">
                 {history.map((event) => (
-                  <div
-                    key={event.id}
-                    className="flex items-center gap-3 rounded-lg bg-slate-900/60 border border-slate-800/30 px-3 py-2.5"
-                  >
+                  <div key={event.id} className="group flex items-center gap-3 rounded-lg bg-slate-900/60 border border-slate-800/30 px-3 py-2.5">
                     <ChevronRight className="h-3.5 w-3.5 shrink-0 text-slate-600" />
                     <div className="min-w-0 flex-1">
                       {event.season != null && event.episode != null ? (
                         <span className="text-sm text-slate-200">
-                          S{String(event.season).padStart(2, "0")}:E
-                          {String(event.episode).padStart(2, "0")}
+                          S{String(event.season).padStart(2, "0")}:E{String(event.episode).padStart(2, "0")}
                         </span>
                       ) : (
                         <span className="text-sm text-slate-200">Watched</span>
                       )}
                     </div>
                     <time className="shrink-0 text-2xs text-slate-500">
-                      {new Date(event.watchedAt).toLocaleDateString(undefined, {
-                        month: "short",
-                        day: "numeric",
-                        year: "numeric",
-                      })}
+                      {new Date(event.watchedAt).getFullYear() === 2000 && new Date(event.watchedAt).getMonth() === 0
+                        ? "Unknown date"
+                        : new Date(event.watchedAt).toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" })}
                     </time>
+                    <button
+                      type="button"
+                      onClick={() => void handleDeleteEvent(event.id)}
+                      className="shrink-0 rounded p-1 text-slate-700 opacity-0 group-hover:opacity-100 hover:bg-rose-500/10 hover:text-rose-400 transition-all"
+                      aria-label="Remove watch event"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </button>
                   </div>
                 ))}
               </div>
             )}
           </div>
+
+          {/* Drop Show (series only) */}
+          {item.type === "series" && !droppedLoading && (
+            <div className="pt-2 border-t border-slate-800/40">
+              <button
+                type="button"
+                onClick={() => void handleToggleDrop()}
+                className={`w-full rounded-xl px-4 py-2.5 text-sm font-semibold transition-colors ${
+                  isDropped
+                    ? "bg-slate-800 text-slate-300 hover:bg-slate-700"
+                    : "bg-rose-500/10 text-rose-400 ring-1 ring-rose-500/20 hover:bg-rose-500/20"
+                }`}
+              >
+                {isDropped ? "✓ Dropped — Click to Undrop" : "Drop Show"}
+              </button>
+            </div>
+          )}
         </div>
       </aside>
+
+      {/* Watch Date Modal */}
+      {watchTarget && (
+        <WatchDateModal
+          target={watchTarget}
+          onLog={handleLog}
+          onClose={() => setWatchTarget(null)}
+        />
+      )}
+
+      {/* Check-in Modal (series only) */}
+      {showCheckinModal && item.type === "series" && (
+        <CheckInModal
+          seriesImdbId={item.imdbId}
+          seriesName={item.name}
+          poster={item.poster ?? undefined}
+          runtime={item.runtime}
+          defaultSeason={history.find((e) => e.season != null)?.season ?? 1}
+          defaultEpisode={(history.find((e) => e.episode != null)?.episode ?? 0) + 1}
+          onCheckIn={async (season, episode) => { await handleCheckin(season, episode); }}
+          onClose={() => setShowCheckinModal(false)}
+        />
+      )}
     </>
   );
 }
 
-/* ─── Hook: open panel with history loading ───────────────── */
+/* ─── Hook: open panel with history + meta loading ────────── */
 
 export function useDetailPanel() {
   const [selectedItem, setSelectedItem] = useState<SearchResult | null>(null);
@@ -313,9 +945,7 @@ export function useDetailPanel() {
   const [panelHistoryLoading, setPanelHistoryLoading] = useState(false);
 
   useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setSelectedItem(null);
-    };
+    const handler = (e: KeyboardEvent) => { if (e.key === "Escape") setSelectedItem(null); };
     document.addEventListener("keydown", handler);
     return () => document.removeEventListener("keydown", handler);
   }, []);
@@ -325,8 +955,11 @@ export function useDetailPanel() {
     let cancelled = false;
     const active = selectedItem;
 
-    // Enrich with metadata if fields are missing
-    if (!active.description && active.genres.length === 0 && active.rating == null) {
+    const needsMeta = !active.description && active.genres.length === 0 && active.rating == null;
+    const needsOmdb = active.imdbRating === undefined;
+    const needsDetail = active.runtime === undefined;
+
+    if (needsMeta || needsOmdb || needsDetail) {
       void (async () => {
         try {
           const meta = await api.getItemMeta(active.type, active.imdbId);
@@ -339,6 +972,14 @@ export function useDetailPanel() {
                 genres: meta.genres.length > 0 ? meta.genres : prev.genres,
                 rating: meta.rating ?? prev.rating,
                 poster: meta.poster ?? prev.poster,
+                imdbRating: meta.imdbRating !== undefined ? meta.imdbRating : prev.imdbRating,
+                rtScore: meta.rtScore !== undefined ? meta.rtScore : prev.rtScore,
+                mcScore: meta.mcScore !== undefined ? meta.mcScore : prev.mcScore,
+                runtime: meta.runtime !== undefined ? meta.runtime : prev.runtime,
+                certification: meta.certification !== undefined ? meta.certification : prev.certification,
+                status: meta.status !== undefined ? meta.status : prev.status,
+                network: meta.network !== undefined ? meta.network : prev.network,
+                releaseDate: meta.releaseDate !== undefined ? meta.releaseDate : prev.releaseDate,
               };
             });
           }
@@ -351,11 +992,7 @@ export function useDetailPanel() {
       try {
         const history = await api.getWatchHistory(50);
         if (!cancelled) {
-          setPanelHistory(
-            history.filter(
-              (e) => (e.seriesImdbId ?? e.imdbId) === active.imdbId || e.imdbId === active.imdbId
-            )
-          );
+          setPanelHistory(history.filter((e) => (e.seriesImdbId ?? e.imdbId) === active.imdbId || e.imdbId === active.imdbId));
         }
       } catch {
         if (!cancelled) setPanelHistory([]);
@@ -366,5 +1003,8 @@ export function useDetailPanel() {
     return () => { cancelled = true; };
   }, [selectedItem]);
 
-  return { selectedItem, setSelectedItem, panelHistory, panelHistoryLoading };
+  return {
+    selectedItem, setSelectedItem,
+    panelHistory, setPanelHistory, panelHistoryLoading,
+  };
 }

--- a/apps/web/src/components/MediaDetailPanel.tsx
+++ b/apps/web/src/components/MediaDetailPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import {
   Calendar, Check, ChevronRight, Clock, Film, Radio, Star, Trash2, Tv, TvMinimalPlay, User, X,
 } from "lucide-react";
@@ -80,7 +80,7 @@ function WatchDateModal({
   onClose,
 }: {
   target: WatchLogTarget;
-  onLog: (date: string) => Promise<void>;
+  onLog: (date: string, episode?: { season: number; episode: number }) => Promise<void>;
   onClose: () => void;
 }) {
   const [mode, setMode] = useState<"quick" | "custom">("quick");
@@ -96,7 +96,8 @@ function WatchDateModal({
     setSaving(true);
     setError(null);
     try {
-      await onLog(dateIso);
+      const episodeInfo = target.kind === "episode" ? { season, episode } : undefined;
+      await onLog(dateIso, episodeInfo);
       onClose();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to log watch");
@@ -162,7 +163,10 @@ function WatchDateModal({
               <button
                 type="button"
                 disabled={saving}
-                onClick={() => void submit(new Date(releaseDate).toISOString())}
+                onClick={() => {
+                  const [y, m, d] = releaseDate.split("-").map(Number);
+                  void submit(new Date(Date.UTC(y, m - 1, d, 12)).toISOString());
+                }}
                 className="rounded-xl bg-slate-800 px-4 py-3 text-sm font-semibold text-white hover:bg-slate-700 disabled:opacity-50 transition-colors"
               >
                 Release date
@@ -204,7 +208,10 @@ function WatchDateModal({
               <button
                 type="button"
                 disabled={saving || !customDate}
-                onClick={() => void submit(new Date(customDate).toISOString())}
+                onClick={() => {
+                  const [y, m, d] = customDate.split("-").map(Number);
+                  void submit(new Date(Date.UTC(y, m - 1, d, 12)).toISOString());
+                }}
                 className="flex-1 rounded-xl bg-red-500 px-4 py-2.5 text-sm font-semibold text-white hover:bg-red-600 disabled:opacity-50 transition-colors"
               >
                 {saving ? "Saving…" : "Log Watch"}
@@ -222,19 +229,13 @@ function WatchDateModal({
 /* ─── Check-in Modal (series episode picker) ─────────────── */
 
 function CheckInModal({
-  seriesImdbId,
   seriesName,
-  poster,
-  runtime,
   defaultSeason,
   defaultEpisode,
   onCheckIn,
   onClose,
 }: {
-  seriesImdbId: string;
   seriesName: string;
-  poster?: string;
-  runtime?: number | null;
   defaultSeason: number;
   defaultEpisode: number;
   onCheckIn: (season: number, episode: number) => Promise<void>;
@@ -586,7 +587,7 @@ export function DetailPanel({
     }
   };
 
-  const handleLog = async (dateIso: string) => {
+  const handleLog = async (dateIso: string, episodeInfo?: { season: number; episode: number }) => {
     if (!watchTarget) return;
     if (watchTarget.kind === "movie") {
       await api.logWatch({ type: "movie", imdbId: watchTarget.imdbId, watchedAt: dateIso });
@@ -595,8 +596,8 @@ export function DetailPanel({
         type: "episode",
         imdbId: watchTarget.seriesImdbId,
         seriesImdbId: watchTarget.seriesImdbId,
-        season: watchTarget.season,
-        episode: watchTarget.episode,
+        season: episodeInfo?.season ?? watchTarget.season,
+        episode: episodeInfo?.episode ?? watchTarget.episode,
         watchedAt: dateIso,
       });
     }
@@ -923,10 +924,7 @@ export function DetailPanel({
       {/* Check-in Modal (series only) */}
       {showCheckinModal && item.type === "series" && (
         <CheckInModal
-          seriesImdbId={item.imdbId}
           seriesName={item.name}
-          poster={item.poster ?? undefined}
-          runtime={item.runtime}
           defaultSeason={history.find((e) => e.season != null)?.season ?? 1}
           defaultEpisode={(history.find((e) => e.episode != null)?.episode ?? 0) + 1}
           onCheckIn={async (season, episode) => { await handleCheckin(season, episode); }}

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -7,13 +7,16 @@ import {
   ChevronRight,
   ChevronLeft,
   Check,
+  Radio,
   Star,
   TrendingUp,
   Sparkles,
+  X,
 } from "lucide-react";
 import {
   api,
   CalendarEntry,
+  CheckIn,
   runtimeConfig,
   SearchResult,
   SeriesProgress,
@@ -255,18 +258,23 @@ export function DashboardPage() {
   const [trendingLoading, setTrendingLoading] = useState(true);
   const [recommendations, setRecommendations] = useState<TrendingMeta[]>([]);
   const [recsLoading, setRecsLoading] = useState(true);
+  const [seriesRecs, setSeriesRecs] = useState<TrendingMeta[]>([]);
+  const [seriesRecsLoading, setSeriesRecsLoading] = useState(true);
   const [calendarEntries, setCalendarEntries] = useState<CalendarEntry[]>([]);
   const [calendarLoading, setCalendarLoading] = useState(true);
 
   const [markingNext, setMarkingNext] = useState<Set<string>>(new Set());
   const [markedDone, setMarkedDone] = useState<Set<string>>(new Set());
 
+  const [activeCheckin, setActiveCheckin] = useState<CheckIn | null>(null);
+
   const continueScroll = useHorizontalScroll();
   const recentScroll = useHorizontalScroll();
   const trendingScroll = useHorizontalScroll();
   const recsScroll = useHorizontalScroll();
+  const seriesRecsScroll = useHorizontalScroll();
 
-  const { selectedItem, setSelectedItem, panelHistory, panelHistoryLoading } = useDetailPanel();
+  const { selectedItem, setSelectedItem, panelHistory, setPanelHistory, panelHistoryLoading } = useDetailPanel();
 
   const toSearchResult = useCallback((imdbId: string, type: "movie" | "series", name: string, opts?: {
     poster?: string; year?: number | null; description?: string | null; genres?: string[]; rating?: number | null;
@@ -285,14 +293,16 @@ export function DashboardPage() {
 
   const load = useCallback(async () => {
     try {
-      const [progressRes, historyRes, statsRes] = await Promise.all([
+      const [progressRes, historyRes, statsRes, checkinRes] = await Promise.all([
         api.getSeriesProgress(),
         api.getWatchHistory(20),
         api.getWatchStats(),
+        api.getCheckin().catch(() => ({ checkin: null })),
       ]);
       setProgress(progressRes ?? []);
       setHistory(historyRes ?? []);
       setStats(statsRes);
+      setActiveCheckin(checkinRes.checkin);
     } catch (err) {
       setError(
         err instanceof Error ? err.message : "Failed to load dashboard",
@@ -323,6 +333,14 @@ export function DashboardPage() {
     })();
     void (async () => {
       try {
+        const res = await api.getPersonalRecommendations("series", 20);
+        if (mounted) setSeriesRecs(res.metas ?? []);
+      } catch { /* optional */ } finally {
+        if (mounted) setSeriesRecsLoading(false);
+      }
+    })();
+    void (async () => {
+      try {
         const res = await api.getCalendar(14);
         if (mounted) setCalendarEntries(res.calendar ?? []);
       } catch { /* optional */ } finally {
@@ -344,9 +362,10 @@ export function DashboardPage() {
       recentScroll.checkScroll();
       trendingScroll.checkScroll();
       recsScroll.checkScroll();
+      seriesRecsScroll.checkScroll();
     }, 50);
     return () => clearTimeout(timer);
-  }, [loading, trendingLoading, recsLoading, progress.length, history.length, continueScroll.checkScroll, recentScroll.checkScroll, trendingScroll.checkScroll, recsScroll.checkScroll]);
+  }, [loading, trendingLoading, recsLoading, seriesRecsLoading, progress.length, history.length, continueScroll.checkScroll, recentScroll.checkScroll, trendingScroll.checkScroll, recsScroll.checkScroll, seriesRecsScroll.checkScroll]);
 
   const handleMarkNext = async (imdbId: string) => {
     setMarkingNext((prev) => new Set(prev).add(imdbId));
@@ -406,8 +425,57 @@ export function DashboardPage() {
     );
   }
 
+  const handleCheckout = async (logWatch: boolean) => {
+    await api.endCheckin(logWatch);
+    setActiveCheckin(null);
+    if (logWatch) void load();
+  };
+
   return (
     <div className="space-y-10">
+      {/* ── Now Watching Banner ── */}
+      {activeCheckin && (
+        <div className="flex items-center gap-4 rounded-2xl border border-red-500/30 bg-red-500/5 px-5 py-4">
+          {activeCheckin.poster && (
+            <div className="h-14 w-10 flex-none overflow-hidden rounded-lg ring-1 ring-white/10">
+              <img src={activeCheckin.poster} alt="" className="h-full w-full object-cover" loading="lazy" />
+            </div>
+          )}
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2">
+              <span className="relative flex h-2 w-2">
+                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-red-400 opacity-75" />
+                <span className="relative inline-flex rounded-full h-2 w-2 bg-red-500" />
+              </span>
+              <span className="text-xs font-semibold uppercase tracking-wider text-red-400">Now Watching</span>
+            </div>
+            <p className="mt-0.5 truncate text-sm font-semibold text-white">{activeCheckin.name}</p>
+            {activeCheckin.season != null && activeCheckin.episode != null && (
+              <p className="text-xs text-slate-400">
+                S{String(activeCheckin.season).padStart(2, "0")}:E{String(activeCheckin.episode).padStart(2, "0")}
+              </p>
+            )}
+          </div>
+          <div className="flex items-center gap-2 flex-none">
+            <button
+              type="button"
+              onClick={() => void handleCheckout(true)}
+              className="flex items-center gap-1.5 rounded-xl bg-red-500 px-3 py-2 text-xs font-semibold text-white hover:bg-red-600 transition-colors"
+            >
+              <Check className="h-3.5 w-3.5" /> Finished
+            </button>
+            <button
+              type="button"
+              onClick={() => void handleCheckout(false)}
+              className="flex h-8 w-8 items-center justify-center rounded-xl border border-slate-700/60 bg-slate-800 text-slate-400 hover:bg-slate-700 hover:text-white transition-colors"
+              aria-label="Check out without logging"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+      )}
+
       {/* ── Inline stats bar ── */}
       <section>
         {loading ? (
@@ -709,6 +777,42 @@ export function DashboardPage() {
         </section>
       )}
 
+      {/* ── Recommended Series For You ── */}
+      {(seriesRecsLoading || seriesRecs.length > 0) && (
+        <section>
+          <SectionHeader title="Recommended Series For You">
+            {!seriesRecsLoading && seriesRecs.length > 0 && (
+              <ScrollArrows
+                canScrollLeft={seriesRecsScroll.canScrollLeft}
+                canScrollRight={seriesRecsScroll.canScrollRight}
+                onScroll={seriesRecsScroll.scroll}
+              />
+            )}
+          </SectionHeader>
+          {seriesRecsLoading ? (
+            <ContinueWatchingSkeleton />
+          ) : (
+            <div
+              ref={seriesRecsScroll.ref}
+              className="flex gap-4 overflow-x-auto pb-2 scroll-smooth scrollbar-hide"
+            >
+              {seriesRecs.map((item) => (
+                <DiscoveryCard
+                  key={item.id}
+                  item={item}
+                  onSelect={(i) => setSelectedItem(toSearchResult(i.id, "series", i.name, { poster: i.poster, year: i.year, description: item.description, genres: i.genres, rating: i.rating }))}
+                  badge={
+                    <span className="inline-flex items-center gap-1 rounded-md bg-violet-600/80 px-1.5 py-0.5 text-2xs font-semibold text-white backdrop-blur-sm">
+                      <Sparkles className="h-2.5 w-2.5" />
+                    </span>
+                  }
+                />
+              ))}
+            </div>
+          )}
+        </section>
+      )}
+
       {/* ── Detail Panel ── */}
       {selectedItem && (
         <DetailPanel
@@ -718,6 +822,7 @@ export function DashboardPage() {
           listMap={emptyListMap}
           onClose={() => setSelectedItem(null)}
           onShowToast={() => {}}
+          onHistoryChange={(events) => setPanelHistory(events)}
         />
       )}
 

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -7,7 +7,6 @@ import {
   ChevronRight,
   ChevronLeft,
   Check,
-  Radio,
   Star,
   TrendingUp,
   Sparkles,

--- a/apps/web/src/pages/SearchPage.tsx
+++ b/apps/web/src/pages/SearchPage.tsx
@@ -48,7 +48,7 @@ export function SearchPage() {
   const [pendingAdds, setPendingAdds] = useState<Record<string, boolean>>({});
   const [toasts, setToasts] = useState<Toast[]>([]);
   const [openDropdown, setOpenDropdown] = useState<string | null>(null);
-  const { selectedItem, setSelectedItem, panelHistory, panelHistoryLoading } = useDetailPanel();
+  const { selectedItem, setSelectedItem, panelHistory, setPanelHistory, panelHistoryLoading } = useDetailPanel();
   const debounceRef = useRef<ReturnType<typeof setTimeout>>();
   const dropdownRef = useRef<HTMLDivElement>(null);
 
@@ -303,6 +303,7 @@ export function SearchPage() {
           listMap={listMap}
           onClose={() => setSelectedItem(null)}
           onShowToast={showToast}
+          onHistoryChange={(events) => setPanelHistory(events)}
         />
       )}
 

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -1,6 +1,6 @@
 import { FormEvent, ReactNode, useCallback, useEffect, useId, useRef, useState } from "react";
 import { api, runtimeConfig } from "../api";
-import { ChevronDown, Key, Link, Database, Info, Eye, EyeOff, Loader2, Check, AlertCircle, Unplug, Clapperboard, Image, Globe, Shield, Copy, ExternalLink } from "lucide-react";
+import { ChevronDown, Key, Link, Database, Info, Eye, EyeOff, Loader2, Check, AlertCircle, Unplug, Clapperboard, Image, Globe, Shield, Copy, ExternalLink, Star } from "lucide-react";
 
 declare const __APP_VERSION__: string;
 const APP_VERSION = typeof __APP_VERSION__ !== "undefined" ? __APP_VERSION__ : "unknown";
@@ -251,6 +251,120 @@ function TraktSection() {
   );
 }
 
+function OmdbSection() {
+  const [loading, setLoading] = useState(true);
+  const [configured, setConfigured] = useState(false);
+  const [apiKey, setApiKey] = useState("");
+  const [showKey, setShowKey] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    void (async () => {
+      try {
+        const status = await api.getOmdbStatus();
+        setConfigured(status.configured);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to load OMDB status");
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  const save = async (e: FormEvent) => {
+    e.preventDefault();
+    setSaving(true);
+    setError(null);
+    try {
+      const result = await api.setOmdbKey(apiKey.trim());
+      setConfigured(result.configured);
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save OMDB key");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const disconnect = async () => {
+    try {
+      await api.removeOmdbKey();
+      setConfigured(false);
+      setApiKey("");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to remove OMDB key");
+    }
+  };
+
+  if (loading) {
+    return <div className="flex items-center gap-2 text-sm text-slate-400"><Loader2 size={16} className="animate-spin" /> Checking OMDB status...</div>;
+  }
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-slate-400 leading-relaxed">
+        OMDB provides ratings from <strong className="text-slate-300">IMDb</strong>, <strong className="text-slate-300">Rotten Tomatoes</strong>, and <strong className="text-slate-300">Metacritic</strong> for every movie and show in your detail panels.
+        Get a free API key at{" "}
+        <a href="https://www.omdbapi.com/apikey.aspx" target="_blank" rel="noopener noreferrer" className="text-red-400 underline hover:text-red-300">
+          omdbapi.com
+        </a>.
+      </p>
+
+      <div className="flex items-center gap-3">
+        <StatusBadge ok={configured} label={configured ? "Active" : "Not configured"} />
+      </div>
+
+      {configured ? (
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={disconnect}
+            className="inline-flex items-center gap-2 rounded-xl bg-slate-800 px-4 py-2.5 text-sm font-semibold transition-colors hover:bg-rose-600 border border-slate-700/60"
+          >
+            <Unplug size={16} /> Remove Key
+          </button>
+        </div>
+      ) : (
+        <form onSubmit={save} className="space-y-3">
+          <div className="relative">
+            <input
+              type={showKey ? "text" : "password"}
+              value={apiKey}
+              onChange={(e) => setApiKey(e.target.value)}
+              placeholder="Paste your OMDB API key"
+              className="w-full rounded-xl border border-slate-700/60 bg-slate-950 px-4 py-3 pr-20 text-sm focus:border-red-500 focus:outline-none focus:ring-2 focus:ring-red-500/15"
+            />
+            <button
+              type="button"
+              onClick={() => setShowKey((p) => !p)}
+              className="absolute right-3 top-1/2 -translate-y-1/2 rounded-lg p-1.5 text-slate-400 transition-colors hover:bg-slate-800 hover:text-slate-200"
+              aria-label={showKey ? "Hide key" : "Show key"}
+            >
+              {showKey ? <EyeOff size={16} /> : <Eye size={16} />}
+            </button>
+          </div>
+          <button
+            type="submit"
+            disabled={saving || !apiKey.trim()}
+            className={`inline-flex items-center gap-2 rounded-xl px-5 py-2.5 text-sm font-semibold transition-all ${
+              saved
+                ? "bg-emerald-500/15 text-emerald-400 ring-1 ring-emerald-500/20"
+                : "bg-red-500 text-white hover:bg-red-600 shadow-lg shadow-red-500/20 disabled:opacity-50"
+            }`}
+          >
+            {saved ? <><Check size={16} /> Saved</> : saving ? <><Loader2 size={16} className="animate-spin" /> Saving...</> : "Save OMDB Key"}
+          </button>
+        </form>
+      )}
+
+      {error && <p className="flex items-center gap-2 text-sm text-rose-400"><AlertCircle size={16} /> {error}</p>}
+    </div>
+  );
+}
+
 function RpdbSection() {
   const [loading, setLoading] = useState(true);
   const [configured, setConfigured] = useState(false);
@@ -308,7 +422,7 @@ function RpdbSection() {
     <div className="space-y-4">
       <p className="text-sm text-slate-400 leading-relaxed">
         RPDB (Rating Poster Database) overlays rating badges directly onto poster images.
-        When enabled, all posters in Stremio will show IMDb/TMDB ratings on the poster artwork.
+        When enabled, all posters across the web UI and Stremio will show rating badges on the artwork.
         Get an API key at{" "}
         <a href="https://ratingposterdb.com/api-key/" target="_blank" rel="noopener noreferrer" className="text-red-400 underline hover:text-red-300">
           ratingposterdb.com
@@ -781,6 +895,10 @@ export function SettingsPage() {
 
       <Section title="Preferences" icon={<Globe size={20} />}>
         <PreferencesSection />
+      </Section>
+
+      <Section title="OMDB Ratings" icon={<Star size={20} />}>
+        <OmdbSection />
       </Section>
 
       <Section title="RPDB Posters" icon={<Image size={20} />}>


### PR DESCRIPTION
…tions, and check-in

- OMDB integration: IMDb, Rotten Tomatoes, Metacritic ratings with inline SVG logos in detail panel and settings
- RPDB posters applied across all web UI catalog endpoints (watchlist, continue, recent, trending, popular, recommendations, search, streaming, anime)
- Detail panel enrichment: runtime, certification (R/PG-13), status (Ended/Returning), network/studio, cast with photos, series season breakdown
- Watch management: log a watch with custom date modal (just finished / release date / unknown / other), delete individual watch events, drop/undrop show
- Series and movie personal recommendations sections on dashboard
- Check-in / Now Watching: check in to a movie or episode (series shows season/episode picker), pulsing Now Watching banner on dashboard, check out silently or with watch log
- DB migrations for new metadata fields (imdbRating, rtScore, mcScore, runtime, certification, status, network, releaseDate)
- OMDB settings section in SettingsPage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OMDB ratings (IMDb, Rotten Tomatoes, Metacritic) shown across search and media detail views
  * New metadata details: runtime, certification, status, network, and release date displayed
  * Cast and seasons displays for series (with on-demand loading)
  * Check-in / Now Watching banner, plus check-in modals and Watch logging UI
  * Drop/undrop show controls and watch event deletion
  * RPDB poster overrides applied across lists and detail views
  * OMDB API key management in Settings and bulk/enrichment refresh controls
<!-- end of auto-generated comment: release notes by coderabbit.ai -->