### PR TITLE
Add advanced search filters and sorting to SearchPage

### DIFF
--- a/apps/web/src/hooks/useSearchFilters.ts
+++ b/apps/web/src/hooks/useSearchFilters.ts
@@ -1,0 +1,149 @@
+import { useCallback, useMemo } from "react";
+import { useSearchParams } from "react-router-dom";
+
+export type FilterType = "all" | "movie" | "series";
+export type SortOption = "relevance" | "rating" | "year_desc" | "year_asc" | "title";
+export type RuntimeBucket = "" | "short" | "medium" | "long" | "epic";
+
+export type SearchFilters = {
+  query: string;
+  filter: FilterType;
+  genre: string;
+  yearMin: string;
+  yearMax: string;
+  ratingMin: string;
+  provider: string;
+  runtime: RuntimeBucket;
+  sort: SortOption;
+};
+
+const DEFAULTS: SearchFilters = {
+  query: "",
+  filter: "all",
+  genre: "",
+  yearMin: "",
+  yearMax: "",
+  ratingMin: "",
+  provider: "",
+  runtime: "",
+  sort: "relevance",
+};
+
+const VALID_FILTERS: FilterType[] = ["all", "movie", "series"];
+const VALID_SORTS: SortOption[] = ["relevance", "rating", "year_desc", "year_asc", "title"];
+const VALID_RUNTIMES: RuntimeBucket[] = ["", "short", "medium", "long", "epic"];
+
+export const RUNTIME_LABELS: Record<RuntimeBucket, string> = {
+  "": "Any",
+  short: "< 60 min",
+  medium: "60–120 min",
+  long: "120–180 min",
+  epic: "180+ min",
+};
+
+export const SORT_LABELS: Record<SortOption, string> = {
+  relevance: "Relevance",
+  rating: "Highest Rated",
+  year_desc: "Newest First",
+  year_asc: "Oldest First",
+  title: "Title A–Z",
+};
+
+export const GENRE_OPTIONS = [
+  "Action", "Adventure", "Animation", "Comedy", "Crime", "Documentary",
+  "Drama", "Family", "Fantasy", "History", "Horror", "Music",
+  "Mystery", "Romance", "Science Fiction", "Sci-Fi", "Thriller", "War", "Western",
+];
+
+export function useSearchFilters() {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const filters: SearchFilters = useMemo(() => {
+    const f = searchParams.get("filter") as FilterType;
+    const s = searchParams.get("sort") as SortOption;
+    const r = searchParams.get("runtime") as RuntimeBucket;
+    return {
+      query: searchParams.get("q") ?? DEFAULTS.query,
+      filter: VALID_FILTERS.includes(f) ? f : DEFAULTS.filter,
+      genre: searchParams.get("genre") ?? DEFAULTS.genre,
+      yearMin: searchParams.get("yearMin") ?? DEFAULTS.yearMin,
+      yearMax: searchParams.get("yearMax") ?? DEFAULTS.yearMax,
+      ratingMin: searchParams.get("ratingMin") ?? DEFAULTS.ratingMin,
+      provider: searchParams.get("provider") ?? DEFAULTS.provider,
+      runtime: VALID_RUNTIMES.includes(r) ? r : DEFAULTS.runtime,
+      sort: VALID_SORTS.includes(s) ? s : DEFAULTS.sort,
+    };
+  }, [searchParams]);
+
+  const setFilters = useCallback(
+    (updates: Partial<SearchFilters>) => {
+      setSearchParams((prev) => {
+        const next = new URLSearchParams(prev);
+        const merged = { ...filters, ...updates };
+
+        // Map state keys to URL param keys
+        const paramMap: Record<keyof SearchFilters, string> = {
+          query: "q",
+          filter: "filter",
+          genre: "genre",
+          yearMin: "yearMin",
+          yearMax: "yearMax",
+          ratingMin: "ratingMin",
+          provider: "provider",
+          runtime: "runtime",
+          sort: "sort",
+        };
+
+        for (const [key, paramName] of Object.entries(paramMap)) {
+          const val = merged[key as keyof SearchFilters];
+          const def = DEFAULTS[key as keyof SearchFilters];
+          if (val && val !== def) {
+            next.set(paramName, val);
+          } else {
+            next.delete(paramName);
+          }
+        }
+
+        return next;
+      }, { replace: true });
+    },
+    [filters, setSearchParams]
+  );
+
+  const clearFilters = useCallback(() => {
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      // Keep only query
+      const q = next.get("q");
+      for (const key of [...next.keys()]) {
+        if (key !== "q") next.delete(key);
+      }
+      return next;
+    }, { replace: true });
+  }, [setSearchParams]);
+
+  const hasActiveFilters = useMemo(() => {
+    return (
+      filters.genre !== DEFAULTS.genre ||
+      filters.yearMin !== DEFAULTS.yearMin ||
+      filters.yearMax !== DEFAULTS.yearMax ||
+      filters.ratingMin !== DEFAULTS.ratingMin ||
+      filters.provider !== DEFAULTS.provider ||
+      filters.runtime !== DEFAULTS.runtime ||
+      filters.sort !== DEFAULTS.sort
+    );
+  }, [filters]);
+
+  const activeFilterCount = useMemo(() => {
+    let count = 0;
+    if (filters.genre) count++;
+    if (filters.yearMin || filters.yearMax) count++;
+    if (filters.ratingMin) count++;
+    if (filters.provider) count++;
+    if (filters.runtime) count++;
+    if (filters.sort !== "relevance") count++;
+    return count;
+  }, [filters]);
+
+  return { filters, setFilters, clearFilters, hasActiveFilters, activeFilterCount };
+}

--- a/apps/web/src/hooks/useSearchFilters.ts
+++ b/apps/web/src/hooks/useSearchFilters.ts
@@ -55,46 +55,58 @@ export const GENRE_OPTIONS = [
   "Mystery", "Romance", "Sci-Fi", "Thriller", "War", "Western",
 ];
 
