### PR TITLE
Add Docker image publishing workflow and update compose config

### DIFF
--- a/.github/workflows/dockerpublish.yml
+++ b/.github/workflows/dockerpublish.yml
@@ -1,0 +1,62 @@
+name: Build and Publish Docker Images
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_PREFIX: ghcr.io/theshield2594/cataloggy
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push API image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: apps/api/Dockerfile
+          push: true
+          tags: ${{ env.IMAGE_PREFIX }}-api:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and push Addon image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: apps/addon/Dockerfile
+          push: true
+          tags: ${{ env.IMAGE_PREFIX }}-addon:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and push Web image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: apps/web/Dockerfile
+          push: true
+          tags: ${{ env.IMAGE_PREFIX }}-web:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,9 +18,7 @@ services:
       - cataloggy
 
   api:
-    build:
-      context: .
-      dockerfile: apps/api/Dockerfile
+    image: ghcr.io/theshield2594/cataloggy-api:latest
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@db:5432/${POSTGRES_DB:-cataloggy}
       PORT: "7000"
@@ -52,9 +50,7 @@ services:
       - cataloggy
 
   addon:
-    build:
-      context: .
-      dockerfile: apps/addon/Dockerfile
+    image: ghcr.io/theshield2594/cataloggy-addon:latest
     environment:
       PORT: "7001"
       CATALOGGY_API_BASE: http://api:7000
@@ -75,9 +71,7 @@ services:
       - cataloggy
 
   web:
-    build:
-      context: .
-      dockerfile: apps/web/Dockerfile
+    image: ghcr.io/theshield2594/cataloggy-web:latest
     environment:
       VITE_API_BASE: ${VITE_API_BASE:-http://192.168.1.20:7000}
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,14 +23,14 @@ services:
       DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@db:5432/${POSTGRES_DB:-cataloggy}
       PORT: "7000"
       API_TOKEN: ${API_TOKEN:-dev-token}
-      CATALOGGY_ALLOWED_ORIGINS: ${CATALOGGY_ALLOWED_ORIGINS:-http://192.168.1.20:7002}
-      CATALOGGY_API_PUBLIC: ${CATALOGGY_API_PUBLIC:-http://192.168.1.20:7000}
+      CATALOGGY_ALLOWED_ORIGINS: ${CATALOGGY_ALLOWED_ORIGINS:-http://192.168.1.25:7002}
+      CATALOGGY_API_PUBLIC: ${CATALOGGY_API_PUBLIC:-http://192.168.1.25:7000}
       # Optional integrations — set these in a .env file or export them.
       # Leaving them unset is safe; the API validates at startup/request time
       # and returns clear error messages if they are missing when needed.
       TRAKT_CLIENT_ID: ${TRAKT_CLIENT_ID}
       TRAKT_CLIENT_SECRET: ${TRAKT_CLIENT_SECRET}
-      TRAKT_REDIRECT_URI: ${TRAKT_REDIRECT_URI:-http://192.168.1.20:7000/trakt/oauth/callback}
+      TRAKT_REDIRECT_URI: ${TRAKT_REDIRECT_URI:-http://192.168.1.25:7000/trakt/oauth/callback}
       TRAKT_POLL_INTERVAL_SEC: ${TRAKT_POLL_INTERVAL_SEC:-300}
       TRAKT_POLL_MAX_PAGES: ${TRAKT_POLL_MAX_PAGES:-20}
       TMDB_API_KEY: ${TMDB_API_KEY}
@@ -55,7 +55,7 @@ services:
       PORT: "7001"
       CATALOGGY_API_BASE: http://api:7000
       CATALOGGY_API_TOKEN: ${API_TOKEN:-dev-token}
-      ADDON_PUBLIC_BASE: ${ADDON_PUBLIC_BASE:-http://192.168.1.20:7001}
+      ADDON_PUBLIC_BASE: ${ADDON_PUBLIC_BASE:-http://192.168.1.25:7001}
     ports:
       - "7001:7001"
     depends_on:
@@ -73,7 +73,7 @@ services:
   web:
     image: ghcr.io/theshield2594/cataloggy-web:latest
     environment:
-      VITE_API_BASE: ${VITE_API_BASE:-http://192.168.1.20:7000}
+      VITE_API_BASE: ${VITE_API_BASE:-http://192.168.1.25:7000}
     ports:
       - "7002:7002"
     depends_on:


### PR DESCRIPTION
## Summary
This PR introduces automated Docker image building and publishing to GitHub Container Registry (GHCR), and updates the docker-compose configuration to use pre-built images instead of building locally.

## Key Changes
- **Added GitHub Actions workflow** (`.github/workflows/dockerpublish.yml`):
  - Automatically builds and publishes Docker images for API, Addon, and Web services to GHCR
  - Triggered on pushes to `main` branch and manual workflow dispatch
  - Uses Docker Buildx with GitHub Actions cache for optimized builds
  - Publishes images with `-api`, `-addon`, and `-web` suffixes to `ghcr.io/theshield2594/cataloggy`

- **Updated docker-compose.yml**:
  - Replaced local `build` configurations with pre-built image references from GHCR
  - Updated default IP addresses from `192.168.1.20` to `192.168.1.25` across all services (API, Addon, and Web)
  - Maintains all existing environment variable configurations and service dependencies

## Implementation Details
- The workflow uses GitHub's built-in `GITHUB_TOKEN` for authentication with GHCR
- Docker layer caching is configured to use GitHub Actions cache backend for faster subsequent builds
- All three application services (API, Addon, Web) are built and published in a single workflow run
- The docker-compose configuration now expects images to be available in GHCR, enabling faster local deployments without rebuild overhead

https://claude.ai/code/session_01WwUTM9vzRSKF8cbc235rUd