### PR TITLE
Configure allowed hosts for Vite dev and preview servers

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -41,10 +41,12 @@ export default defineConfig({
   ],
   server: {
     host: "0.0.0.0",
-    port: 7002
+    port: 7002,
+    allowedHosts: ["cataloggy.shieldsfam.lol"]
   },
   preview: {
     host: "0.0.0.0",
-    port: 7002
+    port: 7002,
+    allowedHosts: ["cataloggy.shieldsfam.lol"]
   }
 });


### PR DESCRIPTION
## Summary
Added host allowlist configuration to the Vite development and preview servers to restrict access to a specific domain.

## Changes
- Added `allowedHosts: ["cataloggy.shieldsfam.lol"]` to the `server` configuration block
- Added `allowedHosts: ["cataloggy.shieldsfam.lol"]` to the `preview` configuration block

## Details
This change configures Vite's host validation for both development and preview servers, allowing requests only from the specified domain `cataloggy.shieldsfam.lol`. This improves security by preventing access from arbitrary hosts while the development server is running.

https://claude.ai/code/session_012dRe8wPmmfAXFhhcuW5ABf