### PR TITLE
Fix CORS: always allow local/private-network origins regardless of NO…

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -208,17 +208,24 @@ const isAllowedOrigin = (origin: string | undefined) => {
 const applyCorsHeaders = (request: FastifyRequest, reply: FastifyReply) => {
   const origin = request.headers.origin;
 
-  if (!isAllowedOrigin(origin)) {
+  // Always allow CORS for local/private-network origins, and in dev mode.
+  // For self-hosted setups where NODE_ENV may not be set, this ensures
+  // the web UI can always reach the API on the same LAN.
+  if (IS_DEVELOPMENT || (origin && isLocalOrigin(origin))) {
+    reply.header("Access-Control-Allow-Origin", origin ?? "*");
+    reply.header("Access-Control-Allow-Methods", CORS_METHODS);
+    reply.header("Access-Control-Allow-Headers", CORS_HEADERS);
     return;
   }
 
-  reply.header("Access-Control-Allow-Origin", IS_DEVELOPMENT ? "*" : origin!);
+  if (!origin || !ALLOWED_ORIGINS.includes(origin)) {
+    return;
+  }
+
+  reply.header("Access-Control-Allow-Origin", origin);
   reply.header("Access-Control-Allow-Methods", CORS_METHODS);
   reply.header("Access-Control-Allow-Headers", CORS_HEADERS);
-
-  if (!IS_DEVELOPMENT) {
-    reply.header("Vary", "Origin");
-  }
+  reply.header("Vary", "Origin");
 };
 
 const toSha256Digest = (value: string) => createHash("sha256").update(value).digest();


### PR DESCRIPTION
…DE_ENV

The previous CORS logic relied on isAllowedOrigin which only bypassed checks when NODE_ENV=development. In self-hosted setups where NODE_ENV is unset, the origin check fell through to production validation even for localhost requests — causing preflight failures.

Restructure applyCorsHeaders to directly allow any local/private origin (localhost, 127.0.0.1, RFC 1918 IPs) without depending on NODE_ENV. Production origins still require explicit ALLOWED_ORIGINS.

https://claude.ai/code/session_01DqqNCqQtnx7Bpd476UcUJj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened API security by implementing stricter cross-origin request validation that requires approved origins in production environments, while maintaining full support for local and private network requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->