### PR TITLE
Allow CORS from private/LAN IP origins (192.168.x, 10.x, 172.16-31.x)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -182,7 +182,12 @@ const MAX_STREMIO_LIMIT = 200;
 const isLocalOrigin = (origin: string) => {
   try {
     const { hostname } = new URL(origin);
-    return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
+    return hostname === "localhost"
+      || hostname === "127.0.0.1"
+      || hostname === "::1"
+      || hostname.startsWith("192.168.")
+      || hostname.startsWith("10.")
+      || /^172\.(1[6-9]|2\d|3[01])\./.test(hostname);
   } catch {
     return false;
   }


### PR DESCRIPTION
isLocalOrigin only matched localhost/127.0.0.1/::1, so when the web UI at localhost:7002 made requests to the API at a LAN IP like 192.168.1.20:7000, preflight requests failed with no Access-Control-Allow-Origin header. Extend the check to also allow RFC 1918 private network addresses.

https://claude.ai/code/session_01DqqNCqQtnx7Bpd476UcUJj