+const PARAM_MAP: Record<keyof SearchFilters, string> = {
+  query: "q",
+  filter: "filter",
+  genre: "genre",
+  yearMin: "yearMin",
+  yearMax: "yearMax",
+  ratingMin: "ratingMin",
+  provider: "provider",
+  runtime: "runtime",
+  sort: "sort",
+};
+
+function parseParams(params: URLSearchParams): SearchFilters {
+  const f = params.get("filter") as FilterType;
+  const s = params.get("sort") as SortOption;
+  const r = params.get("runtime") as RuntimeBucket;
+  return {
+    query: params.get("q") ?? DEFAULTS.query,
+    filter: VALID_FILTERS.includes(f) ? f : DEFAULTS.filter,
+    genre: params.get("genre") ?? DEFAULTS.genre,
+    yearMin: numericParam(params.get("yearMin"), DEFAULTS.yearMin),
+    yearMax: numericParam(params.get("yearMax"), DEFAULTS.yearMax),
+    ratingMin: numericParam(params.get("ratingMin"), DEFAULTS.ratingMin),
+    provider: params.get("provider") ?? DEFAULTS.provider,
+    runtime: VALID_RUNTIMES.includes(r) ? r : DEFAULTS.runtime,
+    sort: VALID_SORTS.includes(s) ? s : DEFAULTS.sort,
+  };
+}
+
+/** Return the string if it parses as a finite number, otherwise fallback. */
+function numericParam(raw: string | null, fallback: string): string {
+  if (raw == null) return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) ? raw : fallback;
+}
+
 export function useSearchFilters() {
   const [searchParams, setSearchParams] = useSearchParams();
 
-  const filters: SearchFilters = useMemo(() => {
-    const f = searchParams.get("filter") as FilterType;
-    const s = searchParams.get("sort") as SortOption;
-    const r = searchParams.get("runtime") as RuntimeBucket;
-    return {
-      query: searchParams.get("q") ?? DEFAULTS.query,
-      filter: VALID_FILTERS.includes(f) ? f : DEFAULTS.filter,
-      genre: searchParams.get("genre") ?? DEFAULTS.genre,
-      yearMin: searchParams.get("yearMin") ?? DEFAULTS.yearMin,
-      yearMax: searchParams.get("yearMax") ?? DEFAULTS.yearMax,
-      ratingMin: searchParams.get("ratingMin") ?? DEFAULTS.ratingMin,
-      provider: searchParams.get("provider") ?? DEFAULTS.provider,
-      runtime: VALID_RUNTIMES.includes(r) ? r : DEFAULTS.runtime,
-      sort: VALID_SORTS.includes(s) ? s : DEFAULTS.sort,
-    };
-  }, [searchParams]);
+  const filters: SearchFilters = useMemo(() => parseParams(searchParams), [searchParams]);
 
   const setFilters = useCallback(
     (updates: Partial<SearchFilters>) => {
       setSearchParams((prev) => {
-        const next = new URLSearchParams(prev);
-        const merged = { ...filters, ...updates };
+        // Derive base state from prev (not the captured filters closure)
+        // so back-to-back calls within the same render cycle don't lose updates.
+        const base = parseParams(prev);
+        const merged = { ...base, ...updates };
 
-        // Map state keys to URL param keys
-        const paramMap: Record<keyof SearchFilters, string> = {
-          query: "q",
-          filter: "filter",
-          genre: "genre",
-          yearMin: "yearMin",
-          yearMax: "yearMax",
-          ratingMin: "ratingMin",
-          provider: "provider",
-          runtime: "runtime",
-          sort: "sort",
-        };
+        const next = new URLSearchParams();
 
-        for (const [key, paramName] of Object.entries(paramMap)) {
+        for (const [key, paramName] of Object.entries(PARAM_MAP)) {
           const val = merged[key as keyof SearchFilters];
           const def = DEFAULTS[key as keyof SearchFilters];
           if (val && val !== def) {
@@ -107,7 +119,7 @@ export function useSearchFilters() {
         return next;
       }, { replace: true });
     },
-    [filters, setSearchParams]
+    [setSearchParams]
   );
 
   const clearFilters = useCallback(() => {

--- a/apps/web/src/hooks/useSearchFilters.ts
+++ b/apps/web/src/hooks/useSearchFilters.ts
@@ -113,10 +113,9 @@ export function useSearchFilters() {
   const clearFilters = useCallback(() => {
     setSearchParams((prev) => {
       const next = new URLSearchParams(prev);
-      // Keep only query
-      const q = next.get("q");
+      // Keep query and media type filter
       for (const key of [...next.keys()]) {
-        if (key !== "q") next.delete(key);
+        if (key !== "q" && key !== "filter") next.delete(key);
       }
       return next;
     }, { replace: true });
@@ -128,7 +127,6 @@ export function useSearchFilters() {
       filters.yearMin !== DEFAULTS.yearMin ||
       filters.yearMax !== DEFAULTS.yearMax ||
       filters.ratingMin !== DEFAULTS.ratingMin ||
-      filters.provider !== DEFAULTS.provider ||
       filters.runtime !== DEFAULTS.runtime ||
       filters.sort !== DEFAULTS.sort
     );
@@ -139,7 +137,6 @@ export function useSearchFilters() {
     if (filters.genre) count++;
     if (filters.yearMin || filters.yearMax) count++;
     if (filters.ratingMin) count++;
-    if (filters.provider) count++;
     if (filters.runtime) count++;
     if (filters.sort !== "relevance") count++;
     return count;

--- a/apps/web/src/hooks/useSearchFilters.ts
+++ b/apps/web/src/hooks/useSearchFilters.ts
@@ -127,7 +127,6 @@ export function useSearchFilters() {
       filters.yearMin !== DEFAULTS.yearMin ||
       filters.yearMax !== DEFAULTS.yearMax ||
       filters.ratingMin !== DEFAULTS.ratingMin ||
-      filters.runtime !== DEFAULTS.runtime ||
       filters.sort !== DEFAULTS.sort
     );
   }, [filters]);
@@ -137,7 +136,6 @@ export function useSearchFilters() {
     if (filters.genre) count++;
     if (filters.yearMin || filters.yearMax) count++;
     if (filters.ratingMin) count++;
-    if (filters.runtime) count++;
     if (filters.sort !== "relevance") count++;
     return count;
   }, [filters]);

--- a/apps/web/src/hooks/useSearchFilters.ts
+++ b/apps/web/src/hooks/useSearchFilters.ts
@@ -52,7 +52,7 @@ export const SORT_LABELS: Record<SortOption, string> = {
 export const GENRE_OPTIONS = [
   "Action", "Adventure", "Animation", "Comedy", "Crime", "Documentary",
   "Drama", "Family", "Fantasy", "History", "Horror", "Music",
-  "Mystery", "Romance", "Science Fiction", "Sci-Fi", "Thriller", "War", "Western",
+  "Mystery", "Romance", "Sci-Fi", "Thriller", "War", "Western",
 ];
 
 export function useSearchFilters() {

--- a/apps/web/src/pages/SearchPage.tsx
+++ b/apps/web/src/pages/SearchPage.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { FormEvent, useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 import { Check, ChevronDown, ChevronUp, Film, Filter, Plus, Search, SlidersHorizontal, Star, Tv, X, Heart } from "lucide-react";
 import { api, CatalogList, MediaType, SearchResult } from "../api";
 import { DetailPanel, useDetailPanel } from "../components/MediaDetailPanel";
@@ -67,7 +67,6 @@ function applyFiltersAndSort(
   yearMax: string,
   ratingMin: string,
   runtime: RuntimeBucket,
-  provider: string,
   sort: SortOption,
 ): SearchResult[] {
   let filtered = results;
@@ -97,9 +96,6 @@ function applyFiltersAndSort(
   if (runtime) {
     filtered = filtered.filter((r) => matchesRuntime(r.runtime, runtime));
   }
-
-  // Provider filter — not available in basic search results, reserved for future use
-  // if (provider) { ... }
 
   // Sort
   switch (sort) {
@@ -134,11 +130,11 @@ export function SearchPage() {
   const [toasts, setToasts] = useState<Toast[]>([]);
   const [openDropdown, setOpenDropdown] = useState<string | null>(null);
   const [filtersOpen, setFiltersOpen] = useState(false);
-  const [providers, setProviders] = useState<{ key: string; name: string }[]>([]);
   const { selectedItem, setSelectedItem, panelHistory, setPanelHistory, panelHistoryLoading } = useDetailPanel();
   const debounceRef = useRef<ReturnType<typeof setTimeout>>();
   const dropdownRef = useRef<HTMLDivElement>(null);
   const lastSearchRef = useRef<{ filter: FilterType; query: string }>({ filter: "all", query: "" });
+  const requestIdRef = useRef(0);
 
   const showToast = useCallback((message: string, type: Toast["type"] = "success") => {
     const id = ++toastId;
@@ -157,14 +153,6 @@ export function SearchPage() {
       } catch (err) {
         console.error(err);
         showToast(err instanceof Error ? err.message : "Failed to load lists", "error");
-      }
-    })();
-    void (async () => {
-      try {
-        const { providers: p } = await api.getStreamingProviders();
-        setProviders(p.map((x) => ({ key: x.key, name: x.name })));
-      } catch {
-        // Non-critical
       }
     })();
   }, [showToast]);
@@ -189,6 +177,7 @@ export function SearchPage() {
   const doSearch = useCallback(
     async (searchFilter: FilterType, searchQuery: string) => {
       if (!searchQuery.trim()) return;
+      const requestId = ++requestIdRef.current;
       setIsSearching(true);
       lastSearchRef.current = { filter: searchFilter, query: searchQuery };
 
@@ -198,6 +187,7 @@ export function SearchPage() {
             api.search("movie", searchQuery),
             api.search("series", searchQuery),
           ]);
+          if (requestIdRef.current !== requestId) return;
           const merged: SearchResult[] = [];
           const maxLen = Math.max(movies.length, series.length);
           for (let i = 0; i < maxLen; i++) {
@@ -207,13 +197,17 @@ export function SearchPage() {
           setRawResults(merged);
         } else {
           const response = await api.search(searchFilter, searchQuery);
+          if (requestIdRef.current !== requestId) return;
           setRawResults(response);
         }
       } catch (err) {
+        if (requestIdRef.current !== requestId) return;
         setRawResults([]);
         showToast(err instanceof Error ? err.message : "Search failed", "error");
       } finally {
-        setIsSearching(false);
+        if (requestIdRef.current === requestId) {
+          setIsSearching(false);
+        }
       }
     },
     [showToast]
@@ -229,10 +223,9 @@ export function SearchPage() {
       filters.yearMax,
       filters.ratingMin,
       filters.runtime,
-      filters.provider,
       filters.sort,
     );
-  }, [rawResults, filters.genre, filters.yearMin, filters.yearMax, filters.ratingMin, filters.runtime, filters.provider, filters.sort]);
+  }, [rawResults, filters.genre, filters.yearMin, filters.yearMax, filters.ratingMin, filters.runtime, filters.sort]);
 
   // Debounced auto-search on query/filter change
   useEffect(() => {
@@ -251,7 +244,7 @@ export function SearchPage() {
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current);
     };
-  }, [filters.query, filters.filter, doSearch]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [filters.query, filters.filter, doSearch]);
 
   const submitSearch = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -416,6 +409,7 @@ export function SearchPage() {
                 <input
                   type="number"
                   placeholder="From"
+                  aria-label="Minimum year"
                   min="1900"
                   max="2030"
                   value={filters.yearMin}
@@ -425,6 +419,7 @@ export function SearchPage() {
                 <input
                   type="number"
                   placeholder="To"
+                  aria-label="Maximum year"
                   min="1900"
                   max="2030"
                   value={filters.yearMax}
@@ -449,12 +444,13 @@ export function SearchPage() {
               ]}
             />
 
-            {/* Provider */}
+            {/* Provider — not yet available in search results */}
             <FilterSelect
               label="Provider"
-              value={filters.provider}
-              onChange={(v) => setFilters({ provider: v })}
-              options={[{ value: "", label: "Any provider" }, ...providers.map((p) => ({ value: p.key, label: p.name }))]}
+              value=""
+              onChange={() => {}}
+              disabled
+              options={[{ value: "", label: "Coming soon" }]}
             />
 
             {/* Runtime */}
@@ -586,19 +582,24 @@ function FilterSelect({
   value,
   onChange,
   options,
+  disabled,
 }: {
   label: string;
   value: string;
   onChange: (v: string) => void;
   options: { value: string; label: string }[];
+  disabled?: boolean;
 }) {
+  const id = useId();
   return (
     <div className="flex flex-col gap-1">
-      <label className="text-2xs font-medium uppercase tracking-wider text-slate-400">{label}</label>
+      <label htmlFor={id} className="text-2xs font-medium uppercase tracking-wider text-slate-400">{label}</label>
       <select
+        id={id}
         value={value}
+        disabled={disabled}
         onChange={(e) => onChange(e.target.value)}
-        className="rounded-lg border border-slate-700/60 bg-slate-900 px-2.5 py-2 text-sm text-slate-200 focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500/30 appearance-none cursor-pointer"
+        className="rounded-lg border border-slate-700/60 bg-slate-900 px-2.5 py-2 text-sm text-slate-200 focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500/30 appearance-none cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
         style={{
           backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%2394a3b8' stroke-width='2'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E")`,
           backgroundRepeat: "no-repeat",

--- a/apps/web/src/pages/SearchPage.tsx
+++ b/apps/web/src/pages/SearchPage.tsx
@@ -1,14 +1,12 @@
 import { FormEvent, useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 import { Check, ChevronDown, ChevronUp, Film, Filter, Plus, Search, SlidersHorizontal, Star, Tv, X, Heart } from "lucide-react";
-import { api, CatalogList, MediaType, SearchResult } from "../api";
+import { api, CatalogList, SearchResult } from "../api";
 import { DetailPanel, useDetailPanel } from "../components/MediaDetailPanel";
 import {
   useSearchFilters,
   FilterType,
-  RuntimeBucket,
   SortOption,
   GENRE_OPTIONS,
-  RUNTIME_LABELS,
   SORT_LABELS,
 } from "../hooks/useSearchFilters";
 
@@ -48,25 +46,12 @@ let toastId = 0;
 
 /* ─── Helpers ─── */
 
-function matchesRuntime(runtime: number | null | undefined, bucket: RuntimeBucket): boolean {
-  if (!bucket) return true;
-  if (runtime == null) return true; // Don't exclude items without runtime data
-  switch (bucket) {
-    case "short": return runtime < 60;
-    case "medium": return runtime >= 60 && runtime <= 120;
-    case "long": return runtime > 120 && runtime <= 180;
-    case "epic": return runtime > 180;
-    default: return true;
-  }
-}
-
 function applyFiltersAndSort(
   results: SearchResult[],
   genre: string,
   yearMin: string,
   yearMax: string,
   ratingMin: string,
-  runtime: RuntimeBucket,
   sort: SortOption,
 ): SearchResult[] {
   let filtered = results;
@@ -91,10 +76,6 @@ function applyFiltersAndSort(
   if (ratingMin) {
     const min = parseFloat(ratingMin);
     if (!isNaN(min)) filtered = filtered.filter((r) => r.rating != null && r.rating >= min);
-  }
-
-  if (runtime) {
-    filtered = filtered.filter((r) => matchesRuntime(r.runtime, runtime));
   }
 
   // Sort
@@ -222,15 +203,18 @@ export function SearchPage() {
       filters.yearMin,
       filters.yearMax,
       filters.ratingMin,
-      filters.runtime,
       filters.sort,
     );
-  }, [rawResults, filters.genre, filters.yearMin, filters.yearMax, filters.ratingMin, filters.runtime, filters.sort]);
+  }, [rawResults, filters.genre, filters.yearMin, filters.yearMax, filters.ratingMin, filters.sort]);
 
   // Debounced auto-search on query/filter change
   useEffect(() => {
+    // Invalidate any in-flight request so its response is discarded
+    ++requestIdRef.current;
+
     if (!filters.query.trim()) {
       setRawResults(null);
+      setIsSearching(false);
       return;
     }
     // Only re-search if query or media type filter changed
@@ -453,12 +437,13 @@ export function SearchPage() {
               options={[{ value: "", label: "Coming soon" }]}
             />
 
-            {/* Runtime */}
+            {/* Runtime — not available in search results */}
             <FilterSelect
               label="Runtime"
-              value={filters.runtime}
-              onChange={(v) => setFilters({ runtime: v as RuntimeBucket })}
-              options={Object.entries(RUNTIME_LABELS).map(([value, label]) => ({ value, label }))}
+              value=""
+              onChange={() => {}}
+              disabled
+              options={[{ value: "", label: "Coming soon" }]}
             />
 
             {/* Sort */}

--- a/apps/web/src/pages/SearchPage.tsx
+++ b/apps/web/src/pages/SearchPage.tsx
@@ -1,9 +1,16 @@
 import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Check, Film, Plus, Search, Star, Tv, X, Heart } from "lucide-react";
+import { Check, ChevronDown, ChevronUp, Film, Filter, Plus, Search, SlidersHorizontal, Star, Tv, X, Heart } from "lucide-react";
 import { api, CatalogList, MediaType, SearchResult } from "../api";
 import { DetailPanel, useDetailPanel } from "../components/MediaDetailPanel";
-
-type FilterType = "all" | MediaType;
+import {
+  useSearchFilters,
+  FilterType,
+  RuntimeBucket,
+  SortOption,
+  GENRE_OPTIONS,
+  RUNTIME_LABELS,
+  SORT_LABELS,
+} from "../hooks/useSearchFilters";
 
 /* ─── Toast System ─── */
 
@@ -39,18 +46,99 @@ function ToastContainer({ toasts, onRemove }: { toasts: Toast[]; onRemove: (id: 
 type Toast = { id: number; message: string; type: "success" | "error" | "info" };
 let toastId = 0;
 
+/* ─── Helpers ─── */
+
+function matchesRuntime(runtime: number | null | undefined, bucket: RuntimeBucket): boolean {
+  if (!bucket) return true;
+  if (runtime == null) return true; // Don't exclude items without runtime data
+  switch (bucket) {
+    case "short": return runtime < 60;
+    case "medium": return runtime >= 60 && runtime <= 120;
+    case "long": return runtime > 120 && runtime <= 180;
+    case "epic": return runtime > 180;
+    default: return true;
+  }
+}
+
+function applyFiltersAndSort(
+  results: SearchResult[],
+  genre: string,
+  yearMin: string,
+  yearMax: string,
+  ratingMin: string,
+  runtime: RuntimeBucket,
+  provider: string,
+  sort: SortOption,
+): SearchResult[] {
+  let filtered = results;
+
+  if (genre) {
+    const g = genre.toLowerCase();
+    filtered = filtered.filter((r) =>
+      r.genres.some((rg) => rg.toLowerCase() === g)
+    );
+  }
+
+  if (yearMin) {
+    const min = parseInt(yearMin, 10);
+    if (!isNaN(min)) filtered = filtered.filter((r) => r.year != null && r.year >= min);
+  }
+
+  if (yearMax) {
+    const max = parseInt(yearMax, 10);
+    if (!isNaN(max)) filtered = filtered.filter((r) => r.year != null && r.year <= max);
+  }
+
+  if (ratingMin) {
+    const min = parseFloat(ratingMin);
+    if (!isNaN(min)) filtered = filtered.filter((r) => r.rating != null && r.rating >= min);
+  }
+
+  if (runtime) {
+    filtered = filtered.filter((r) => matchesRuntime(r.runtime, runtime));
+  }
+
+  // Provider filter — not available in basic search results, reserved for future use
+  // if (provider) { ... }
+
+  // Sort
+  switch (sort) {
+    case "rating":
+      filtered = [...filtered].sort((a, b) => (b.rating ?? 0) - (a.rating ?? 0));
+      break;
+    case "year_desc":
+      filtered = [...filtered].sort((a, b) => (b.year ?? 0) - (a.year ?? 0));
+      break;
+    case "year_asc":
+      filtered = [...filtered].sort((a, b) => (a.year ?? 0) - (b.year ?? 0));
+      break;
+    case "title":
+      filtered = [...filtered].sort((a, b) => a.name.localeCompare(b.name));
+      break;
+    case "relevance":
+    default:
+      break;
+  }
+
+  return filtered;
+}
+
+/* ─── Main Component ─── */
+
 export function SearchPage() {
-  const [query, setQuery] = useState("");
-  const [filter, setFilter] = useState<FilterType>("all");
-  const [results, setResults] = useState<SearchResult[] | null>(null);
+  const { filters, setFilters, clearFilters, hasActiveFilters, activeFilterCount } = useSearchFilters();
+  const [rawResults, setRawResults] = useState<SearchResult[] | null>(null);
   const [isSearching, setIsSearching] = useState(false);
   const [lists, setLists] = useState<CatalogList[]>([]);
   const [pendingAdds, setPendingAdds] = useState<Record<string, boolean>>({});
   const [toasts, setToasts] = useState<Toast[]>([]);
   const [openDropdown, setOpenDropdown] = useState<string | null>(null);
+  const [filtersOpen, setFiltersOpen] = useState(false);
+  const [providers, setProviders] = useState<{ key: string; name: string }[]>([]);
   const { selectedItem, setSelectedItem, panelHistory, setPanelHistory, panelHistoryLoading } = useDetailPanel();
   const debounceRef = useRef<ReturnType<typeof setTimeout>>();
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const lastSearchRef = useRef<{ filter: FilterType; query: string }>({ filter: "all", query: "" });
 
   const showToast = useCallback((message: string, type: Toast["type"] = "success") => {
     const id = ++toastId;
@@ -60,7 +148,7 @@ export function SearchPage() {
     }, 3000);
   }, []);
 
-  // Load lists on mount
+  // Load lists + providers on mount
   useEffect(() => {
     void (async () => {
       try {
@@ -69,6 +157,14 @@ export function SearchPage() {
       } catch (err) {
         console.error(err);
         showToast(err instanceof Error ? err.message : "Failed to load lists", "error");
+      }
+    })();
+    void (async () => {
+      try {
+        const { providers: p } = await api.getStreamingProviders();
+        setProviders(p.map((x) => ({ key: x.key, name: x.name })));
+      } catch {
+        // Non-critical
       }
     })();
   }, [showToast]);
@@ -84,7 +180,6 @@ export function SearchPage() {
     return () => document.removeEventListener("mousedown", handler);
   }, []);
 
-
   const listMap = useMemo(() => {
     const map = new Map<string, CatalogList>();
     for (const l of lists) map.set(l.id, l);
@@ -95,6 +190,7 @@ export function SearchPage() {
     async (searchFilter: FilterType, searchQuery: string) => {
       if (!searchQuery.trim()) return;
       setIsSearching(true);
+      lastSearchRef.current = { filter: searchFilter, query: searchQuery };
 
       try {
         if (searchFilter === "all") {
@@ -102,20 +198,19 @@ export function SearchPage() {
             api.search("movie", searchQuery),
             api.search("series", searchQuery),
           ]);
-          // Interleave: movie, series, movie, series...
           const merged: SearchResult[] = [];
           const maxLen = Math.max(movies.length, series.length);
           for (let i = 0; i < maxLen; i++) {
             if (i < movies.length) merged.push(movies[i]);
             if (i < series.length) merged.push(series[i]);
           }
-          setResults(merged);
+          setRawResults(merged);
         } else {
           const response = await api.search(searchFilter, searchQuery);
-          setResults(response);
+          setRawResults(response);
         }
       } catch (err) {
-        setResults([]);
+        setRawResults([]);
         showToast(err instanceof Error ? err.message : "Search failed", "error");
       } finally {
         setIsSearching(false);
@@ -124,25 +219,44 @@ export function SearchPage() {
     [showToast]
   );
 
-  // Debounced auto-search (300ms)
+  // Filtered + sorted results
+  const results = useMemo(() => {
+    if (!rawResults) return null;
+    return applyFiltersAndSort(
+      rawResults,
+      filters.genre,
+      filters.yearMin,
+      filters.yearMax,
+      filters.ratingMin,
+      filters.runtime,
+      filters.provider,
+      filters.sort,
+    );
+  }, [rawResults, filters.genre, filters.yearMin, filters.yearMax, filters.ratingMin, filters.runtime, filters.provider, filters.sort]);
+
+  // Debounced auto-search on query/filter change
   useEffect(() => {
-    if (!query.trim()) {
-      setResults(null);
+    if (!filters.query.trim()) {
+      setRawResults(null);
       return;
     }
+    // Only re-search if query or media type filter changed
+    const last = lastSearchRef.current;
+    if (last.query === filters.query && last.filter === filters.filter && rawResults !== null) return;
+
     if (debounceRef.current) clearTimeout(debounceRef.current);
     debounceRef.current = setTimeout(() => {
-      void doSearch(filter, query);
+      void doSearch(filters.filter, filters.query);
     }, 300);
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current);
     };
-  }, [query, filter, doSearch]);
+  }, [filters.query, filters.filter, doSearch]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const submitSearch = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     if (debounceRef.current) clearTimeout(debounceRef.current);
-    await doSearch(filter, query);
+    await doSearch(filters.filter, filters.query);
   };
 
   const handleAdd = async (listId: string, result: SearchResult) => {
@@ -155,16 +269,12 @@ export function SearchPage() {
       await api.addToList(listId, { type: result.type, imdbId: result.imdbId, title: result.name });
       const listName = listMap.get(listId)?.name ?? "list";
       showToast(`Added "${result.name}" to ${listName}`, "success");
-      // Update local lists state to reflect the addition
       setLists((prev) =>
         prev.map((l) =>
-          l.id === listId
-            ? { ...l, itemCount: l.itemCount + 1 }
-            : l
+          l.id === listId ? { ...l, itemCount: l.itemCount + 1 } : l
         )
       );
-      // Update search results to include the new list
-      setResults((prev) =>
+      setRawResults((prev) =>
         prev?.map((r) =>
           r.imdbId === result.imdbId ? { ...r, lists: [...r.lists, listId] } : r
         ) ?? null
@@ -183,7 +293,19 @@ export function SearchPage() {
     { value: "series", label: "Series", icon: Tv },
   ];
 
-  const hasSearched = results !== null;
+  // Collect genres from current results for smart suggestions
+  const availableGenres = useMemo(() => {
+    if (!rawResults) return GENRE_OPTIONS;
+    const found = new Set<string>();
+    for (const r of rawResults) {
+      for (const g of r.genres) found.add(g);
+    }
+    // Merge with common genres, prioritizing found ones
+    const all = [...found, ...GENRE_OPTIONS.filter((g) => !found.has(g))];
+    return all;
+  }, [rawResults]);
+
+  const hasSearched = rawResults !== null;
   const noResults = hasSearched && (results?.length ?? 0) === 0;
 
   return (
@@ -196,16 +318,16 @@ export function SearchPage() {
         <div className="relative">
           <Search className="pointer-events-none absolute left-5 top-1/2 h-5 w-5 -translate-y-1/2 text-slate-400" />
           <input
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
+            value={filters.query}
+            onChange={(e) => setFilters({ query: e.target.value })}
             placeholder="Search movies & TV shows..."
             className="w-full rounded-full border border-slate-700/60 bg-slate-950 py-3.5 pl-14 pr-12 text-base placeholder:text-slate-400 focus:border-red-500 focus:outline-none focus:ring-2 focus:ring-red-500/15 transition-all"
             autoFocus
           />
-          {query && (
+          {filters.query && (
             <button
               type="button"
-              onClick={() => { setQuery(""); setResults(null); }}
+              onClick={() => { setFilters({ query: "" }); setRawResults(null); }}
               className="absolute right-4 top-1/2 -translate-y-1/2 flex h-6 w-6 items-center justify-center rounded-full bg-slate-600 text-xs font-bold text-slate-950 hover:bg-slate-400 transition-colors"
             >
               <X className="h-3.5 w-3.5" />
@@ -213,17 +335,17 @@ export function SearchPage() {
           )}
         </div>
 
-        {/* Filter pills */}
-        <div className="mt-3 flex items-center gap-2">
+        {/* Filter pills + advanced toggle */}
+        <div className="mt-3 flex items-center gap-2 flex-wrap">
           <div className="flex rounded-full border border-slate-700/60 bg-slate-800/60 p-1">
             {filterOptions.map((opt) => {
               const Icon = opt.icon;
-              const active = filter === opt.value;
+              const active = filters.filter === opt.value;
               return (
                 <button
                   key={opt.value}
                   type="button"
-                  onClick={() => setFilter(opt.value)}
+                  onClick={() => setFilters({ filter: opt.value })}
                   className={`flex items-center gap-1.5 rounded-full px-4 py-1.5 text-sm font-medium transition-all ${
                     active
                       ? "bg-red-500 text-white shadow-lg shadow-red-500/25"
@@ -236,6 +358,38 @@ export function SearchPage() {
               );
             })}
           </div>
+
+          {/* Advanced filters toggle */}
+          <button
+            type="button"
+            onClick={() => setFiltersOpen((v) => !v)}
+            className={`flex items-center gap-1.5 rounded-full border px-3.5 py-1.5 text-sm font-medium transition-all ${
+              hasActiveFilters
+                ? "border-red-500/50 bg-red-500/10 text-red-400"
+                : "border-slate-700/60 bg-slate-800/60 text-slate-400 hover:text-white"
+            }`}
+          >
+            <SlidersHorizontal className="h-3.5 w-3.5" />
+            <span className="hidden sm:inline">Filters</span>
+            {activeFilterCount > 0 && (
+              <span className="flex h-5 w-5 items-center justify-center rounded-full bg-red-500 text-2xs font-bold text-white">
+                {activeFilterCount}
+              </span>
+            )}
+            {filtersOpen ? <ChevronUp className="h-3.5 w-3.5" /> : <ChevronDown className="h-3.5 w-3.5" />}
+          </button>
+
+          {hasActiveFilters && (
+            <button
+              type="button"
+              onClick={clearFilters}
+              className="flex items-center gap-1 rounded-full px-3 py-1.5 text-sm text-slate-400 hover:text-white transition-colors"
+            >
+              <X className="h-3 w-3" />
+              Clear
+            </button>
+          )}
+
           {isSearching && (
             <span className="ml-auto flex items-center gap-2 text-sm text-slate-400">
               <span className="inline-block h-4 w-4 animate-spin rounded-full border-2 border-red-500 border-t-transparent" />
@@ -243,6 +397,83 @@ export function SearchPage() {
             </span>
           )}
         </div>
+
+        {/* Advanced filters panel */}
+        {filtersOpen && (
+          <div className="mt-3 grid grid-cols-2 gap-3 rounded-xl border border-slate-700/40 bg-slate-800/40 p-3 sm:grid-cols-3 lg:grid-cols-6">
+            {/* Genre */}
+            <FilterSelect
+              label="Genre"
+              value={filters.genre}
+              onChange={(v) => setFilters({ genre: v })}
+              options={[{ value: "", label: "Any genre" }, ...availableGenres.map((g) => ({ value: g, label: g }))]}
+            />
+
+            {/* Year range */}
+            <div className="flex flex-col gap-1">
+              <label className="text-2xs font-medium uppercase tracking-wider text-slate-400">Year</label>
+              <div className="flex gap-1.5">
+                <input
+                  type="number"
+                  placeholder="From"
+                  min="1900"
+                  max="2030"
+                  value={filters.yearMin}
+                  onChange={(e) => setFilters({ yearMin: e.target.value })}
+                  className="w-full rounded-lg border border-slate-700/60 bg-slate-900 px-2.5 py-2 text-sm text-slate-200 placeholder:text-slate-500 focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500/30"
+                />
+                <input
+                  type="number"
+                  placeholder="To"
+                  min="1900"
+                  max="2030"
+                  value={filters.yearMax}
+                  onChange={(e) => setFilters({ yearMax: e.target.value })}
+                  className="w-full rounded-lg border border-slate-700/60 bg-slate-900 px-2.5 py-2 text-sm text-slate-200 placeholder:text-slate-500 focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500/30"
+                />
+              </div>
+            </div>
+
+            {/* Min rating */}
+            <FilterSelect
+              label="Min Rating"
+              value={filters.ratingMin}
+              onChange={(v) => setFilters({ ratingMin: v })}
+              options={[
+                { value: "", label: "Any rating" },
+                { value: "9", label: "9+ Exceptional" },
+                { value: "8", label: "8+ Great" },
+                { value: "7", label: "7+ Good" },
+                { value: "6", label: "6+ Decent" },
+                { value: "5", label: "5+ Average" },
+              ]}
+            />
+
+            {/* Provider */}
+            <FilterSelect
+              label="Provider"
+              value={filters.provider}
+              onChange={(v) => setFilters({ provider: v })}
+              options={[{ value: "", label: "Any provider" }, ...providers.map((p) => ({ value: p.key, label: p.name }))]}
+            />
+
+            {/* Runtime */}
+            <FilterSelect
+              label="Runtime"
+              value={filters.runtime}
+              onChange={(v) => setFilters({ runtime: v as RuntimeBucket })}
+              options={Object.entries(RUNTIME_LABELS).map(([value, label]) => ({ value, label }))}
+            />
+
+            {/* Sort */}
+            <FilterSelect
+              label="Sort by"
+              value={filters.sort}
+              onChange={(v) => setFilters({ sort: v as SortOption })}
+              options={Object.entries(SORT_LABELS).map(([value, label]) => ({ value, label }))}
+            />
+          </div>
+        )}
       </form>
 
       {/* Empty state – no search yet */}
@@ -262,18 +493,53 @@ export function SearchPage() {
       {noResults && (
         <div className="flex flex-col items-center justify-center py-20 text-center">
           <div className="flex h-24 w-24 items-center justify-center rounded-full bg-slate-900 ring-1 ring-slate-800">
-            <Search className="h-12 w-12 text-slate-700" />
+            <Filter className="h-12 w-12 text-slate-700" />
           </div>
           <p className="mt-5 text-lg font-semibold text-slate-300">No results found</p>
-          <p className="mt-1 text-sm text-slate-400">Try a different search term or filter.</p>
+          <p className="mt-1 text-sm text-slate-400">
+            {hasActiveFilters
+              ? "Try adjusting your filters or search term."
+              : "Try a different search term or filter."}
+          </p>
+          {hasActiveFilters && (
+            <button
+              onClick={clearFilters}
+              className="mt-3 rounded-full border border-slate-700/60 px-4 py-2 text-sm font-medium text-slate-300 hover:bg-slate-800 transition-colors"
+            >
+              Clear all filters
+            </button>
+          )}
         </div>
       )}
 
       {/* Results grid */}
-      {hasSearched && results.length > 0 && (
+      {hasSearched && results !== null && results.length > 0 && (
         <>
           <div className="flex items-center justify-between">
-            <p className="text-sm text-slate-400">{results.length} results</p>
+            <p className="text-sm text-slate-400">
+              {results.length} result{results.length !== 1 ? "s" : ""}
+              {rawResults && results.length !== rawResults.length && (
+                <span className="text-slate-500"> (filtered from {rawResults.length})</span>
+              )}
+            </p>
+            {/* Inline sort shortcut on desktop */}
+            <div className="hidden sm:flex items-center gap-2">
+              <span className="text-2xs text-slate-500">Sort:</span>
+              {(["relevance", "rating", "year_desc", "title"] as const).map((s) => (
+                <button
+                  key={s}
+                  type="button"
+                  onClick={() => setFilters({ sort: s })}
+                  className={`rounded-full px-2.5 py-1 text-2xs font-medium transition-all ${
+                    filters.sort === s
+                      ? "bg-slate-700 text-white"
+                      : "text-slate-400 hover:text-white"
+                  }`}
+                >
+                  {SORT_LABELS[s]}
+                </button>
+              ))}
+            </div>
           </div>
           <div className="grid grid-cols-2 gap-5 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
             {results.map((result) => (
@@ -309,6 +575,41 @@ export function SearchPage() {
 
       {/* Toast notifications */}
       <ToastContainer toasts={toasts} onRemove={(id) => setToasts((prev) => prev.filter((t) => t.id !== id))} />
+    </div>
+  );
+}
+
+/* ─── Filter Select ─── */
+
+function FilterSelect({
+  label,
+  value,
+  onChange,
+  options,
+}: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  options: { value: string; label: string }[];
+}) {
+  return (
+    <div className="flex flex-col gap-1">
+      <label className="text-2xs font-medium uppercase tracking-wider text-slate-400">{label}</label>
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="rounded-lg border border-slate-700/60 bg-slate-900 px-2.5 py-2 text-sm text-slate-200 focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500/30 appearance-none cursor-pointer"
+        style={{
+          backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%2394a3b8' stroke-width='2'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E")`,
+          backgroundRepeat: "no-repeat",
+          backgroundPosition: "right 10px center",
+          paddingRight: "2rem",
+        }}
+      >
+        {options.map((opt) => (
+          <option key={opt.value} value={opt.value}>{opt.label}</option>
+        ))}
+      </select>
     </div>
   );
 }
@@ -474,4 +775,3 @@ function ResultCard({
     </div>
   );
 }
-


### PR DESCRIPTION
## Summary
Refactored the search functionality to support advanced filtering and sorting capabilities. Extracted filter state management into a custom hook that persists filters to URL search parameters, enabling shareable search URLs and better UX.

## Key Changes

- **New `useSearchFilters` hook** (`apps/web/src/hooks/useSearchFilters.ts`):
  - Manages all filter state (query, media type, genre, year range, rating, provider, runtime, sort)
  - Persists filters to URL search parameters for bookmarkable/shareable searches
  - Provides `setFilters`, `clearFilters`, and helper flags (`hasActiveFilters`, `activeFilterCount`)
  - Validates filter values against allowed options

- **Enhanced SearchPage component**:
  - Integrated `useSearchFilters` hook to replace local state management
  - Added `applyFiltersAndSort()` function to filter and sort results client-side
  - Added `matchesRuntime()` helper for runtime bucket filtering
  - Implemented collapsible advanced filters panel with genre, year range, min rating, provider, runtime, and sort options
  - Added inline sort shortcuts on desktop for quick sorting
  - Improved empty state messaging to reflect active filters
  - Added visual indicators (badge) showing count of active filters
  - Added "Clear filters" button for easy reset
  - Separated raw search results from filtered/sorted results using `rawResults` and `results`
  - Added smart genre suggestions based on current search results
  - Loads streaming providers on mount for provider filter options

- **UI/UX Improvements**:
  - Filter toggle button with chevron icon and active filter count badge
  - Responsive filter grid (2 cols mobile, 3 cols tablet, 6 cols desktop)
  - Better visual feedback for active filters (red highlight)
  - Result count now shows filtered vs. total when filters are applied
  - Debounced search only re-runs when query or media type filter changes

## Implementation Details

- Filters are stored in URL search parameters (e.g., `?q=batman&genre=Action&sort=rating`), allowing users to share filtered search results
- Client-side filtering/sorting is applied to search results without additional API calls
- Provider filter is reserved for future use (API support not yet available)
- Runtime filtering uses predefined buckets: short (<60min), medium (60-120min), long (120-180min), epic (180+min)
- Genre options are merged with genres found in current results for smart suggestions

https://claude.ai/code/session_01DqqNCqQtnx7Bpd476UcUJj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Advanced filters panel with Genre, Year range, Min Rating, disabled Provider/Runtime selects, and Sort
  * Filters persist in the URL, show an active-filter count, and a “Clear all filters” action
  * Results header shows total and optional “(filtered from N)”

* **Improvements**
  * Debounced auto-search that avoids stale overwrites
  * Client-side filtering/sorting for consistent, faster updates after adding items
<!-- end of auto-generated comment: release notes by coderabbit.ai -->