### PR TITLE
Add User-Agent header and improve OAuth HTML response

### DIFF
--- a/apps/api/src/lib/html.ts
+++ b/apps/api/src/lib/html.ts
@@ -10,6 +10,6 @@ export const escapeHtml = (str: string): string =>
   str.replace(/[&<>"']/g, (ch) => htmlEscapeMap[ch]);
 
 export const renderOAuthHtml = (detail: string, title = "Trakt Connection Failed"): string =>
-  `<html><body style="background:#0f172a;color:#e2e8f0;font-family:sans-serif;display:flex;align-items:center;justify-content:center;height:100vh">
+  `<!DOCTYPE html><html><head><meta charset="utf-8"><title>${escapeHtml(title)}</title></head><body style="background:#0f172a;color:#e2e8f0;font-family:sans-serif;display:flex;align-items:center;justify-content:center;height:100vh">
   <div style="text-align:center"><h1>${escapeHtml(title)}</h1><p>${escapeHtml(detail)}</p><p style="color:#94a3b8;margin-top:1rem">You can close this tab and return to Cataloggy.</p></div>
 </body></html>`;

--- a/apps/api/src/routes/trakt.ts
+++ b/apps/api/src/routes/trakt.ts
@@ -75,7 +75,7 @@ const traktRoutes: FastifyPluginAsync = async (app) => {
     try {
       tokenResponse = await fetch("https://api.trakt.tv/oauth/token", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", "User-Agent": "Cataloggy/1.0" },
         signal: tokenExchangeController.signal,
         body: JSON.stringify({
           code,

--- a/apps/api/src/trakt.ts
+++ b/apps/api/src/trakt.ts
@@ -264,7 +264,7 @@ export class TraktClient {
 
     const response = await fetch(url, {
       method: options.method,
-      headers: options.headers,
+      headers: { "User-Agent": "Cataloggy/1.0", ...options.headers },
       body: options.body
     });
 
@@ -292,7 +292,8 @@ export class TraktClient {
     const response = await fetch(new URL("/oauth/token", TRAKT_API_BASE), {
       method: "POST",
       headers: {
-        "Content-Type": "application/json"
+        "Content-Type": "application/json",
+        "User-Agent": "Cataloggy/1.0"
       },
       body: JSON.stringify({
         refresh_token: this.refreshToken,


### PR DESCRIPTION
## Summary
This PR adds a consistent User-Agent header to all Trakt API requests and improves the HTML structure of OAuth error responses.

## Key Changes
- **User-Agent Header**: Added `"User-Agent": "Cataloggy/1.0"` header to all Trakt API requests:
  - Generic API requests in `TraktClient.request()`
  - OAuth token refresh requests in `TraktClient`
  - OAuth token exchange requests in the Trakt routes handler
  
- **OAuth HTML Response**: Enhanced the HTML structure of OAuth error pages:
  - Added `<!DOCTYPE html>` declaration for proper HTML5 compliance
  - Added `<head>` section with UTF-8 charset meta tag
  - Added dynamic `<title>` tag that reflects the error title (properly escaped)
  - Maintains existing styling and layout

## Implementation Details
The User-Agent header is consistently set to "Cataloggy/1.0" across all Trakt API interactions, ensuring proper identification of requests from the application. The OAuth HTML improvements ensure better browser compatibility and accessibility while maintaining the existing visual design.

https://claude.ai/code/session_01Bb5Bu3qzyFMjxisLMb7gPn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved OAuth HTML structure with proper DOCTYPE, charset encoding, and title element formatting
  * Added standardized identification headers to Trakt API requests and token refresh operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->