### PR TITLE
Fix MetadataPayload type error by adding missing properties

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1444,6 +1444,11 @@ app.get<{ Querystring: { type?: string; limit?: string } }>("/recommendations/pe
           voteCount: null,
           totalSeasons: null,
           totalEpisodes: null,
+          runtime: null,
+          certification: null,
+          status: null,
+          network: null,
+          releaseDate: null,
         }));
       } else {
         recs = await tmdb.recommendations(type, tmdbId);


### PR DESCRIPTION
The cached seed reconstruction in the recommendations handler was missing the runtime, certification, status, network, and releaseDate properties that were added to the MetadataPayload type.

https://claude.ai/code/session_01KNAEL5uZYK8W9mAmmhdRi7