### PR TITLE
Serialize bigint traktHistoryId to string in watch event responses

### DIFF
--- a/apps/api/src/routes/watch.ts
+++ b/apps/api/src/routes/watch.ts
@@ -4,6 +4,10 @@ import { prisma } from "../lib/prisma.js";
 import { upsertSeriesProgressIfNewer } from "../lib/series-progress.js";
 import { resolveProfile } from "../lib/profile.js";
 
+function serializeWatchEvent<T extends { traktHistoryId: bigint | null }>(event: T) {
+  return { ...event, traktHistoryId: event.traktHistoryId != null ? event.traktHistoryId.toString() : null };
+}
+
 const watchRoutes: FastifyPluginAsync = async (app) => {
   app.addHook("preHandler", resolveProfile);
 
@@ -84,7 +88,7 @@ const watchRoutes: FastifyPluginAsync = async (app) => {
         where: { id: existing.id },
         data: { plays: existing.plays + 1 },
       });
-      return reply.code(200).send({ watchEvent: updated });
+      return reply.code(200).send({ watchEvent: serializeWatchEvent(updated) });
     }
 
     const watchEvent = await prisma.watchEvent.create({
@@ -99,7 +103,7 @@ const watchRoutes: FastifyPluginAsync = async (app) => {
       });
     }
 
-    return reply.code(201).send({ watchEvent });
+    return reply.code(201).send({ watchEvent: serializeWatchEvent(watchEvent) });
   });
 
   app.delete<{ Params: { eventId: string } }>("/watch/:eventId", async (request, reply) => {
@@ -193,7 +197,7 @@ const watchRoutes: FastifyPluginAsync = async (app) => {
         const lookupId =
           event.type === "episode" && event.seriesImdbId ? event.seriesImdbId : event.imdbId;
         const meta = metadataByImdbId.get(lookupId);
-        return { ...event, name: meta?.name ?? null, poster: meta?.poster ?? null };
+        return { ...serializeWatchEvent(event), name: meta?.name ?? null, poster: meta?.poster ?? null };
       });
 
       return { history };


### PR DESCRIPTION
## Summary
This PR fixes serialization of the `traktHistoryId` field in watch event API responses. The field is stored as a `bigint` in the database but needs to be converted to a string for JSON serialization to prevent data loss or serialization errors.

## Key Changes
- Added `serializeWatchEvent()` helper function that converts `traktHistoryId` from `bigint` to `string` (or `null` if not present)
- Applied serialization to watch event responses in three locations:
  - POST /watch endpoint when updating existing watch event (200 response)
  - POST /watch endpoint when creating new watch event (201 response)
  - GET /watch/history endpoint when returning historical events

## Implementation Details
The helper function uses a generic type constraint to ensure type safety while transforming the `traktHistoryId` field. This approach maintains backward compatibility while ensuring all watch event responses have consistent serialization of large integer values.

https://claude.ai/code/session_01SpiY98zoQMiPJ37Cs18fuj