### PR TITLE
Add X-Profile-Id to CORS allowed headers

### DIFF
--- a/apps/api/src/lib/cors.ts
+++ b/apps/api/src/lib/cors.ts
@@ -11,7 +11,7 @@ export const ALLOWED_ORIGINS = IS_DEVELOPMENT
   : Array.from(new Set([PRODUCTION_UI_ORIGIN, ...CATALOGGY_ALLOWED_ORIGINS]));
 
 const CORS_METHODS = "GET,POST,DELETE,PATCH,OPTIONS";
-const CORS_HEADERS = "Authorization,Content-Type";
+const CORS_HEADERS = "Authorization,Content-Type,X-Profile-Id";
 
 export const isAllowedOrigin = (origin: string | undefined): boolean => {
   if (IS_DEVELOPMENT) return true;


### PR DESCRIPTION
## Summary
Updated CORS configuration to allow the `X-Profile-Id` header in cross-origin requests.

## Changes
- Added `X-Profile-Id` to the `CORS_HEADERS` configuration in the CORS middleware
- This header can now be sent and received in CORS requests alongside the existing `Authorization` and `Content-Type` headers

## Details
The `X-Profile-Id` header is now explicitly whitelisted in the CORS policy, enabling clients to include profile identification information in cross-origin API requests.

https://claude.ai/code/session_01CYqngxXSGVpyxq3g5yHqJK