### PR TITLE
Improve MediaDetailPanel layout and prevent background scroll

### DIFF
--- a/apps/web/src/components/MediaDetailPanel.tsx
+++ b/apps/web/src/components/MediaDetailPanel.tsx
@@ -482,6 +482,13 @@ export function DetailPanel({
 }) {
   const listNames = item.lists.map((id) => listMap.get(id)?.name).filter(Boolean) as string[];
 
+  // Lock background scroll while the panel is open
+  useEffect(() => {
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => { document.body.style.overflow = previousOverflow; };
+  }, []);
+
   // Cast
   const [cast, setCast] = useState<Array<{ name: string; character: string; photo: string | null }>>([]);
   const [castLoading, setCastLoading] = useState(true);
@@ -633,7 +640,7 @@ export function DetailPanel({
     <>
       <div className="fixed inset-0 z-50 bg-black/70 backdrop-blur-sm" onClick={onClose} />
 
-      <aside className="fixed right-0 top-0 z-50 flex h-full w-full flex-col overflow-y-auto border-l border-ink-800/60 bg-[#0d0b0a] shadow-2xl sm:max-w-lg md:max-w-2xl lg:max-w-3xl">
+      <aside className="fixed right-0 top-0 z-50 flex h-full w-full flex-col overflow-y-auto border-l border-ink-800/60 bg-[#0d0b0a] shadow-2xl sm:w-[90vw] sm:max-w-3xl md:max-w-4xl lg:max-w-5xl">
         {/* Close */}
         <button
           type="button" onClick={onClose}
@@ -656,7 +663,7 @@ export function DetailPanel({
         </div>
 
         {/* Content */}
-        <div className="-mt-16 relative z-20 flex-1 space-y-6 px-6 pb-8">
+        <div className="-mt-16 relative z-20 flex-1 space-y-6 px-6 pb-16">
 
           {/* Title + badges */}
           <div>


### PR DESCRIPTION
## Summary
Enhanced the MediaDetailPanel component with improved responsive sizing and background scroll prevention for better UX when the panel is open.

## Key Changes
- **Prevent background scroll**: Added a `useEffect` hook that sets `document.body.style.overflow` to "hidden" while the detail panel is open, preventing users from scrolling the page behind the modal. The previous overflow value is restored when the panel closes.
- **Responsive width adjustments**: Updated the aside element's width constraints:
  - Added `sm:w-[90vw]` to use 90% of viewport width on small screens
  - Increased max-width breakpoints: `sm:max-w-3xl`, `md:max-w-4xl`, `lg:max-w-5xl` (previously `sm:max-w-lg`, `md:max-w-2xl`, `lg:max-w-3xl`)
- **Improved bottom padding**: Increased content padding-bottom from `pb-8` to `pb-16` for better spacing at the bottom of the scrollable content area

## Implementation Details
The scroll lock is implemented using a cleanup function in the useEffect hook to ensure the previous overflow style is properly restored when the component unmounts, preventing any lingering scroll lock issues.

https://claude.ai/code/session_01EgbXj87gWZqrGMLozURXdS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unwanted background scrolling while the detail panel is open, keeping user focus on the panel content.

* **Style**
  * Improved detail panel layout with better responsive width handling for different screen sizes and increased padding around content for improved visual hierarchy and spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->