### PR TITLE
Improve text contrast and visual hierarchy with color adjustments

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -84,7 +84,7 @@ export function App() {
               key={item.to}
               to={item.to}
               className={`flex flex-1 flex-col items-center gap-0.5 py-2.5 text-2xs font-medium transition-colors ${
-                isActive ? "text-red-400" : "text-slate-500"
+                isActive ? "text-red-400" : "text-slate-400"
               }`}
             >
               <Icon className="h-5 w-5" />
@@ -95,7 +95,7 @@ export function App() {
       </nav>
 
       {/* Footer */}
-      <footer className="border-t border-slate-800/40 py-8 text-center text-sm text-slate-600">
+      <footer className="border-t border-slate-800/40 py-8 text-center text-sm text-slate-400">
         Cataloggy &middot; Personal Media Tracker
       </footer>
     </div>

--- a/apps/web/src/components/MediaDetailPanel.tsx
+++ b/apps/web/src/components/MediaDetailPanel.tsx
@@ -127,7 +127,7 @@ function WatchDateModal({
         {target.kind === "episode" && (
           <div className="mb-4 flex gap-3">
             <div className="flex-1">
-              <label className="mb-1 block text-xs text-slate-500">Season</label>
+              <label className="mb-1 block text-xs text-slate-400">Season</label>
               <input
                 type="number"
                 min={1}
@@ -137,7 +137,7 @@ function WatchDateModal({
               />
             </div>
             <div className="flex-1">
-              <label className="mb-1 block text-xs text-slate-500">Episode</label>
+              <label className="mb-1 block text-xs text-slate-400">Episode</label>
               <input
                 type="number"
                 min={1}
@@ -289,7 +289,7 @@ function CheckInModal({
           <p className="text-sm text-slate-400">Which episode of <span className="font-semibold text-slate-200">{seriesName}</span> are you watching?</p>
           <div className="flex gap-3">
             <div className="flex-1">
-              <label className="mb-1.5 block text-xs font-medium text-slate-500">Season</label>
+              <label className="mb-1.5 block text-xs font-medium text-slate-400">Season</label>
               <input
                 type="number" min="1" value={season}
                 onChange={(e) => setSeason(e.target.value)}
@@ -297,7 +297,7 @@ function CheckInModal({
               />
             </div>
             <div className="flex-1">
-              <label className="mb-1.5 block text-xs font-medium text-slate-500">Episode</label>
+              <label className="mb-1.5 block text-xs font-medium text-slate-400">Episode</label>
               <input
                 type="number" min="1" value={episode}
                 onChange={(e) => setEpisode(e.target.value)}
@@ -339,13 +339,13 @@ function ExternalRatings({
   if (imdbRating == null && rtScore == null && mcScore == null) return null;
   return (
     <div>
-      <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-500">Ratings</h3>
+      <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-400">Ratings</h3>
       <div className="flex flex-wrap items-center gap-4">
         {imdbRating != null && (
           <div className="flex items-center gap-1.5">
             <ImdbLogo />
             <span className="text-sm font-semibold text-slate-200">{imdbRating.toFixed(1)}</span>
-            <span className="text-xs text-slate-500">/10</span>
+            <span className="text-xs text-slate-400">/10</span>
           </div>
         )}
         {rtScore != null && (
@@ -358,7 +358,7 @@ function ExternalRatings({
           <div className="flex items-center gap-1.5">
             <McIcon score={mcScore} />
             <span className="text-sm font-semibold text-slate-200">{mcScore}</span>
-            <span className="text-xs text-slate-500">/100</span>
+            <span className="text-xs text-slate-400">/100</span>
           </div>
         )}
       </div>
@@ -433,7 +433,7 @@ export function StarRating({
   const displayRating = hoverRating ?? userRating ?? 0;
   return (
     <div>
-      <h3 className="mb-2 flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-slate-500">
+      <h3 className="mb-2 flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-slate-400">
         <Star className="h-3.5 w-3.5" /> Your Rating
       </h3>
       <div className="flex items-center gap-1">
@@ -446,7 +446,7 @@ export function StarRating({
             className="p-0.5 transition-transform hover:scale-125 disabled:opacity-50"
             aria-label={`Rate ${star} out of 10`}
           >
-            <Star className={`h-5 w-5 transition-colors ${star <= displayRating ? "fill-amber-400 text-amber-400" : "text-slate-600 hover:text-slate-500"}`} />
+            <Star className={`h-5 w-5 transition-colors ${star <= displayRating ? "fill-amber-400 text-amber-400" : "text-slate-500 hover:text-slate-400"}`} />
           </button>
         ))}
         {userRating !== null && <span className="ml-2 text-sm font-semibold text-amber-400">{userRating}/10</span>}
@@ -762,7 +762,7 @@ export function DetailPanel({
           {/* Description */}
           {item.description && (
             <div>
-              <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-500">Overview</h3>
+              <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-400">Overview</h3>
               <p className="text-sm leading-relaxed text-slate-300">{item.description}</p>
             </div>
           )}
@@ -770,7 +770,7 @@ export function DetailPanel({
           {/* Cast */}
           {castLoading ? (
             <div>
-              <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-500">Cast</h3>
+              <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-400">Cast</h3>
               <div className="flex gap-3 overflow-hidden">
                 {[1, 2, 3, 4].map((i) => (
                   <div key={i} className="flex-none w-16 space-y-1">
@@ -782,7 +782,7 @@ export function DetailPanel({
             </div>
           ) : cast.length > 0 && (
             <div>
-              <h3 className="mb-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-slate-500">
+              <h3 className="mb-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-slate-400">
                 <User className="h-3.5 w-3.5" /> Cast
               </h3>
               <div className="flex gap-3 overflow-x-auto pb-1 scrollbar-hide">
@@ -797,11 +797,11 @@ export function DetailPanel({
                       />
                     ) : (
                       <div className="h-16 w-16 rounded-full bg-slate-800 flex items-center justify-center mx-auto ring-1 ring-white/10">
-                        <User className="h-6 w-6 text-slate-600" />
+                        <User className="h-6 w-6 text-slate-500" />
                       </div>
                     )}
                     <p className="mt-1.5 text-2xs font-medium text-slate-300 leading-tight truncate">{member.name}</p>
-                    <p className="text-2xs text-slate-600 truncate">{member.character}</p>
+                    <p className="text-2xs text-slate-500 truncate">{member.character}</p>
                   </div>
                 ))}
               </div>
@@ -812,14 +812,14 @@ export function DetailPanel({
           {item.type === "series" && (
             seasonsLoading ? (
               <div>
-                <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-500">Seasons</h3>
+                <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-400">Seasons</h3>
                 <div className="grid grid-cols-2 gap-2">
                   {[1, 2, 3, 4].map((i) => <div key={i} className="skeleton h-10 rounded-xl" />)}
                 </div>
               </div>
             ) : seasons.length > 0 && (
               <div>
-                <h3 className="mb-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-slate-500">
+                <h3 className="mb-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-slate-400">
                   <Tv className="h-3.5 w-3.5" /> Seasons
                 </h3>
                 <div className="grid grid-cols-2 gap-2">
@@ -830,7 +830,7 @@ export function DetailPanel({
                       </div>
                       <div className="min-w-0">
                         <p className="text-xs font-medium text-slate-200 truncate">{s.name}</p>
-                        <p className="text-2xs text-slate-500">{s.episodeCount} eps{s.airYear ? ` · ${s.airYear}` : ""}</p>
+                        <p className="text-2xs text-slate-400">{s.episodeCount} eps{s.airYear ? ` · ${s.airYear}` : ""}</p>
                       </div>
                     </div>
                   ))}
@@ -842,7 +842,7 @@ export function DetailPanel({
           {/* Watch History */}
           <div>
             <div className="mb-3 flex items-center justify-between">
-              <h3 className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-slate-500">
+              <h3 className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-slate-400">
                 <Clock className="h-3.5 w-3.5" /> Watch History
               </h3>
               <button
@@ -857,14 +857,14 @@ export function DetailPanel({
             {historyLoading ? (
               <div className="space-y-2">{[1, 2, 3].map((i) => <div key={i} className="skeleton h-11 rounded-lg" />)}</div>
             ) : history.length === 0 ? (
-              <p className="rounded-xl bg-slate-900/60 border border-slate-800/40 py-5 text-center text-sm text-slate-500">
+              <p className="rounded-xl bg-slate-900/60 border border-slate-800/40 py-5 text-center text-sm text-slate-400">
                 No watch history yet
               </p>
             ) : (
               <div className="space-y-1.5">
                 {history.map((event) => (
                   <div key={event.id} className="group flex items-center gap-3 rounded-lg bg-slate-900/60 border border-slate-800/30 px-3 py-2.5">
-                    <ChevronRight className="h-3.5 w-3.5 shrink-0 text-slate-600" />
+                    <ChevronRight className="h-3.5 w-3.5 shrink-0 text-slate-500" />
                     <div className="min-w-0 flex-1">
                       {event.season != null && event.episode != null ? (
                         <span className="text-sm text-slate-200">
@@ -874,7 +874,7 @@ export function DetailPanel({
                         <span className="text-sm text-slate-200">Watched</span>
                       )}
                     </div>
-                    <time className="shrink-0 text-2xs text-slate-500">
+                    <time className="shrink-0 text-2xs text-slate-400">
                       {new Date(event.watchedAt).getFullYear() === 2000 && new Date(event.watchedAt).getMonth() === 0
                         ? "Unknown date"
                         : new Date(event.watchedAt).toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" })}

--- a/apps/web/src/components/MediaList.tsx
+++ b/apps/web/src/components/MediaList.tsx
@@ -70,7 +70,7 @@ export function MediaList({ title, items, count, onSeeAll, onAddItem }: Props) {
       {items.length === 0 ? (
         <div className="rounded-2xl border border-dashed border-slate-800 py-12 text-center">
           <Film className="mx-auto h-10 w-10 text-slate-700" />
-          <p className="mt-3 text-sm text-slate-500">No items yet.</p>
+          <p className="mt-3 text-sm text-slate-400">No items yet.</p>
         </div>
       ) : (
         <div
@@ -102,7 +102,7 @@ export function MediaList({ title, items, count, onSeeAll, onAddItem }: Props) {
                   />
                 ) : (
                   <div className={`flex h-full w-full items-center justify-center bg-gradient-to-br ${getGradient(item.name)}`}>
-                    <span className="text-2xl font-bold text-white/40 select-none">
+                    <span className="text-2xl font-bold text-white/60 select-none">
                       {getInitials(item.name)}
                     </span>
                   </div>
@@ -123,7 +123,7 @@ export function MediaList({ title, items, count, onSeeAll, onAddItem }: Props) {
                 )}
               </div>
               <p className="mt-2.5 truncate text-sm font-semibold text-slate-200">{item.name}</p>
-              {item.year ? <p className="text-2xs text-slate-500">{item.year}</p> : null}
+              {item.year ? <p className="text-2xs text-slate-400">{item.year}</p> : null}
             </div>
           ))}
         </div>

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -31,17 +31,17 @@ body {
   background: transparent;
 }
 ::-webkit-scrollbar-thumb {
-  background: rgb(51 65 85 / 0.6);
+  background: rgb(71 85 105 / 0.7);
   border-radius: 4px;
 }
 ::-webkit-scrollbar-thumb:hover {
-  background: rgb(100 116 139 / 0.8);
+  background: rgb(100 116 139 / 0.9);
 }
 
 /* Firefox scrollbar */
 * {
   scrollbar-width: thin;
-  scrollbar-color: rgb(51 65 85 / 0.6) transparent;
+  scrollbar-color: rgb(71 85 105 / 0.7) transparent;
 }
 
 /* Hide scrollbar for carousels */

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -93,7 +93,7 @@ function Poster({
       <div
         className={`flex items-center justify-center bg-gradient-to-br ${getGradient(alt)} ${className}`}
       >
-        <span className="text-xl font-bold text-white/40 select-none">
+        <span className="text-xl font-bold text-white/60 select-none">
           {getInitials(alt)}
         </span>
       </div>
@@ -157,11 +157,11 @@ function DiscoveryCard({ item, badge, reason, onSelect }: { item: DiscoveryItem;
         </div>
       </div>
       <p className="mt-2.5 truncate text-sm font-semibold text-slate-200 group-hover:text-white transition-colors">{item.name}</p>
-      <p className="text-2xs text-slate-500">
+      <p className="text-2xs text-slate-400">
         {item.year ?? ""}{item.type ? ` ${item.type === "movie" ? "Movie" : "Series"}` : ""}
       </p>
       {reason && (
-        <p className="mt-0.5 truncate text-2xs italic text-slate-500" title={reason}>{reason}</p>
+        <p className="mt-0.5 truncate text-2xs italic text-slate-400" title={reason}>{reason}</p>
       )}
     </div>
   );
@@ -400,7 +400,7 @@ export function DashboardPage() {
           Unable to connect to the API
         </p>
         <p className="text-sm text-slate-400">{error}</p>
-        <p className="text-sm text-slate-500">
+        <p className="text-sm text-slate-400">
           Current API base:{" "}
           <span className="font-mono text-red-300">
             {runtimeConfig.getApiBase()}
@@ -485,19 +485,19 @@ export function DashboardPage() {
             <div className="flex items-center gap-2">
               <Film className="h-4 w-4 text-red-400" />
               <span className="text-lg font-bold text-white tabular-nums">{stats.totalMovies.toLocaleString()}</span>
-              <span className="text-sm text-slate-500">movies</span>
+              <span className="text-sm text-slate-400">movies</span>
             </div>
             <div className="h-4 w-px bg-slate-800" />
             <div className="flex items-center gap-2">
               <Tv className="h-4 w-4 text-violet-400" />
               <span className="text-lg font-bold text-white tabular-nums">{stats.totalEpisodes.toLocaleString()}</span>
-              <span className="text-sm text-slate-500">episodes</span>
+              <span className="text-sm text-slate-400">episodes</span>
             </div>
             <div className="h-4 w-px bg-slate-800" />
             <div className="flex items-center gap-2">
               <Play className="h-4 w-4 text-amber-400" />
               <span className="text-lg font-bold text-white tabular-nums">{stats.totalPlays.toLocaleString()}</span>
-              <span className="text-sm text-slate-500">total plays</span>
+              <span className="text-sm text-slate-400">total plays</span>
             </div>
           </div>
         ) : null}
@@ -519,7 +519,7 @@ export function DashboardPage() {
         ) : progress.length === 0 ? (
           <div className="rounded-2xl border border-dashed border-slate-800 py-12 text-center">
             <Tv className="mx-auto h-10 w-10 text-slate-700" />
-            <p className="mt-3 text-sm text-slate-500">
+            <p className="mt-3 text-sm text-slate-400">
               No series in progress. Start watching something!
             </p>
           </div>
@@ -602,7 +602,7 @@ export function DashboardPage() {
                     {s.name}
                   </button>
                   {progressPct !== null && (
-                    <p className="text-2xs text-slate-500">
+                    <p className="text-2xs text-slate-400">
                       {s.watchedEpisodes} of {s.totalEpisodes} episodes
                     </p>
                   )}
@@ -629,7 +629,7 @@ export function DashboardPage() {
         ) : history.length === 0 ? (
           <div className="rounded-2xl border border-dashed border-slate-800 py-12 text-center">
             <Film className="mx-auto h-10 w-10 text-slate-700" />
-            <p className="mt-3 text-sm text-slate-500">No watch history yet.</p>
+            <p className="mt-3 text-sm text-slate-400">No watch history yet.</p>
           </div>
         ) : (
           <div
@@ -682,7 +682,7 @@ export function DashboardPage() {
                 <p className="mt-2.5 truncate text-sm font-semibold text-slate-200 group-hover:text-white transition-colors">
                   {event.name}
                 </p>
-                <p className="text-2xs text-slate-500">
+                <p className="text-2xs text-slate-400">
                   {event.type === "episode" &&
                   event.season != null &&
                   event.episode != null
@@ -721,7 +721,7 @@ export function DashboardPage() {
         ) : trendingMovies.length === 0 ? (
           <div className="rounded-2xl border border-dashed border-slate-800 py-12 text-center">
             <TrendingUp className="mx-auto h-10 w-10 text-slate-700" />
-            <p className="mt-3 text-sm text-slate-500">
+            <p className="mt-3 text-sm text-slate-400">
               Unable to load trending content. Please try again or check your network connection.
             </p>
           </div>
@@ -755,7 +755,7 @@ export function DashboardPage() {
           </SectionHeader>
           {recsLoading ? (
             aiActive ? (
-              <p className="text-sm text-slate-500 italic">Generating AI recommendations…</p>
+              <p className="text-sm text-slate-400 italic">Generating AI recommendations…</p>
             ) : (
               <ContinueWatchingSkeleton />
             )
@@ -797,7 +797,7 @@ export function DashboardPage() {
           </SectionHeader>
           {seriesRecsLoading ? (
             aiActive ? (
-              <p className="text-sm text-slate-500 italic">Generating AI recommendations…</p>
+              <p className="text-sm text-slate-400 italic">Generating AI recommendations…</p>
             ) : (
               <ContinueWatchingSkeleton />
             )
@@ -880,7 +880,7 @@ export function DashboardPage() {
                       <p className="truncate text-sm font-semibold text-slate-100">
                         {entry.seriesName}
                       </p>
-                      <p className="mt-0.5 text-xs text-slate-500">
+                      <p className="mt-0.5 text-xs text-slate-400">
                         S{entry.season}:E{entry.episode} — {entry.episodeName}
                       </p>
                     </div>
@@ -894,7 +894,7 @@ export function DashboardPage() {
                       }`}>
                         {dateLabel}
                       </span>
-                      <span className="text-2xs text-slate-600">
+                      <span className="text-2xs text-slate-500">
                         {airDate.toLocaleDateString(undefined, { month: "short", day: "numeric" })}
                       </span>
                     </div>

--- a/apps/web/src/pages/ListsPage.tsx
+++ b/apps/web/src/pages/ListsPage.tsx
@@ -102,7 +102,7 @@ function AddItemModal({
         {/* Search input */}
         <div className="flex gap-2 border-b border-slate-800/60 px-5 py-3">
           <div className="relative flex-1">
-            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
+            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
             <input
               ref={inputRef}
               value={query}
@@ -134,9 +134,9 @@ function AddItemModal({
         {/* Results */}
         <div className="max-h-[50vh] overflow-y-auto px-5 py-3">
           {error && <p className="mb-2 rounded-lg bg-rose-500/10 border border-rose-500/20 px-3 py-2 text-xs text-rose-300">{error}</p>}
-          {searching && <p className="py-6 text-center text-sm text-slate-500">Searching...</p>}
+          {searching && <p className="py-6 text-center text-sm text-slate-400">Searching...</p>}
           {!searching && query.trim() && results.length === 0 && (
-            <p className="py-6 text-center text-sm text-slate-500">No results found.</p>
+            <p className="py-6 text-center text-sm text-slate-400">No results found.</p>
           )}
           <div className="space-y-1">
             {results.map((r) => (
@@ -151,12 +151,12 @@ function AddItemModal({
                   {r.poster ? (
                     <img src={r.poster} alt="" className="h-full w-full object-cover" />
                   ) : (
-                    <div className="flex h-full w-full items-center justify-center"><Film className="h-4 w-4 text-slate-600" /></div>
+                    <div className="flex h-full w-full items-center justify-center"><Film className="h-4 w-4 text-slate-500" /></div>
                   )}
                 </div>
                 <div className="min-w-0 flex-1">
                   <p className="truncate text-sm font-semibold text-slate-200">{r.name}</p>
-                  <p className="text-xs text-slate-500">{r.year ?? "Unknown"} &middot; {r.type}</p>
+                  <p className="text-xs text-slate-400">{r.year ?? "Unknown"} &middot; {r.type}</p>
                 </div>
                 <Plus className="h-4 w-4 flex-none text-red-400" />
               </button>
@@ -275,7 +275,7 @@ export function ListsPage() {
                     <AlertTriangle className="h-4 w-4 flex-none text-rose-400" />
                     <p className="text-xs font-semibold text-rose-300">Delete "{list.name}"?</p>
                   </div>
-                  <p className="text-xs text-slate-500 mb-3">This will remove the list and all its items.</p>
+                  <p className="text-xs text-slate-400 mb-3">This will remove the list and all its items.</p>
                   <div className="flex gap-2">
                     <button
                       type="button"
@@ -308,7 +308,7 @@ export function ListsPage() {
                     }`}
                   >
                     <p className="truncate font-semibold">{list.name}</p>
-                    <p className="mt-0.5 text-xs text-slate-500">
+                    <p className="mt-0.5 text-xs text-slate-400">
                       {list.itemCount} {list.itemCount === 1 ? "item" : "items"}
                     </p>
                   </button>
@@ -316,7 +316,7 @@ export function ListsPage() {
                     <button
                       type="button"
                       onClick={(e) => { e.stopPropagation(); setConfirmDeleteId(list.id); }}
-                      className="mr-2 flex h-7 w-7 flex-none items-center justify-center rounded-lg text-slate-600 opacity-0 group-hover:opacity-100 hover:bg-rose-500/15 hover:text-rose-400 transition-all focus:opacity-100"
+                      className="mr-2 flex h-7 w-7 flex-none items-center justify-center rounded-lg text-slate-500 opacity-0 group-hover:opacity-100 hover:bg-rose-500/15 hover:text-rose-400 transition-all focus:opacity-100"
                       aria-label={`Delete list ${list.name}`}
                     >
                       <Trash2 className="h-3.5 w-3.5" />
@@ -356,7 +356,7 @@ export function ListsPage() {
               <FolderOpen className="h-10 w-10 text-slate-700" />
             </div>
             <p className="mt-4 text-lg font-semibold text-slate-400">No list selected</p>
-            <p className="mt-1 text-sm text-slate-500">Select a list from the sidebar or create a new one.</p>
+            <p className="mt-1 text-sm text-slate-400">Select a list from the sidebar or create a new one.</p>
           </div>
         ) : (
           <>
@@ -364,7 +364,7 @@ export function ListsPage() {
             <div className="mb-5 flex items-center justify-between">
               <div>
                 <h2 className="text-2xl font-bold text-white">{selectedList.name}</h2>
-                <p className="mt-0.5 text-sm text-slate-500">
+                <p className="mt-0.5 text-sm text-slate-400">
                   {items.length} {items.length === 1 ? "item" : "items"}
                 </p>
               </div>
@@ -395,7 +395,7 @@ export function ListsPage() {
                   <FolderOpen className="h-10 w-10 text-slate-700" />
                 </div>
                 <p className="mt-4 text-lg font-semibold text-slate-400">This list is empty</p>
-                <p className="mt-1 text-sm text-slate-500">
+                <p className="mt-1 text-sm text-slate-400">
                   Click <span className="font-semibold text-red-400">+ Add</span> to search and add titles.
                 </p>
               </div>
@@ -413,7 +413,7 @@ export function ListsPage() {
                           <img src={poster} alt={name} className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105" loading="lazy" />
                         ) : (
                           <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-slate-800 to-slate-900">
-                            <Film className="h-10 w-10 text-slate-600" />
+                            <Film className="h-10 w-10 text-slate-500" />
                           </div>
                         )}
                         {/* Type badge */}
@@ -439,7 +439,7 @@ export function ListsPage() {
                       </div>
                       {/* Title & year */}
                       <p className="mt-2.5 truncate text-sm font-semibold text-slate-100">{name}</p>
-                      <p className="text-xs text-slate-500">{year ?? "Unknown year"}</p>
+                      <p className="text-xs text-slate-400">{year ?? "Unknown year"}</p>
                     </div>
                   );
                 })}

--- a/apps/web/src/pages/SearchPage.tsx
+++ b/apps/web/src/pages/SearchPage.tsx
@@ -194,12 +194,12 @@ export function SearchPage() {
         className="sticky top-[76px] z-40 rounded-2xl border border-slate-800/60 bg-slate-900/90 p-4 backdrop-blur-xl shadow-lg"
       >
         <div className="relative">
-          <Search className="pointer-events-none absolute left-5 top-1/2 h-5 w-5 -translate-y-1/2 text-slate-500" />
+          <Search className="pointer-events-none absolute left-5 top-1/2 h-5 w-5 -translate-y-1/2 text-slate-400" />
           <input
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             placeholder="Search movies & TV shows..."
-            className="w-full rounded-full border border-slate-700/60 bg-slate-950 py-3.5 pl-14 pr-12 text-base placeholder:text-slate-500 focus:border-red-500 focus:outline-none focus:ring-2 focus:ring-red-500/15 transition-all"
+            className="w-full rounded-full border border-slate-700/60 bg-slate-950 py-3.5 pl-14 pr-12 text-base placeholder:text-slate-400 focus:border-red-500 focus:outline-none focus:ring-2 focus:ring-red-500/15 transition-all"
             autoFocus
           />
           {query && (
@@ -252,7 +252,7 @@ export function SearchPage() {
             <Search className="h-14 w-14 text-slate-700" />
           </div>
           <p className="mt-6 text-2xl font-bold text-slate-100">Discover your next favorite</p>
-          <p className="mt-2 max-w-sm text-slate-500">
+          <p className="mt-2 max-w-sm text-slate-400">
             Search for movies and series to add them to your lists and track what you watch.
           </p>
         </div>
@@ -265,7 +265,7 @@ export function SearchPage() {
             <Search className="h-12 w-12 text-slate-700" />
           </div>
           <p className="mt-5 text-lg font-semibold text-slate-300">No results found</p>
-          <p className="mt-1 text-sm text-slate-500">Try a different search term or filter.</p>
+          <p className="mt-1 text-sm text-slate-400">Try a different search term or filter.</p>
         </div>
       )}
 
@@ -273,7 +273,7 @@ export function SearchPage() {
       {hasSearched && results.length > 0 && (
         <>
           <div className="flex items-center justify-between">
-            <p className="text-sm text-slate-500">{results.length} results</p>
+            <p className="text-sm text-slate-400">{results.length} results</p>
           </div>
           <div className="grid grid-cols-2 gap-5 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
             {results.map((result) => (
@@ -411,7 +411,7 @@ function ResultCard({
       {isOpen && (
         <div ref={dropdownRef} className="relative z-30 mt-1">
           <div className="absolute left-0 right-0 overflow-hidden rounded-xl border border-slate-700/60 bg-slate-900 shadow-2xl">
-            <p className="border-b border-slate-800 px-3 py-2.5 text-2xs font-semibold uppercase tracking-wider text-slate-500">
+            <p className="border-b border-slate-800 px-3 py-2.5 text-2xs font-semibold uppercase tracking-wider text-slate-400">
               Add to list
             </p>
             {lists.map((list) => {
@@ -435,7 +435,7 @@ function ResultCard({
                     <Plus className="h-3.5 w-3.5 text-slate-400" />
                   )}
                   <span className={already ? "text-slate-400" : "text-slate-200"}>{list.name}</span>
-                  {already && <span className="ml-auto text-2xs text-slate-500">Added</span>}
+                  {already && <span className="ml-auto text-2xs text-slate-400">Added</span>}
                   {pending && (
                     <span className="ml-auto inline-block h-3 w-3 animate-spin rounded-full border border-red-500 border-t-transparent" />
                   )}
@@ -450,7 +450,7 @@ function ResultCard({
       <div className="mt-3">
         <p className="truncate text-sm font-semibold text-slate-100">{result.name}</p>
         <div className="mt-0.5 flex items-center gap-2">
-          <span className="text-xs text-slate-500">{result.year ?? "Unknown year"}</span>
+          <span className="text-xs text-slate-400">{result.year ?? "Unknown year"}</span>
           {result.rating != null && result.rating > 0 && (
             <span className="flex items-center gap-0.5 text-xs text-amber-400">
               <Star className="h-3 w-3 fill-amber-400" />

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -40,7 +40,7 @@ function Section({ title, icon, defaultOpen, children }: { title: string; icon: 
         <span className="flex-1 text-base font-semibold">{title}</span>
         <ChevronDown
           size={18}
-          className={`text-slate-500 transition-transform duration-300 ${open ? "rotate-180" : ""}`}
+          className={`text-slate-400 transition-transform duration-300 ${open ? "rotate-180" : ""}`}
         />
       </button>
       <div
@@ -104,7 +104,7 @@ function ApiTokenSection() {
           {showToken ? <EyeOff size={16} /> : <Eye size={16} />}
         </button>
       </div>
-      <p className="text-xs text-amber-400/80">Only use this on trusted devices.</p>
+      <p className="text-xs text-amber-400">Only use this on trusted devices.</p>
       <button
         type="submit"
         className={`inline-flex items-center gap-2 rounded-xl px-5 py-2.5 text-sm font-semibold transition-all ${
@@ -193,7 +193,7 @@ function TraktSection() {
             Your Trakt app's <strong className="text-slate-300">Redirect URI</strong> must be set to:
           </p>
           <code className="block text-sm text-red-400 break-all select-all">{status.redirectUri}</code>
-          <p className="text-xs text-slate-500">
+          <p className="text-xs text-slate-400">
             Set this at trakt.tv under Settings &gt; Your API Apps &gt; Edit. A mismatch causes an OAuth error.
           </p>
         </div>
@@ -554,7 +554,7 @@ function AddonManifestUrl() {
           <ExternalLink size={13} />
         </a>
       </div>
-      <p className="text-xs text-slate-500">
+      <p className="text-xs text-slate-400">
         The URL points to your local API server. Stremio must be able to reach it on your network.
       </p>
     </div>
@@ -650,14 +650,14 @@ function AddonConfigSection() {
         })}
       </div>
       {available.some((c) => c === "cataloggy-ai-movie" || c === "cataloggy-ai-series") && !aiConfigured && (
-        <p className="text-xs text-slate-500 italic">Configure AI Recommendations to enable the AI Picks catalogs.</p>
+        <p className="text-xs text-slate-400 italic">Configure AI Recommendations to enable the AI Picks catalogs.</p>
       )}
 
       {/* User lists */}
       {availableLists.length > 0 && (
         <div className="space-y-2">
-          <p className="text-xs font-semibold uppercase tracking-wider text-slate-500 pt-1">My Lists</p>
-          <p className="text-xs text-slate-500">Each list adds separate Movies and Series catalogs to Stremio.</p>
+          <p className="text-xs font-semibold uppercase tracking-wider text-slate-400 pt-1">My Lists</p>
+          <p className="text-xs text-slate-400">Each list adds separate Movies and Series catalogs to Stremio.</p>
           {availableLists.map((list) => {
             const catalogId = `list:${list.id}`;
             return (
@@ -822,7 +822,7 @@ function AiRecommendationsSection() {
       <div className="flex items-center gap-3">
         <StatusBadge ok={configured} label={configured ? "Configured" : "Not configured"} />
         {lastGeneratedAt && (
-          <span className="inline-flex items-center gap-1.5 text-xs text-slate-500">
+          <span className="inline-flex items-center gap-1.5 text-xs text-slate-400">
             <Clock size={12} /> Last generated {timeAgo(lastGeneratedAt)}
           </span>
         )}
@@ -1021,7 +1021,7 @@ function PreferencesSection() {
             <option key={l.code} value={l.code}>{l.label} ({l.code})</option>
           ))}
         </select>
-        <p className="mt-1 text-xs text-slate-500">
+        <p className="mt-1 text-xs text-slate-400">
           Titles, descriptions, and metadata will be fetched in this language from TMDB.
         </p>
       </div>
@@ -1042,7 +1042,7 @@ function PreferencesSection() {
             <option key={r} value={r}>{r}</option>
           ))}
         </select>
-        <p className="mt-1 text-xs text-slate-500">
+        <p className="mt-1 text-xs text-slate-400">
           Streaming service catalogs (Netflix, Disney+, etc.) show content available in this region.
         </p>
       </div>
@@ -1061,7 +1061,7 @@ function PreferencesSection() {
             <Shield size={14} className="text-violet-400" />
             Spoiler Protection
           </span>
-          <p className="mt-0.5 text-xs text-slate-500">
+          <p className="mt-0.5 text-xs text-slate-400">
             Hides series descriptions in Stremio for shows you haven't finished watching yet.
           </p>
         </div>

--- a/apps/web/src/pages/StatsPage.tsx
+++ b/apps/web/src/pages/StatsPage.tsx
@@ -84,7 +84,7 @@ export function StatsPage() {
               const label = new Date(m.month + "-15").toLocaleDateString(undefined, { month: "short" });
               return (
                 <div key={m.month} className="flex flex-1 flex-col items-center gap-1">
-                  <span className="text-2xs text-slate-500 tabular-nums">{total || ""}</span>
+                  <span className="text-2xs text-slate-400 tabular-nums">{total || ""}</span>
                   <div className="flex w-full flex-col justify-end" style={{ height: "140px" }}>
                     {episodeHeight > 0 && (
                       <div
@@ -104,12 +104,12 @@ export function StatsPage() {
                       <div className="w-full rounded bg-slate-800/60" style={{ height: "2%" }} />
                     )}
                   </div>
-                  <span className="text-2xs text-slate-500">{label}</span>
+                  <span className="text-2xs text-slate-400">{label}</span>
                 </div>
               );
             })}
           </div>
-          <div className="mt-3 flex items-center gap-4 text-xs text-slate-500">
+          <div className="mt-3 flex items-center gap-4 text-xs text-slate-400">
             <span className="flex items-center gap-1.5">
               <span className="h-2.5 w-2.5 rounded-sm bg-red-500/70" /> Movies
             </span>
@@ -134,7 +134,7 @@ export function StatsPage() {
                     style={{ width: `${(g.count / maxGenreCount) * 100}%` }}
                   />
                 </div>
-                <span className="w-8 text-right text-sm tabular-nums text-slate-500">{g.count}</span>
+                <span className="w-8 text-right text-sm tabular-nums text-slate-400">{g.count}</span>
               </div>
             ))}
           </div>
@@ -166,7 +166,7 @@ export function StatsPage() {
                   )}
                 </div>
                 <p className="mt-1.5 truncate text-sm font-medium text-slate-200">{item.name}</p>
-                <p className="text-2xs text-slate-500 capitalize">{item.type}</p>
+                <p className="text-2xs text-slate-400 capitalize">{item.type}</p>
               </div>
             ))}
           </div>

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -39,7 +39,7 @@ export default {
         sans: ["Outfit", "Inter", "system-ui", "-apple-system", "BlinkMacSystemFont", '"Segoe UI"', "sans-serif"],
       },
       fontSize: {
-        "2xs": ["0.625rem", { lineHeight: "0.875rem" }],
+        "2xs": ["0.6875rem", { lineHeight: "1rem" }],
       },
       aspectRatio: {
         poster: "2 / 3",


### PR DESCRIPTION
## Summary
This PR improves the visual hierarchy and text contrast throughout the application by adjusting the color palette. The changes primarily involve shifting secondary text colors from `slate-500` to `slate-400` for better readability, along with some strategic adjustments to accent colors and scrollbar styling.

## Key Changes

- **Text Color Improvements**: Updated secondary and tertiary text colors from `text-slate-500` to `text-slate-400` across multiple components for improved contrast and readability
  - Section headers and labels in modals and panels
  - Metadata text (years, episode counts, ratings)
  - Placeholder text and helper text
  - Secondary information in cards and lists

- **Icon Color Adjustments**: Updated icon colors to match the new text hierarchy
  - Secondary icons changed from `text-slate-600` to `text-slate-500`
  - Hover states adjusted for better visual feedback

- **Accent Color Refinements**:
  - Poster placeholder initials: increased opacity from `text-white/40` to `text-white/60` for better visibility
  - Warning text: adjusted from `text-amber-400/80` to `text-amber-400` for consistency
  - Navigation inactive state: changed from `text-slate-500` to `text-slate-400`
  - Footer text: updated from `text-slate-600` to `text-slate-400`

- **Scrollbar Styling**: Enhanced scrollbar visibility
  - Thumb color: shifted from `slate-600/0.6` to `slate-700/0.7`
  - Hover state: increased opacity from `0.8` to `0.9`
  - Applied to both webkit and Firefox scrollbars

- **Typography Adjustment**: Fine-tuned the `2xs` font size from `0.625rem` to `0.6875rem` with adjusted line height for better readability of small text

## Implementation Details
All changes maintain the existing component structure and functionality while improving the visual presentation. The color adjustments follow a consistent pattern of moving from darker secondary colors to lighter ones, creating better visual separation between primary and secondary content.

https://claude.ai/code/session_01516RBhJeytQVvqgddrKtWR