### PR TITLE
Redesign dashboard layout with sidebar, command palette, and stat strip

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,10 +1,11 @@
 import { useState } from "react";
 import { Link, Route, Routes, useLocation } from "react-router-dom";
-import { BarChart3, Clapperboard, Search, List, Settings, Sun, Moon } from "lucide-react";
+import { BarChart3, Clapperboard, Search, List, Settings } from "lucide-react";
 import { runtimeConfig } from "./api";
 import { CommandPalette, useCommandPalette } from "./components/CommandPalette";
 import { InstallButton } from "./components/InstallButton";
 import { Sidebar } from "./components/Sidebar";
+import { ThemeToggle } from "./components/ThemeToggle";
 import { useTheme } from "./hooks/useTheme";
 import { DashboardPage } from "./pages/DashboardPage";
 import { ListsPage } from "./pages/ListsPage";
@@ -80,15 +81,7 @@ export function App() {
           </button>
 
           <div className="flex items-center gap-3">
-            <button
-              type="button"
-              onClick={toggleTheme}
-              className="flex h-9 w-9 items-center justify-center rounded-full transition-all active:scale-95"
-              style={{ border: "1px solid var(--border-strong)", color: "var(--text-dim)" }}
-              aria-label={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
-            >
-              {theme === "dark" ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
-            </button>
+            <ThemeToggle theme={theme} onToggle={toggleTheme} />
             <InstallButton />
           </div>
         </div>

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,8 +1,10 @@
 import { useState } from "react";
-import { Link, NavLink, Route, Routes, useLocation } from "react-router-dom";
-import { BarChart3, Clapperboard, LayoutDashboard, Search, List, Settings, Sun, Moon } from "lucide-react";
+import { Link, Route, Routes, useLocation } from "react-router-dom";
+import { BarChart3, Clapperboard, Search, List, Settings, Sun, Moon } from "lucide-react";
 import { runtimeConfig } from "./api";
+import { CommandPalette, useCommandPalette } from "./components/CommandPalette";
 import { InstallButton } from "./components/InstallButton";
+import { Sidebar } from "./components/Sidebar";
 import { useTheme } from "./hooks/useTheme";
 import { DashboardPage } from "./pages/DashboardPage";
 import { ListsPage } from "./pages/ListsPage";
@@ -12,8 +14,8 @@ import { SettingsPage } from "./pages/SettingsPage";
 import { SetupWizard } from "./pages/SetupWizard";
 import { StatsPage } from "./pages/StatsPage";
 
-const navItems = [
-  { to: "/", label: "Dashboard", icon: LayoutDashboard, end: true },
+const mobileNavItems = [
+  { to: "/", label: "Dashboard", icon: Clapperboard, end: true },
   { to: "/search", label: "Search", icon: Search, end: false },
   { to: "/lists", label: "Lists", icon: List, end: false },
   { to: "/stats", label: "Stats", icon: BarChart3, end: false },
@@ -25,6 +27,7 @@ export function App() {
   const [needsSetup, setNeedsSetup] = useState(() => !runtimeConfig.getToken());
   const [needsProfile, setNeedsProfile] = useState(() => !runtimeConfig.getProfileId());
   const { theme, toggleTheme } = useTheme();
+  const { open: paletteOpen, setOpen: setPaletteOpen } = useCommandPalette();
 
   if (needsSetup) {
     return (
@@ -43,20 +46,40 @@ export function App() {
 
   return (
     <div className="min-h-screen w-full">
-      {/* Fixed header */}
+      <Sidebar />
+      <CommandPalette open={paletteOpen} onClose={() => setPaletteOpen(false)} />
+
+      {/* Slim top bar */}
       <header
-        className="fixed top-0 left-0 right-0 z-30 backdrop-blur-xl"
+        className="fixed top-0 left-0 right-0 z-30 backdrop-blur-xl sm:pl-16"
         style={{ borderBottom: "1px solid var(--border)", backgroundColor: "color-mix(in srgb, var(--bg-0) 90%, transparent)" }}
       >
-        <div className="mx-auto flex max-w-[1400px] items-center justify-between gap-6 px-6 py-3.5">
-          <Link to="/" className="flex items-center gap-2.5 text-xl font-bold" style={{ color: "var(--text)" }}>
-            <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-claw-500">
-              <Clapperboard className="h-5 w-5 text-white" />
+        <div className="mx-auto flex max-w-[1400px] items-center justify-between gap-4 px-6 py-3">
+          <Link to="/" className="flex items-center gap-2.5 text-lg font-bold sm:hidden" style={{ color: "var(--text)" }}>
+            <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-claw-500">
+              <Clapperboard className="h-4 w-4 text-white" />
             </div>
-            <span className="hidden sm:inline">Cataloggy</span>
+            <span>Cataloggy</span>
           </Link>
 
-          <div className="flex items-center gap-4">
+          <button
+            type="button"
+            onClick={() => setPaletteOpen(true)}
+            className="flex flex-1 max-w-sm items-center gap-2.5 rounded-full px-4 py-2 text-sm transition-colors hover:bg-[var(--surface-strong)]"
+            style={{ border: "1px solid var(--border-strong)", color: "var(--text-mute)", background: "var(--surface)" }}
+          >
+            <Search className="h-4 w-4" />
+            <span className="hidden sm:inline">Search everything...</span>
+            <span className="sm:hidden">Search</span>
+            <kbd
+              className="ml-auto hidden rounded px-1.5 py-0.5 text-2xs font-medium sm:inline"
+              style={{ background: "var(--surface-strong)", color: "var(--text-mute)" }}
+            >
+              ⌘K
+            </kbd>
+          </button>
+
+          <div className="flex items-center gap-3">
             <button
               type="button"
               onClick={toggleTheme}
@@ -66,43 +89,13 @@ export function App() {
             >
               {theme === "dark" ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
             </button>
-
             <InstallButton />
-
-            {/* Desktop pill nav */}
-            <nav
-              className="hidden sm:flex rounded-full p-1"
-              style={{ border: "1px solid var(--border-strong)", backgroundColor: "var(--surface-strong)" }}
-            >
-              {navItems.map((item) => (
-                <NavLink
-                  key={item.to}
-                  to={item.to}
-                  end={item.end ?? false}
-                  className={({ isActive }) =>
-                    `flex items-center gap-2 rounded-full px-4 py-2 text-sm font-medium transition-all duration-200 ${
-                      isActive ? "bg-claw-500 text-white shadow-lg shadow-claw-500/20" : "hover:opacity-80"
-                    }`
-                  }
-                  style={({ isActive }: { isActive: boolean }) =>
-                    isActive ? {} : { color: "var(--text-dim)" }
-                  }
-                >
-                  {({ isActive }) => (
-                    <>
-                      <item.icon className="h-4 w-4" />
-                      <span>{item.label}</span>
-                    </>
-                  )}
-                </NavLink>
-              ))}
-            </nav>
           </div>
         </div>
       </header>
 
       {/* Main content */}
-      <main className="mx-auto max-w-[1400px] px-6 pb-24 pt-[88px] sm:pb-8">
+      <main className="mx-auto max-w-[1400px] px-6 pb-24 pt-[76px] sm:pb-10 sm:pl-[5rem]">
         <Routes>
           <Route path="/" element={<DashboardPage />} />
           <Route path="/search" element={<SearchPage />} />
@@ -117,7 +110,7 @@ export function App() {
         className="fixed bottom-0 left-0 right-0 z-40 flex sm:hidden backdrop-blur-xl"
         style={{ borderTop: "1px solid var(--border)", backgroundColor: "color-mix(in srgb, var(--bg-0) 96%, transparent)" }}
       >
-        {navItems.map((item) => {
+        {mobileNavItems.map((item) => {
           const Icon = item.icon;
           const isActive = item.end
             ? location.pathname === item.to
@@ -138,7 +131,7 @@ export function App() {
 
       {/* Footer */}
       <footer
-        className="py-8 text-center text-sm"
+        className="py-8 text-center text-sm sm:pl-16"
         style={{ borderTop: "1px solid var(--border)", color: "var(--text-mute)" }}
       >
         Cataloggy &middot; Personal Media Tracker

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -1,0 +1,220 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { BarChart3, Clapperboard, Film, List, Search, Settings, Tv } from "lucide-react";
+import { api, SearchResult } from "../api";
+import { Poster } from "./Poster";
+
+type Action = {
+  id: string;
+  label: string;
+  hint?: string;
+  icon: React.ElementType;
+  run: () => void;
+};
+
+export function useCommandPalette() {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const isK = e.key.toLowerCase() === "k";
+      if ((e.metaKey || e.ctrlKey) && isK) {
+        e.preventDefault();
+        setOpen((v) => !v);
+      } else if (e.key === "Escape") {
+        setOpen(false);
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, []);
+
+  return { open, setOpen };
+}
+
+export function CommandPalette({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const navigate = useNavigate();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>();
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<SearchResult[]>([]);
+  const [searching, setSearching] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  useEffect(() => {
+    if (open) {
+      setQuery("");
+      setResults([]);
+      setActiveIndex(0);
+      setTimeout(() => inputRef.current?.focus(), 10);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!query.trim()) {
+      setResults([]);
+      setSearching(false);
+      return;
+    }
+    setSearching(true);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      void (async () => {
+        try {
+          const [movies, series] = await Promise.all([
+            api.search("movie", query),
+            api.search("series", query),
+          ]);
+          const merged: SearchResult[] = [];
+          const maxLen = Math.max(movies.length, series.length);
+          for (let i = 0; i < maxLen && merged.length < 8; i++) {
+            if (i < movies.length) merged.push(movies[i]);
+            if (i < series.length) merged.push(series[i]);
+          }
+          setResults(merged.slice(0, 8));
+        } catch {
+          setResults([]);
+        } finally {
+          setSearching(false);
+        }
+      })();
+    }, 250);
+    return () => { if (debounceRef.current) clearTimeout(debounceRef.current); };
+  }, [query]);
+
+  const goToSearch = useCallback((q: string) => {
+    onClose();
+    navigate(`/search?q=${encodeURIComponent(q)}`);
+  }, [navigate, onClose]);
+
+  const actions: Action[] = [
+    { id: "nav-dashboard", label: "Go to Dashboard", icon: Clapperboard, run: () => { onClose(); navigate("/"); } },
+    { id: "nav-search", label: "Go to Search", icon: Search, run: () => { onClose(); navigate("/search"); } },
+    { id: "nav-lists", label: "Go to Lists", icon: List, run: () => { onClose(); navigate("/lists"); } },
+    { id: "nav-stats", label: "Go to Stats", icon: BarChart3, run: () => { onClose(); navigate("/stats"); } },
+    { id: "nav-settings", label: "Go to Settings", icon: Settings, run: () => { onClose(); navigate("/settings"); } },
+  ];
+
+  const visibleActions = query.trim()
+    ? actions.filter((a) => a.label.toLowerCase().includes(query.toLowerCase()))
+    : actions;
+
+  const totalItems = results.length + visibleActions.length;
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setActiveIndex((i) => Math.min(i + 1, totalItems - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setActiveIndex((i) => Math.max(i - 1, 0));
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      if (activeIndex < results.length) {
+        const r = results[activeIndex];
+        if (r) goToSearch(r.name);
+      } else {
+        const action = visibleActions[activeIndex - results.length];
+        if (action) action.run();
+        else if (query.trim()) goToSearch(query);
+      }
+    }
+  };
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-[100] flex items-start justify-center px-4 pt-[12vh]"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Command palette"
+    >
+      <div className="absolute inset-0 bg-black/40 backdrop-blur-sm" />
+      <div
+        className="relative w-full max-w-lg overflow-hidden rounded-2xl shadow-feature"
+        style={{ background: "var(--bg-0)", border: "1px solid var(--border-strong)" }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center gap-3 px-4 py-3.5" style={{ borderBottom: "1px solid var(--border)" }}>
+          <Search className="h-4 w-4 flex-none" style={{ color: "var(--text-mute)" }} />
+          <input
+            ref={inputRef}
+            value={query}
+            onChange={(e) => { setQuery(e.target.value); setActiveIndex(0); }}
+            onKeyDown={onKeyDown}
+            placeholder="Search everything..."
+            className="w-full bg-transparent text-sm outline-none"
+            style={{ color: "var(--text)" }}
+            aria-label="Search everything"
+          />
+          <kbd
+            className="rounded px-1.5 py-0.5 text-2xs font-medium"
+            style={{ background: "var(--surface-strong)", color: "var(--text-mute)" }}
+          >
+            Esc
+          </kbd>
+        </div>
+
+        <div className="max-h-[60vh] overflow-y-auto py-2">
+          {searching && (
+            <p className="px-4 py-3 text-xs" style={{ color: "var(--text-dim)" }}>Searching...</p>
+          )}
+
+          {!searching && results.length > 0 && (
+            <div className="px-2 pb-2">
+              <p className="px-2 pb-1 text-2xs font-medium uppercase tracking-wider" style={{ color: "var(--text-mute)" }}>
+                Titles
+              </p>
+              {results.map((r, i) => (
+                <button
+                  key={r.imdbId}
+                  type="button"
+                  onClick={() => goToSearch(r.name)}
+                  onMouseEnter={() => setActiveIndex(i)}
+                  className="flex w-full items-center gap-3 rounded-lg px-2 py-2 text-left transition-colors"
+                  style={{ background: activeIndex === i ? "var(--surface-strong)" : "transparent" }}
+                >
+                  <div className="h-9 w-7 flex-none overflow-hidden rounded" style={{ boxShadow: "0 0 0 1px var(--border)" }}>
+                    <Poster src={r.poster ?? undefined} alt={r.name} className="h-full w-full" />
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-medium" style={{ color: "var(--text)" }}>{r.name}</p>
+                    <p className="text-2xs" style={{ color: "var(--text-mute)" }}>
+                      {r.year ?? ""} {r.type === "movie" ? <Film className="inline h-3 w-3" /> : <Tv className="inline h-3 w-3" />}
+                    </p>
+                  </div>
+                </button>
+              ))}
+            </div>
+          )}
+
+          <div className="px-2">
+            {visibleActions.length > 0 && (
+              <p className="px-2 pb-1 pt-1 text-2xs font-medium uppercase tracking-wider" style={{ color: "var(--text-mute)" }}>
+                Navigate
+              </p>
+            )}
+            {visibleActions.map((action, i) => {
+              const idx = results.length + i;
+              return (
+                <button
+                  key={action.id}
+                  type="button"
+                  onClick={action.run}
+                  onMouseEnter={() => setActiveIndex(idx)}
+                  className="flex w-full items-center gap-3 rounded-lg px-2 py-2.5 text-left transition-colors"
+                  style={{ background: activeIndex === idx ? "var(--surface-strong)" : "transparent" }}
+                >
+                  <action.icon className="h-4 w-4 flex-none" style={{ color: "var(--text-dim)" }} />
+                  <span className="text-sm" style={{ color: "var(--text)" }}>{action.label}</span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/Poster.tsx
+++ b/apps/web/src/components/Poster.tsx
@@ -1,0 +1,36 @@
+import { useEffect, useState } from "react";
+import { getGradient, getInitials } from "./carousel-utils";
+
+export function Poster({
+  src,
+  alt,
+  className = "",
+}: {
+  src?: string;
+  alt: string | null | undefined;
+  className?: string;
+}) {
+  const [loadFailed, setLoadFailed] = useState(false);
+
+  useEffect(() => { setLoadFailed(false); }, [src]);
+
+  if (!src || loadFailed) {
+    return (
+      <div className={`flex items-center justify-center bg-gradient-to-br ${getGradient(alt)} ${className}`}>
+        <span className="text-xl font-bold text-white/60 select-none">
+          {getInitials(alt)}
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <img
+      src={src}
+      alt={alt ?? "Poster"}
+      className={`object-cover ${className}`}
+      loading="lazy"
+      onError={() => setLoadFailed(true)}
+    />
+  );
+}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1,0 +1,98 @@
+import { useState } from "react";
+import { NavLink } from "react-router-dom";
+import { BarChart3, Clapperboard, Pin, PinOff, Search, List, Settings } from "lucide-react";
+
+const navItems = [
+  { to: "/", label: "Dashboard", icon: Clapperboard, end: true },
+  { to: "/search", label: "Search", icon: Search, end: false },
+  { to: "/lists", label: "Lists", icon: List, end: false },
+  { to: "/stats", label: "Stats", icon: BarChart3, end: false },
+  { to: "/settings", label: "Settings", icon: Settings, end: false },
+] as const;
+
+const PIN_KEY = "cataloggy:sidebar-pinned";
+
+export function Sidebar() {
+  const [pinned, setPinned] = useState(() => localStorage.getItem(PIN_KEY) === "1");
+  const [hovered, setHovered] = useState(false);
+  const expanded = pinned || hovered;
+
+  const togglePin = () => {
+    const next = !pinned;
+    setPinned(next);
+    localStorage.setItem(PIN_KEY, next ? "1" : "0");
+  };
+
+  return (
+    <aside
+      className="fixed inset-y-0 left-0 z-40 hidden sm:flex"
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+    >
+      <div
+        className="flex h-full flex-col py-4 transition-[width] duration-200 ease-out overflow-hidden"
+        style={{
+          width: expanded ? "15rem" : "4rem",
+          background: "var(--bg-1)",
+          borderRight: "1px solid var(--border)",
+          boxShadow: expanded ? "8px 0 24px rgba(0,0,0,0.12)" : "none",
+        }}
+      >
+        <div className="flex items-center gap-2.5 px-4 pb-5">
+          <div className="flex h-8 w-8 flex-none items-center justify-center rounded-lg bg-claw-500">
+            <Clapperboard className="h-4.5 w-4.5 text-white" />
+          </div>
+          <span
+            className="whitespace-nowrap text-base font-bold transition-opacity"
+            style={{ color: "var(--text)", opacity: expanded ? 1 : 0 }}
+          >
+            Cataloggy
+          </span>
+        </div>
+
+        <nav className="flex flex-1 flex-col gap-1 px-2.5">
+          {navItems.map((item) => (
+            <NavLink
+              key={item.to}
+              to={item.to}
+              end={item.end}
+              className={({ isActive }) =>
+                `group relative flex items-center gap-3 rounded-lg px-2.5 py-2.5 text-sm font-medium transition-colors ${
+                  isActive ? "" : "hover:bg-[var(--surface-strong)]"
+                }`
+              }
+              style={({ isActive }) => ({ color: isActive ? "var(--text)" : "var(--text-dim)" })}
+            >
+              {({ isActive }) => (
+                <>
+                  {isActive && (
+                    <span className="absolute left-0 top-1.5 bottom-1.5 w-[3px] rounded-full bg-claw-500" />
+                  )}
+                  <item.icon className="h-[1.1rem] w-[1.1rem] flex-none" />
+                  <span className="whitespace-nowrap" style={{ opacity: expanded ? 1 : 0 }}>
+                    {item.label}
+                  </span>
+                </>
+              )}
+            </NavLink>
+          ))}
+        </nav>
+
+        <div className="px-2.5">
+          <button
+            type="button"
+            onClick={togglePin}
+            className="flex w-full items-center gap-3 rounded-lg px-2.5 py-2.5 text-sm font-medium transition-colors hover:bg-[var(--surface-strong)]"
+            style={{ color: "var(--text-dim)" }}
+            aria-label={pinned ? "Unpin sidebar" : "Pin sidebar open"}
+          >
+            {pinned ? <PinOff className="h-[1.1rem] w-[1.1rem] flex-none" /> : <Pin className="h-[1.1rem] w-[1.1rem] flex-none" />}
+            <span className="whitespace-nowrap" style={{ opacity: expanded ? 1 : 0 }}>
+              {pinned ? "Unpin" : "Pin open"}
+            </span>
+          </button>
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/apps/web/src/components/ThemeToggle.tsx
+++ b/apps/web/src/components/ThemeToggle.tsx
@@ -1,0 +1,59 @@
+import { Theme } from "../hooks/useTheme";
+
+/**
+ * Sun/moon slider toggle. All motion is a direct response to the state
+ * change (CSS transition), never an idle/looping animation — clouds and
+ * star-twinkle keyframes were deliberately dropped to match the app's
+ * "fast and purposeful, never decorative" motion rule.
+ */
+export function ThemeToggle({ theme, onToggle }: { theme: Theme; onToggle: () => void }) {
+  const dark = theme === "dark";
+
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={dark}
+      aria-label={dark ? "Switch to light mode" : "Switch to dark mode"}
+      onClick={onToggle}
+      className="relative h-9 w-16 flex-none rounded-full transition-colors duration-200 active:scale-95"
+      style={{
+        border: "1px solid var(--border-strong)",
+        background: dark ? "#1c2333" : "#bfe3ff",
+      }}
+    >
+      {/* static stars, only visible in dark mode — no twinkle loop */}
+      <span
+        className="absolute left-2.5 top-2 h-[3px] w-[3px] rounded-full bg-white transition-opacity duration-200"
+        style={{ opacity: dark ? 0.9 : 0 }}
+      />
+      <span
+        className="absolute left-4 top-4.5 h-[2px] w-[2px] rounded-full bg-white transition-opacity duration-200"
+        style={{ opacity: dark ? 0.7 : 0 }}
+      />
+      <span
+        className="absolute left-2 top-6 h-[2px] w-[2px] rounded-full bg-white transition-opacity duration-200"
+        style={{ opacity: dark ? 0.5 : 0 }}
+      />
+
+      {/* sliding sun/moon knob */}
+      <span
+        className="absolute top-1 left-1 flex h-6 w-6 items-center justify-center rounded-full shadow-sm transition-transform duration-200"
+        style={{
+          transform: dark ? "translateX(28px)" : "translateX(0)",
+          background: dark ? "#e2e8f0" : "#fbbf24",
+        }}
+      >
+        {/* moon craters fade in/out with the knob, no separate animation */}
+        <span
+          className="absolute h-1.5 w-1.5 rounded-full bg-slate-400 transition-opacity duration-200"
+          style={{ opacity: dark ? 0.8 : 0, top: "3px", left: "3px" }}
+        />
+        <span
+          className="absolute h-1 w-1 rounded-full bg-slate-400 transition-opacity duration-200"
+          style={{ opacity: dark ? 0.6 : 0, bottom: "4px", right: "4px" }}
+        />
+      </span>
+    </button>
+  );
+}

--- a/apps/web/src/components/TicketTile.tsx
+++ b/apps/web/src/components/TicketTile.tsx
@@ -1,0 +1,76 @@
+export function MiniBarChart({ data, active = true }: { data: number[]; active?: boolean }) {
+  const max = Math.max(...data, 1);
+  const barW = 10;
+  const gap = 4;
+  const chartH = 40;
+  const totalW = data.length * barW + (data.length - 1) * gap;
+
+  return (
+    <svg width={totalW} height={chartH} aria-hidden="true">
+      {data.map((v, i) => {
+        const barH = Math.max((v / max) * chartH, 2);
+        const x = i * (barW + gap);
+        const isLatest = i === data.length - 1;
+        return (
+          <rect
+            key={i}
+            x={x}
+            y={chartH - barH}
+            width={barW}
+            height={barH}
+            rx={3}
+            fill={isLatest && active ? "var(--accent)" : "var(--surface-strong)"}
+          />
+        );
+      })}
+    </svg>
+  );
+}
+
+/** A "ticket stub" shaped stat tile — Cataloggy's signature collectible-stat motif. */
+export function TicketTile({
+  icon: Icon,
+  label,
+  value,
+  sub,
+  bars,
+}: {
+  icon: React.ElementType;
+  label: string;
+  value: string | number;
+  sub?: string;
+  bars?: number[];
+}) {
+  return (
+    <div className="relative">
+      <div
+        className="rounded-2xl px-4 py-4 flex flex-col gap-2"
+        style={{ border: "1px solid var(--border)", background: "var(--bg-1)" }}
+      >
+        <div className="flex items-center gap-1.5">
+          <Icon className="h-3.5 w-3.5 text-claw-400" />
+          <span className="text-2xs font-medium uppercase tracking-wider" style={{ color: "var(--text-mute)" }}>
+            {label}
+          </span>
+        </div>
+        <span className="text-2xl font-bold tabular-nums leading-none truncate" style={{ color: "var(--text)" }}>
+          {typeof value === "number" ? value.toLocaleString() : value}
+        </span>
+        {bars && bars.length > 0 ? (
+          <MiniBarChart data={bars} />
+        ) : sub ? (
+          <p className="text-2xs" style={{ color: "var(--text-dim)" }}>{sub}</p>
+        ) : null}
+      </div>
+      {/* perforated notches, ticket-stub motif */}
+      <span
+        className="absolute -left-[7px] top-1/2 h-3.5 w-3.5 -translate-y-1/2 rounded-full"
+        style={{ background: "var(--bg-0)" }}
+      />
+      <span
+        className="absolute -right-[7px] top-1/2 h-3.5 w-3.5 -translate-y-1/2 rounded-full"
+        style={{ background: "var(--bg-0)" }}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -29,38 +29,8 @@ import { Link } from "react-router-dom";
 import { useHorizontalScroll } from "../components/carousel-utils";
 import { DetailPanel, useDetailPanel } from "../components/MediaDetailPanel";
 import { Poster } from "../components/Poster";
+import { TicketTile } from "../components/TicketTile";
 import { timeAgo } from "../utils/timeAgo";
-
-/* ─── Mini SVG bar chart ─── */
-
-function MiniBarChart({ data, active = true }: { data: number[]; active?: boolean }) {
-  const max = Math.max(...data, 1);
-  const barW = 10;
-  const gap = 4;
-  const chartH = 40;
-  const totalW = data.length * barW + (data.length - 1) * gap;
-
-  return (
-    <svg width={totalW} height={chartH} aria-hidden="true">
-      {data.map((v, i) => {
-        const barH = Math.max((v / max) * chartH, 2);
-        const x = i * (barW + gap);
-        const isLatest = i === data.length - 1;
-        return (
-          <rect
-            key={i}
-            x={x}
-            y={chartH - barH}
-            width={barW}
-            height={barH}
-            rx={3}
-            fill={isLatest && active ? "var(--accent)" : "var(--surface-strong)"}
-          />
-        );
-      })}
-    </svg>
-  );
-}
 
 /* ─── Collectible stat strip: a row of distinct "ticket" tiles, demoted below the fold ─── */
 
@@ -100,53 +70,6 @@ function StatStrip({
       <TicketTile icon={Film} label="Movies watched" value={stats?.totalMovies ?? 0} bars={movieBars} />
       <TicketTile icon={Tv} label="Episodes watched" value={stats?.totalEpisodes ?? 0} bars={epBars} />
       <TicketTile icon={Trophy} label="Top genre" value={topGenre ?? "—"} sub={genres[0] ? `${genres[0].count} watched` : undefined} />
-    </div>
-  );
-}
-
-function TicketTile({
-  icon: Icon,
-  label,
-  value,
-  sub,
-  bars,
-}: {
-  icon: React.ElementType;
-  label: string;
-  value: string | number;
-  sub?: string;
-  bars?: number[];
-}) {
-  return (
-    <div className="relative">
-      <div
-        className="rounded-2xl px-4 py-4 flex flex-col gap-2"
-        style={{ border: "1px solid var(--border)", background: "var(--bg-1)" }}
-      >
-        <div className="flex items-center gap-1.5">
-          <Icon className="h-3.5 w-3.5 text-claw-400" />
-          <span className="text-2xs font-medium uppercase tracking-wider" style={{ color: "var(--text-mute)" }}>
-            {label}
-          </span>
-        </div>
-        <span className="text-2xl font-bold tabular-nums leading-none truncate" style={{ color: "var(--text)" }}>
-          {typeof value === "number" ? value.toLocaleString() : value}
-        </span>
-        {bars && bars.length > 0 ? (
-          <MiniBarChart data={bars} />
-        ) : sub ? (
-          <p className="text-2xs" style={{ color: "var(--text-dim)" }}>{sub}</p>
-        ) : null}
-      </div>
-      {/* perforated notches, ticket-stub motif */}
-      <span
-        className="absolute -left-[7px] top-1/2 h-3.5 w-3.5 -translate-y-1/2 rounded-full"
-        style={{ background: "var(--bg-0)" }}
-      />
-      <span
-        className="absolute -right-[7px] top-1/2 h-3.5 w-3.5 -translate-y-1/2 rounded-full"
-        style={{ background: "var(--bg-0)" }}
-      />
     </div>
   );
 }

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -7,7 +7,6 @@ import {
   ChevronRight,
   ChevronLeft,
   Check,
-  Star,
   TrendingUp,
   Sparkles,
   X,
@@ -27,8 +26,9 @@ import {
   WatchStats,
 } from "../api";
 import { Link } from "react-router-dom";
-import { useHorizontalScroll, getInitials, getGradient } from "../components/carousel-utils";
+import { useHorizontalScroll } from "../components/carousel-utils";
 import { DetailPanel, useDetailPanel } from "../components/MediaDetailPanel";
+import { Poster } from "../components/Poster";
 import { timeAgo } from "../utils/timeAgo";
 
 /* ─── Mini SVG bar chart ─── */
@@ -62,196 +62,91 @@ function MiniBarChart({ data, active = true }: { data: number[]; active?: boolea
   );
 }
 
-/* ─── Stat block (used inside the unified overview card) ─── */
+/* ─── Collectible stat strip: a row of distinct "ticket" tiles, demoted below the fold ─── */
 
-function StatBlock({
-  label,
-  value,
-  sub,
-  bars,
-  delta,
-  icon: Icon,
-}: {
-  label: string;
-  value: string | number;
-  sub?: string;
-  bars?: number[];
-  delta?: number | null;
-  icon: React.ElementType;
-}) {
-  return (
-    <div className="flex flex-col gap-2.5">
-      <div className="flex items-center gap-1.5">
-        <Icon className="h-3.5 w-3.5 text-claw-400" />
-        <span className="text-2xs font-medium uppercase tracking-wider" style={{ color: "var(--text-mute)" }}>
-          {label}
-        </span>
-      </div>
-      {bars && bars.length > 0 && <MiniBarChart data={bars} />}
-      <div className="flex items-baseline gap-1.5">
-        <span className="text-2xl font-bold tabular-nums leading-none" style={{ color: "var(--text)" }}>
-          {typeof value === "number" ? value.toLocaleString() : value}
-        </span>
-        {delta != null && (
-          <span className={`text-xs font-medium tabular-nums ${delta >= 0 ? "text-emerald-500" : "text-rose-500"}`}>
-            {delta >= 0 ? "+" : ""}{delta}
-          </span>
-        )}
-      </div>
-      {sub && <p className="text-xs" style={{ color: "var(--text-dim)" }}>{sub}</p>}
-    </div>
-  );
-}
-
-/* ─── Unified overview card: lifetime stats, this month, top genres ─── */
-
-function OverviewCard({
+function StatStrip({
   stats,
   monthly,
   genres,
+  currentStreak,
+  longestStreak,
   loading,
 }: {
   stats: WatchStats | null;
   monthly: DetailedWatchStats["monthly"];
   genres: DetailedWatchStats["genreDistribution"];
+  currentStreak: number;
+  longestStreak: number;
   loading: boolean;
 }) {
   const last6 = monthly.slice(-6);
   const movieBars = last6.length ? last6.map((m) => m.movies) : [0, 0, 0, 0, 0, 0];
   const epBars = last6.length ? last6.map((m) => m.episodes) : [0, 0, 0, 0, 0, 0];
-  const playBars = last6.map((m, i) => movieBars[i] + epBars[i]);
+  const topGenre = genres[0]?.genre;
 
-  const current = monthly.length >= 2 ? monthly[monthly.length - 1] : null;
-  const prev = monthly.length >= 2 ? monthly[monthly.length - 2] : null;
-  const movieDelta = current && prev ? current.movies - prev.movies : null;
-  const epDelta = current && prev ? current.episodes - prev.episodes : null;
-
-  const topGenres = genres.slice(0, 5);
+  if (loading) {
+    return (
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="skeleton h-28 rounded-2xl" />
+        ))}
+      </div>
+    );
+  }
 
   return (
-    <div
-      className="rounded-2xl p-6 h-full flex flex-col gap-6"
-      style={{ border: "1px solid var(--border)", background: "var(--bg-1)" }}
-    >
-      <div className="flex items-center justify-between">
-        <p className="text-sm font-semibold" style={{ color: "var(--text)" }}>Overview</p>
-        <Link
-          to="/stats"
-          className="text-xs font-medium text-claw-400 hover:text-claw-300 transition-colors"
-        >
-          Full stats
-        </Link>
-      </div>
-
-      {loading || !stats ? (
-        <div className="grid grid-cols-3 sm:grid-cols-5 gap-6">
-          {Array.from({ length: 5 }).map((_, i) => (
-            <div key={i} className="flex flex-col gap-3">
-              <div className="skeleton h-3 w-16 rounded" />
-              <div className="skeleton h-8 w-full rounded" />
-              <div className="skeleton h-5 w-12 rounded" />
-            </div>
-          ))}
-        </div>
-      ) : (
-        <div className="grid grid-cols-3 sm:grid-cols-5 gap-x-6 gap-y-6">
-          <StatBlock label="Movies" value={stats.totalMovies} bars={movieBars} icon={Film} />
-          <StatBlock label="Episodes" value={stats.totalEpisodes} bars={epBars} icon={Tv} />
-          <StatBlock label="Total plays" value={stats.totalPlays} bars={playBars} icon={Play} />
-          <StatBlock label="This month" value={current?.movies ?? 0} sub="movies" delta={movieDelta} icon={TrendingUp} />
-          <StatBlock label="This month" value={current?.episodes ?? 0} sub="episodes" delta={epDelta} icon={TrendingUp} />
-        </div>
-      )}
-
-      <div style={{ borderTop: "1px solid var(--border)", paddingTop: "1.5rem" }}>
-        <p className="mb-3 text-2xs font-medium uppercase tracking-wider" style={{ color: "var(--text-mute)" }}>
-          Top genres
-        </p>
-        {loading ? (
-          <div className="flex flex-wrap gap-2">
-            {Array.from({ length: 5 }).map((_, i) => (
-              <div key={i} className="skeleton h-7 w-20 rounded-full" />
-            ))}
-          </div>
-        ) : topGenres.length === 0 ? (
-          <p className="text-xs" style={{ color: "var(--text-mute)" }}>No genre data yet.</p>
-        ) : (
-          <div className="flex flex-wrap gap-2">
-            {topGenres.map((g, i) => (
-              <span
-                key={g.genre}
-                className="inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium"
-                style={
-                  i === 0
-                    ? { background: "var(--accent)", color: "white" }
-                    : { background: "var(--surface-strong)", color: "var(--text-dim)" }
-                }
-              >
-                {g.genre}
-                <span
-                  className="text-2xs tabular-nums"
-                  style={{ opacity: i === 0 ? 0.85 : 0.7 }}
-                >
-                  {g.count}
-                </span>
-              </span>
-            ))}
-          </div>
-        )}
-      </div>
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+      <TicketTile icon={Flame} label="Day streak" value={currentStreak} sub={`Best: ${longestStreak}`} />
+      <TicketTile icon={Film} label="Movies watched" value={stats?.totalMovies ?? 0} bars={movieBars} />
+      <TicketTile icon={Tv} label="Episodes watched" value={stats?.totalEpisodes ?? 0} bars={epBars} />
+      <TicketTile icon={Trophy} label="Top genre" value={topGenre ?? "—"} sub={genres[0] ? `${genres[0].count} watched` : undefined} />
     </div>
   );
 }
 
-/* ─── Streak card (accent dark card) ─── */
-
-function StreakCard({
-  current,
-  longest,
-  loading,
+function TicketTile({
+  icon: Icon,
+  label,
+  value,
+  sub,
+  bars,
 }: {
-  current: number;
-  longest: number;
-  loading: boolean;
+  icon: React.ElementType;
+  label: string;
+  value: string | number;
+  sub?: string;
+  bars?: number[];
 }) {
   return (
-    <div className="rounded-2xl p-6 flex flex-col justify-between h-full bg-ink-900 text-cream-50">
-      <p className="text-sm font-semibold text-cream-50">Streaks</p>
-
-      {loading ? (
-        <div className="flex-1 flex flex-col gap-4 mt-5">
-          <div className="skeleton h-12 w-20 rounded" />
-          <div className="skeleton h-3 w-24 rounded" />
-          <div className="skeleton h-8 w-16 rounded mt-4" />
-          <div className="skeleton h-3 w-20 rounded" />
+    <div className="relative">
+      <div
+        className="rounded-2xl px-4 py-4 flex flex-col gap-2"
+        style={{ border: "1px solid var(--border)", background: "var(--bg-1)" }}
+      >
+        <div className="flex items-center gap-1.5">
+          <Icon className="h-3.5 w-3.5 text-claw-400" />
+          <span className="text-2xs font-medium uppercase tracking-wider" style={{ color: "var(--text-mute)" }}>
+            {label}
+          </span>
         </div>
-      ) : (
-        <div className="flex flex-col gap-5 mt-3">
-          <div>
-            <div className="flex items-end gap-2">
-              <Flame className="h-5 w-5 text-claw-400 mb-0.5" />
-              <span className="text-4xl font-bold tabular-nums leading-none text-cream-50">
-                {current}
-              </span>
-            </div>
-            <p className="mt-1.5 text-xs text-ink-300">
-              day streak
-            </p>
-          </div>
-
-          <div className="pt-5 border-t border-ink-700">
-            <div className="flex items-end gap-2">
-              <Trophy className="h-4 w-4 text-claw-300 mb-0.5" />
-              <span className="text-2xl font-bold tabular-nums leading-none text-ink-200">
-                {longest}
-              </span>
-            </div>
-            <p className="mt-1.5 text-xs text-ink-400">
-              longest streak
-            </p>
-          </div>
-        </div>
-      )}
+        <span className="text-2xl font-bold tabular-nums leading-none truncate" style={{ color: "var(--text)" }}>
+          {typeof value === "number" ? value.toLocaleString() : value}
+        </span>
+        {bars && bars.length > 0 ? (
+          <MiniBarChart data={bars} />
+        ) : sub ? (
+          <p className="text-2xs" style={{ color: "var(--text-dim)" }}>{sub}</p>
+        ) : null}
+      </div>
+      {/* perforated notches, ticket-stub motif */}
+      <span
+        className="absolute -left-[7px] top-1/2 h-3.5 w-3.5 -translate-y-1/2 rounded-full"
+        style={{ background: "var(--bg-0)" }}
+      />
+      <span
+        className="absolute -right-[7px] top-1/2 h-3.5 w-3.5 -translate-y-1/2 rounded-full"
+        style={{ background: "var(--bg-0)" }}
+      />
     </div>
   );
 }
@@ -286,42 +181,6 @@ function RecentlyWatchedSkeleton() {
   );
 }
 
-/* ─── Poster component with initials fallback ─── */
-
-function Poster({
-  src,
-  alt,
-  className = "",
-}: {
-  src?: string;
-  alt: string | null | undefined;
-  className?: string;
-}) {
-  const [loadFailed, setLoadFailed] = useState(false);
-
-  useEffect(() => { setLoadFailed(false); }, [src]);
-
-  if (!src || loadFailed) {
-    return (
-      <div className={`flex items-center justify-center bg-gradient-to-br ${getGradient(alt)} ${className}`}>
-        <span className="text-xl font-bold text-white/60 select-none">
-          {getInitials(alt)}
-        </span>
-      </div>
-    );
-  }
-
-  return (
-    <img
-      src={src}
-      alt={alt ?? "Poster"}
-      className={`object-cover ${className}`}
-      loading="lazy"
-      onError={() => setLoadFailed(true)}
-    />
-  );
-}
-
 /* ─── Discovery Card ─── */
 
 type DiscoveryItem = {
@@ -351,34 +210,21 @@ function DiscoveryCard({ item, badge, reason, onSelect }: {
       aria-label={`View details for ${item.name}`}
     >
       <div
-        className="relative aspect-poster overflow-hidden rounded-xl shadow-lg transition-all duration-300 group-hover:shadow-card-hover"
+        className="relative aspect-poster overflow-hidden rounded-xl shadow-lg transition-all duration-300 group-hover:scale-[1.03] group-hover:shadow-card-hover"
         style={{ boxShadow: "inset 0 0 0 1px var(--border)" }}
       >
         <Poster src={item.poster} alt={item.name} className="h-full w-full" />
         {item.rating != null && item.rating > 0 && (
-          <div className="absolute top-2.5 left-2.5">
-            <span className="inline-flex items-center gap-1 rounded-md bg-black/70 px-2 py-0.5 text-2xs font-semibold text-amber-400 backdrop-blur-sm">
-              <Star className="h-2.5 w-2.5 fill-amber-400" />
-              {item.rating.toFixed(1)}
-            </span>
+          <div
+            className="absolute top-2 left-2 flex h-7 w-7 items-center justify-center rounded-full bg-black/70 backdrop-blur-sm"
+            style={{ boxShadow: "0 0 0 1.5px rgba(245,158,11,0.7)" }}
+          >
+            <span className="text-2xs font-bold tabular-nums text-amber-400">{item.rating.toFixed(1)}</span>
           </div>
         )}
-        {badge && <div className="absolute top-2.5 right-2.5">{badge}</div>}
-        <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
-        <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black via-black/60 to-transparent px-3 pb-3 pt-10">
-          {item.genres && item.genres.length > 0 && (
-            <div className="flex flex-wrap gap-1">
-              {item.genres.slice(0, 2).map((g) => (
-                <span
-                  key={g}
-                  className="rounded px-1.5 py-0.5 text-2xs backdrop-blur-sm"
-                  style={{ background: "var(--surface-strong)", color: "var(--text-dim)" }}
-                >
-                  {g}
-                </span>
-              ))}
-            </div>
-          )}
+        {badge && <div className="absolute top-2 right-2">{badge}</div>}
+        <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black via-black/55 to-transparent px-3 pb-2.5 pt-10 opacity-0 transition-opacity duration-200 group-hover:opacity-100">
+          <p className="truncate text-xs font-semibold text-white">{item.name}</p>
         </div>
       </div>
       <p
@@ -387,8 +233,10 @@ function DiscoveryCard({ item, badge, reason, onSelect }: {
       >
         {item.name}
       </p>
-      <p className="text-2xs" style={{ color: "var(--text-dim)" }}>
-        {item.year ?? ""}{item.type ? ` ${item.type === "movie" ? "Movie" : "Series"}` : ""}
+      <p className="truncate text-2xs" style={{ color: "var(--text-dim)" }}>
+        {item.year ?? ""}
+        {item.type ? ` · ${item.type === "movie" ? "Movie" : "Series"}` : ""}
+        {item.genres && item.genres.length > 0 ? ` · ${item.genres.slice(0, 2).join(", ")}` : ""}
       </p>
       {reason && (
         <p className="mt-0.5 truncate text-2xs italic" style={{ color: "var(--text-dim)" }} title={reason}>
@@ -664,68 +512,66 @@ export function DashboardPage() {
 
   return (
     <div className="space-y-8">
-      {/* ── Now Watching Banner ── */}
+      {/* ── Hero: Now Watching ── */}
       {activeCheckin && (
-        <div
-          className="flex items-center gap-4 rounded-2xl border border-claw-400/25 bg-claw-400/6 px-5 py-4"
+        <section
+          className="relative overflow-hidden rounded-3xl"
+          style={{ minHeight: "13rem", border: "1px solid var(--border)" }}
         >
           {activeCheckin.poster && (
-            <div className="h-14 w-10 flex-none overflow-hidden rounded-lg" style={{ boxShadow: "0 0 0 1px var(--border)" }}>
-              <img src={activeCheckin.poster} alt="" className="h-full w-full object-cover" loading="lazy" />
-            </div>
+            <img
+              src={activeCheckin.poster}
+              alt=""
+              aria-hidden="true"
+              className="absolute inset-0 h-full w-full object-cover blur-2xl scale-110 opacity-50"
+            />
           )}
-          <div className="min-w-0 flex-1">
-            <div className="flex items-center gap-2">
-              <span className="relative flex h-2 w-2">
-                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-claw-400 opacity-75" />
-                <span className="relative inline-flex rounded-full h-2 w-2 bg-claw-500" />
-              </span>
-              <span className="text-xs font-semibold uppercase tracking-wider text-claw-400">Now Watching</span>
-            </div>
-            <p className="mt-0.5 truncate text-sm font-semibold" style={{ color: "var(--text)" }}>{activeCheckin.name}</p>
-            {activeCheckin.season != null && activeCheckin.episode != null && (
-              <p className="text-xs" style={{ color: "var(--text-dim)" }}>
-                S{String(activeCheckin.season).padStart(2, "0")}:E{String(activeCheckin.episode).padStart(2, "0")}
-              </p>
+          <div
+            className="absolute inset-0"
+            style={{ background: "linear-gradient(110deg, var(--bg-0) 15%, color-mix(in srgb, var(--bg-0) 35%, transparent) 60%, transparent)" }}
+          />
+          <div className="relative z-10 flex h-full flex-col gap-5 p-6 sm:flex-row sm:items-center">
+            {activeCheckin.poster && (
+              <div className="h-32 w-[5.5rem] flex-none overflow-hidden rounded-xl shadow-feature" style={{ boxShadow: "0 0 0 1px var(--border)" }}>
+                <img src={activeCheckin.poster} alt="" className="h-full w-full object-cover" loading="lazy" />
+              </div>
             )}
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2">
+                <span className="relative flex h-2 w-2">
+                  <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-claw-400 opacity-75" />
+                  <span className="relative inline-flex rounded-full h-2 w-2 bg-claw-500" />
+                </span>
+                <span className="text-xs font-semibold uppercase tracking-wider text-claw-400">Now Watching</span>
+              </div>
+              <p className="mt-1 truncate text-2xl font-bold" style={{ color: "var(--text)" }}>{activeCheckin.name}</p>
+              {activeCheckin.season != null && activeCheckin.episode != null && (
+                <p className="mt-1 text-sm" style={{ color: "var(--text-dim)" }}>
+                  S{String(activeCheckin.season).padStart(2, "0")}:E{String(activeCheckin.episode).padStart(2, "0")}
+                </p>
+              )}
+            </div>
+            <div className="flex items-center gap-2 flex-none">
+              <button
+                type="button"
+                onClick={() => void handleCheckout(true)}
+                className="flex items-center gap-1.5 rounded-xl bg-claw-500 px-4 py-2.5 text-sm font-semibold text-white hover:bg-claw-600 active:scale-[0.98] transition-all"
+              >
+                <Check className="h-4 w-4" /> Finished
+              </button>
+              <button
+                type="button"
+                onClick={() => void handleCheckout(false)}
+                className="flex h-10 w-10 items-center justify-center rounded-xl transition-all active:scale-95"
+                style={{ border: "1px solid var(--border-strong)", background: "var(--bg-1)", color: "var(--text-dim)" }}
+                aria-label="Check out without logging"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
           </div>
-          <div className="flex items-center gap-2 flex-none">
-            <button
-              type="button"
-              onClick={() => void handleCheckout(true)}
-              className="flex items-center gap-1.5 rounded-xl bg-claw-500 px-3 py-2 text-xs font-semibold text-white hover:bg-claw-600 active:scale-[0.98] transition-all"
-            >
-              <Check className="h-3.5 w-3.5" /> Finished
-            </button>
-            <button
-              type="button"
-              onClick={() => void handleCheckout(false)}
-              className="flex h-8 w-8 items-center justify-center rounded-xl transition-all active:scale-95"
-              style={{ border: "1px solid var(--border-strong)", background: "var(--bg-1)", color: "var(--text-dim)" }}
-              aria-label="Check out without logging"
-            >
-              <X className="h-4 w-4" />
-            </button>
-          </div>
-        </div>
+        </section>
       )}
-
-      {/* ── Overview ── */}
-      <section>
-        <div className="grid gap-3 lg:grid-cols-[1fr_220px]">
-          <OverviewCard
-            stats={stats}
-            monthly={monthly}
-            genres={detailedStats?.genreDistribution ?? []}
-            loading={loading || detailedLoading}
-          />
-          <StreakCard
-            current={detailedStats?.currentStreak ?? 0}
-            longest={detailedStats?.longestStreak ?? 0}
-            loading={detailedLoading}
-          />
-        </div>
-      </section>
 
       {/* ── Continue Watching ── */}
       <section>
@@ -818,76 +664,9 @@ export function DashboardPage() {
         )}
       </section>
 
-      {/* ── Recently Watched ── */}
+      {/* ── Trending Now ── */}
       <section>
-        <SectionHeader title="Recently Watched" count={history.length}>
-          {!loading && history.length > 0 && (
-            <ScrollArrows
-              canScrollLeft={recentScroll.canScrollLeft}
-              canScrollRight={recentScroll.canScrollRight}
-              onScroll={recentScroll.scroll}
-            />
-          )}
-        </SectionHeader>
-        {loading ? (
-          <RecentlyWatchedSkeleton />
-        ) : history.length === 0 ? (
-          <div className="rounded-2xl py-12 text-center" style={{ border: "1px dashed var(--border-strong)" }}>
-            <Film className="mx-auto h-10 w-10" style={{ color: "var(--text-mute)" }} />
-            <p className="mt-3 text-sm" style={{ color: "var(--text-dim)" }}>No watch history yet.</p>
-          </div>
-        ) : (
-          <div ref={recentScroll.ref} className="flex gap-4 overflow-x-auto pb-2 scroll-smooth scrollbar-hide">
-            {history.map((event) => (
-              <div
-                key={event.id}
-                role="button"
-                tabIndex={0}
-                className="flex-none group cursor-pointer"
-                style={{ width: "11rem" }}
-                onClick={() => setSelectedItem(toSearchResult(event.imdbId, event.type === "movie" ? "movie" : "series", event.name, { poster: event.poster }))}
-                onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); setSelectedItem(toSearchResult(event.imdbId, event.type === "movie" ? "movie" : "series", event.name, { poster: event.poster })); } }}
-                aria-label={`View details for ${event.name}`}
-              >
-                <div
-                  className="relative aspect-poster overflow-hidden rounded-xl shadow-lg transition-all duration-300 group-hover:shadow-card-hover"
-                  style={{ boxShadow: "inset 0 0 0 1px var(--border)" }}
-                >
-                  <Poster src={event.poster} alt={event.name} className="h-full w-full" />
-                  <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black via-black/70 to-transparent px-3 pb-3 pt-12">
-                    {event.type === "episode" && event.season != null && event.episode != null ? (
-                      <span className="inline-block rounded px-2 py-0.5 text-xs font-semibold text-white backdrop-blur-sm" style={{ background: "var(--surface-strong)" }}>
-                        S{event.season}:E{event.episode}
-                      </span>
-                    ) : event.type === "movie" ? (
-                      <span className="inline-flex items-center gap-1 rounded px-2 py-0.5 text-xs font-semibold text-claw-300 backdrop-blur-sm bg-claw-500/20">
-                        <Film className="h-3 w-3" /> Movie
-                      </span>
-                    ) : null}
-                  </div>
-                  <div className="absolute top-2.5 right-2.5">
-                    <span className="rounded-md bg-black/70 px-2 py-0.5 text-2xs font-medium text-white/80 backdrop-blur-sm">
-                      {timeAgo(event.watchedAt)}
-                    </span>
-                  </div>
-                </div>
-                <p className="mt-2.5 truncate text-sm font-semibold transition-colors group-hover:text-claw-600" style={{ color: "var(--text)" }}>
-                  {event.name}
-                </p>
-                <p className="text-2xs" style={{ color: "var(--text-dim)" }}>
-                  {event.type === "episode" && event.season != null && event.episode != null
-                    ? `Season ${event.season}, Episode ${event.episode}`
-                    : event.type === "movie" ? "Movie" : ""}
-                </p>
-              </div>
-            ))}
-          </div>
-        )}
-      </section>
-
-      {/* ── Trending Movies ── */}
-      <section>
-        <SectionHeader title="Trending This Week">
+        <SectionHeader title="Trending Now">
           <div className="flex items-center gap-3">
             {!trendingLoading && trendingMovies.length > 0 && (
               <ScrollArrows
@@ -997,6 +776,73 @@ export function DashboardPage() {
         </section>
       )}
 
+      {/* ── Recently Watched ── */}
+      <section>
+        <SectionHeader title="Recently Watched" count={history.length}>
+          {!loading && history.length > 0 && (
+            <ScrollArrows
+              canScrollLeft={recentScroll.canScrollLeft}
+              canScrollRight={recentScroll.canScrollRight}
+              onScroll={recentScroll.scroll}
+            />
+          )}
+        </SectionHeader>
+        {loading ? (
+          <RecentlyWatchedSkeleton />
+        ) : history.length === 0 ? (
+          <div className="rounded-2xl py-12 text-center" style={{ border: "1px dashed var(--border-strong)" }}>
+            <Film className="mx-auto h-10 w-10" style={{ color: "var(--text-mute)" }} />
+            <p className="mt-3 text-sm" style={{ color: "var(--text-dim)" }}>No watch history yet.</p>
+          </div>
+        ) : (
+          <div ref={recentScroll.ref} className="flex gap-4 overflow-x-auto pb-2 scroll-smooth scrollbar-hide">
+            {history.map((event) => (
+              <div
+                key={event.id}
+                role="button"
+                tabIndex={0}
+                className="flex-none group cursor-pointer"
+                style={{ width: "11rem" }}
+                onClick={() => setSelectedItem(toSearchResult(event.imdbId, event.type === "movie" ? "movie" : "series", event.name, { poster: event.poster }))}
+                onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); setSelectedItem(toSearchResult(event.imdbId, event.type === "movie" ? "movie" : "series", event.name, { poster: event.poster })); } }}
+                aria-label={`View details for ${event.name}`}
+              >
+                <div
+                  className="relative aspect-poster overflow-hidden rounded-xl shadow-lg transition-all duration-300 group-hover:scale-[1.03] group-hover:shadow-card-hover"
+                  style={{ boxShadow: "inset 0 0 0 1px var(--border)" }}
+                >
+                  <Poster src={event.poster} alt={event.name} className="h-full w-full" />
+                  <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black via-black/70 to-transparent px-3 pb-3 pt-12">
+                    {event.type === "episode" && event.season != null && event.episode != null ? (
+                      <span className="inline-block rounded px-2 py-0.5 text-xs font-semibold text-white backdrop-blur-sm" style={{ background: "var(--surface-strong)" }}>
+                        S{event.season}:E{event.episode}
+                      </span>
+                    ) : event.type === "movie" ? (
+                      <span className="inline-flex items-center gap-1 rounded px-2 py-0.5 text-xs font-semibold text-claw-300 backdrop-blur-sm bg-claw-500/20">
+                        <Film className="h-3 w-3" /> Movie
+                      </span>
+                    ) : null}
+                  </div>
+                  <div className="absolute top-2.5 right-2.5">
+                    <span className="rounded-md bg-black/70 px-2 py-0.5 text-2xs font-medium text-white/80 backdrop-blur-sm">
+                      {timeAgo(event.watchedAt)}
+                    </span>
+                  </div>
+                </div>
+                <p className="mt-2.5 truncate text-sm font-semibold transition-colors group-hover:text-claw-600" style={{ color: "var(--text)" }}>
+                  {event.name}
+                </p>
+                <p className="text-2xs" style={{ color: "var(--text-dim)" }}>
+                  {event.type === "episode" && event.season != null && event.episode != null
+                    ? `Season ${event.season}, Episode ${event.episode}`
+                    : event.type === "movie" ? "Movie" : ""}
+                </p>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+
       {/* ── Detail Panel ── */}
       {selectedItem && (
         <DetailPanel
@@ -1073,6 +919,23 @@ export function DashboardPage() {
           )}
         </section>
       )}
+
+      {/* ── Stat strip ── */}
+      <section>
+        <SectionHeader title="Your Stats">
+          <Link to="/stats" className="text-sm font-medium text-claw-400 hover:text-claw-300 transition-colors">
+            Full stats &rarr;
+          </Link>
+        </SectionHeader>
+        <StatStrip
+          stats={stats}
+          monthly={monthly}
+          genres={detailedStats?.genreDistribution ?? []}
+          currentStreak={detailedStats?.currentStreak ?? 0}
+          longestStreak={detailedStats?.longestStreak ?? 0}
+          loading={loading || detailedLoading}
+        />
+      </section>
     </div>
   );
 }

--- a/apps/web/src/pages/StatsPage.tsx
+++ b/apps/web/src/pages/StatsPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { AlertCircle, Award, BarChart3, Film, Flame, Minus, Star, Trophy, TrendingDown, TrendingUp } from "lucide-react";
 import { api, DetailedWatchStats, WatchStats } from "../api";
+import { TicketTile } from "../components/TicketTile";
 
 type Milestone = { label: string; threshold: number; icon: typeof Film };
 
@@ -56,9 +57,9 @@ export function StatsPage() {
 
   if (error) {
     return (
-      <div className="mx-auto max-w-lg rounded-2xl border border-rose-500/20 bg-rose-500/5 p-8 text-center">
+      <div className="mx-auto max-w-lg rounded-2xl p-8 text-center" style={{ border: "1px solid rgba(244,63,94,0.2)", background: "rgba(244,63,94,0.05)" }}>
         <AlertCircle className="mx-auto h-12 w-12 text-rose-500" />
-        <p className="mt-3 text-lg font-semibold text-rose-600">{error}</p>
+        <p className="mt-3 text-lg font-semibold text-rose-500">{error}</p>
       </div>
     );
   }
@@ -66,13 +67,10 @@ export function StatsPage() {
   if (loading) {
     return (
       <div className="mx-auto max-w-4xl space-y-6">
-        <h2 className="text-2xl font-bold text-ink-900">Watch Statistics</h2>
-        <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        <h2 className="text-2xl font-bold" style={{ color: "var(--text)" }}>Watch Statistics</h2>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
           {Array.from({ length: 4 }).map((_, i) => (
-            <div key={i} className="rounded-2xl border border-ink-100 bg-cream-50 p-5">
-              <div className="skeleton h-8 w-16 rounded-lg mb-2" />
-              <div className="skeleton h-4 w-24 rounded" />
-            </div>
+            <div key={i} className="skeleton h-28 rounded-2xl" />
           ))}
         </div>
         <div className="skeleton h-64 rounded-2xl" />
@@ -99,15 +97,15 @@ export function StatsPage() {
 
   return (
     <div className="mx-auto max-w-4xl space-y-8">
-      <h2 className="text-2xl font-bold text-ink-900">Watch Statistics</h2>
+      <h2 className="text-2xl font-bold" style={{ color: "var(--text)" }}>Watch Statistics</h2>
 
-      {/* Summary cards */}
+      {/* Summary tiles */}
       {stats && (
-        <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
-          <StatCard label="Movies" value={stats.totalMovies} icon={Film} color="red" />
-          <StatCard label="Episodes" value={stats.totalEpisodes} icon={BarChart3} color="violet" />
-          <StatCard label="Current Streak" value={detailed?.currentStreak ?? 0} icon={Flame} color="amber" suffix="d" />
-          <StatCard label="Longest Streak" value={detailed?.longestStreak ?? 0} icon={Trophy} color="emerald" suffix="d" />
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <TicketTile icon={Film} label="Movies" value={stats.totalMovies} />
+          <TicketTile icon={BarChart3} label="Episodes" value={stats.totalEpisodes} />
+          <TicketTile icon={Flame} label="Current Streak" value={`${detailed?.currentStreak ?? 0}d`} />
+          <TicketTile icon={Trophy} label="Longest Streak" value={`${detailed?.longestStreak ?? 0}d`} />
         </div>
       )}
 
@@ -122,18 +120,19 @@ export function StatsPage() {
 
       {/* Monthly activity chart */}
       {detailed && detailed.monthly.length > 0 && (
-        <section className="rounded-2xl border border-ink-100 bg-cream-50 p-5 shadow-sm">
+        <section className="rounded-2xl p-5" style={{ border: "1px solid var(--border)", background: "var(--bg-1)" }}>
           <div className="mb-4 flex items-center justify-between gap-3">
-            <h3 className="text-lg font-semibold text-ink-900">Monthly Activity</h3>
+            <h3 className="text-lg font-semibold" style={{ color: "var(--text)" }}>Monthly Activity</h3>
             {momComparison && (
               <span
                 className={`flex items-center gap-1 text-xs font-medium ${
                   momComparison.diff > 0
-                    ? "text-emerald-600"
+                    ? "text-emerald-500"
                     : momComparison.diff < 0
-                      ? "text-rose-600"
-                      : "text-ink-500"
+                      ? "text-rose-500"
+                      : ""
                 }`}
+                style={momComparison.diff === 0 ? { color: "var(--text-dim)" } : undefined}
               >
                 {momComparison.diff > 0 ? (
                   <TrendingUp className="h-3.5 w-3.5" />
@@ -165,38 +164,41 @@ export function StatsPage() {
                   onTouchStart={() => setHoveredMonth(m.month)}
                 >
                   {isHovered && (
-                    <div className="absolute bottom-full z-10 mb-1.5 whitespace-nowrap rounded-lg border border-ink-100 bg-ink-900 px-2.5 py-1.5 text-2xs shadow-lg">
-                      <p className="font-semibold text-cream-50">
+                    <div
+                      className="absolute bottom-full z-10 mb-1.5 whitespace-nowrap rounded-lg px-2.5 py-1.5 text-2xs shadow-lg"
+                      style={{ border: "1px solid var(--border)", background: "var(--bg-2)" }}
+                    >
+                      <p className="font-semibold" style={{ color: "var(--bg-0)" }}>
                         {new Date(m.month + "-15").toLocaleDateString(undefined, { month: "long", year: "numeric" })}
                       </p>
                       <p className="text-claw-400">{m.movies} movies</p>
-                      <p className="text-plum-400">{m.episodes} episodes</p>
+                      <p className="text-plum-500">{m.episodes} episodes</p>
                     </div>
                   )}
-                  <span className="text-2xs text-ink-500 tabular-nums">{total || ""}</span>
+                  <span className="text-2xs tabular-nums" style={{ color: "var(--text-mute)" }}>{total || ""}</span>
                   <div className="flex w-full flex-col justify-end" style={{ height: "140px" }}>
                     {episodeHeight > 0 && (
                       <div
-                        className={`w-full rounded-t bg-plum-500/70 transition-all duration-500 ${isHovered ? "bg-plum-400" : ""}`}
+                        className={`w-full rounded-t bg-plum-500/70 transition-all duration-500 ${isHovered ? "bg-plum-500" : ""}`}
                         style={{ height: `${episodeHeight}%` }}
                       />
                     )}
                     {movieHeight > 0 && (
                       <div
-                        className={`w-full bg-claw-500/70 transition-all duration-500 ${episodeHeight === 0 ? "rounded-t" : ""} rounded-b ${isHovered ? "bg-claw-400" : ""}`}
+                        className={`w-full bg-claw-500/70 transition-all duration-500 ${episodeHeight === 0 ? "rounded-t" : ""} rounded-b ${isHovered ? "bg-claw-500" : ""}`}
                         style={{ height: `${movieHeight}%` }}
                       />
                     )}
                     {total === 0 && (
-                      <div className="w-full rounded bg-ink-100" style={{ height: "2%" }} />
+                      <div className="w-full rounded" style={{ height: "2%", background: "var(--surface-strong)" }} />
                     )}
                   </div>
-                  <span className="text-2xs text-ink-500">{label}</span>
+                  <span className="text-2xs" style={{ color: "var(--text-mute)" }}>{label}</span>
                 </div>
               );
             })}
           </div>
-          <div className="mt-3 flex items-center gap-4 text-xs text-ink-500">
+          <div className="mt-3 flex items-center gap-4 text-xs" style={{ color: "var(--text-dim)" }}>
             <span className="flex items-center gap-1.5">
               <span className="h-2.5 w-2.5 rounded-sm bg-claw-500/70" /> Movies
             </span>
@@ -209,14 +211,15 @@ export function StatsPage() {
 
       {/* Genre distribution */}
       {detailed && detailed.genreDistribution.length > 0 && (
-        <section className="rounded-2xl border border-ink-100 bg-cream-50 p-5 shadow-sm">
-          <h3 className="mb-4 text-lg font-semibold text-ink-900">Top Genres</h3>
+        <section className="rounded-2xl p-5" style={{ border: "1px solid var(--border)", background: "var(--bg-1)" }}>
+          <h3 className="mb-4 text-lg font-semibold" style={{ color: "var(--text)" }}>Top Genres</h3>
           <div className="space-y-2.5">
             {detailed.genreDistribution.map((g) => (
               <div key={g.genre} className="flex items-center gap-3">
-                <span className="w-28 shrink-0 truncate text-sm text-ink-600">{g.genre}</span>
+                <span className="w-28 shrink-0 truncate text-sm" style={{ color: "var(--text-dim)" }}>{g.genre}</span>
                 <div
-                  className="flex-1 h-5 rounded-full bg-ink-100 overflow-hidden"
+                  className="flex-1 h-5 overflow-hidden rounded-full"
+                  style={{ background: "var(--surface-strong)" }}
                   title={`${g.genre}: ${g.count} watched`}
                 >
                   <div
@@ -224,7 +227,7 @@ export function StatsPage() {
                     style={{ width: `${(g.count / maxGenreCount) * 100}%` }}
                   />
                 </div>
-                <span className="w-8 text-right text-sm tabular-nums text-ink-500">{g.count}</span>
+                <span className="w-8 text-right text-sm tabular-nums" style={{ color: "var(--text-mute)" }}>{g.count}</span>
               </div>
             ))}
           </div>
@@ -233,30 +236,32 @@ export function StatsPage() {
 
       {/* Top rated watched content */}
       {detailed && detailed.topRated.length > 0 && (
-        <section className="rounded-2xl border border-ink-100 bg-cream-50 p-5 shadow-sm">
-          <h3 className="mb-4 text-lg font-semibold flex items-center gap-2 text-ink-900">
-            <Star className="h-5 w-5 text-amber-500" /> Top Rated Watched
+        <section className="rounded-2xl p-5" style={{ border: "1px solid var(--border)", background: "var(--bg-1)" }}>
+          <h3 className="mb-4 flex items-center gap-2 text-lg font-semibold" style={{ color: "var(--text)" }}>
+            <Star className="h-5 w-5 text-amber-400" /> Top Rated Watched
           </h3>
           <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-5">
             {detailed.topRated.map((item) => (
               <div key={item.imdbId} className="group">
-                <div className="relative overflow-hidden rounded-xl ring-1 ring-ink-900/10" style={{ aspectRatio: "2/3" }}>
+                <div
+                  className="relative overflow-hidden rounded-xl transition-transform duration-300 group-hover:scale-[1.03]"
+                  style={{ aspectRatio: "2/3", boxShadow: "inset 0 0 0 1px var(--border)" }}
+                >
                   {item.poster ? (
                     <img src={item.poster} alt={item.name} className="h-full w-full object-cover" loading="lazy" />
                   ) : (
-                    <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-ink-100 to-ink-200">
-                      <Film className="h-8 w-8 text-ink-400" />
+                    <div className="flex h-full w-full items-center justify-center" style={{ background: "var(--surface-strong)" }}>
+                      <Film className="h-8 w-8" style={{ color: "var(--text-mute)" }} />
                     </div>
                   )}
                   {item.rating != null && (
-                    <div className="absolute top-2 right-2 flex items-center gap-1 rounded-md bg-ink-900/80 px-1.5 py-0.5 text-xs font-bold text-amber-400 backdrop-blur-sm">
-                      <Star className="h-3 w-3 fill-amber-400" />
-                      {item.rating.toFixed(1)}
+                    <div className="absolute top-2 left-2 flex h-7 w-7 items-center justify-center rounded-full bg-black/70 backdrop-blur-sm" style={{ boxShadow: "0 0 0 1.5px rgba(245,158,11,0.7)" }}>
+                      <span className="text-2xs font-bold tabular-nums text-amber-400">{item.rating.toFixed(1)}</span>
                     </div>
                   )}
                 </div>
-                <p className="mt-1.5 truncate text-sm font-medium text-ink-900">{item.name}</p>
-                <p className="text-2xs text-ink-500 capitalize">{item.type}</p>
+                <p className="mt-1.5 truncate text-sm font-medium" style={{ color: "var(--text)" }}>{item.name}</p>
+                <p className="text-2xs capitalize" style={{ color: "var(--text-mute)" }}>{item.type}</p>
               </div>
             ))}
           </div>
@@ -294,30 +299,32 @@ function MilestoneBadges({
   if (earned.length === 0 && upcoming.length === 0) return null;
 
   return (
-    <section className="rounded-2xl border border-ink-100 bg-cream-50 p-5 shadow-sm">
-      <h3 className="mb-4 text-lg font-semibold flex items-center gap-2 text-ink-900">
-        <Award className="h-5 w-5 text-amber-500" /> Achievements
+    <section className="rounded-2xl p-5" style={{ border: "1px solid var(--border)", background: "var(--bg-1)" }}>
+      <h3 className="mb-4 flex items-center gap-2 text-lg font-semibold" style={{ color: "var(--text)" }}>
+        <Award className="h-5 w-5 text-amber-400" /> Achievements
       </h3>
       {earned.length > 0 ? (
         <div className="flex flex-wrap gap-2">
           {earned.map((m) => (
             <span
               key={m.label}
-              className="flex items-center gap-1.5 rounded-full border border-amber-500/30 bg-amber-500/10 px-3 py-1.5 text-xs font-medium text-amber-700"
+              className="flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium text-amber-400"
+              style={{ border: "1px solid rgba(245,158,11,0.3)", background: "rgba(245,158,11,0.1)" }}
             >
               <m.icon className="h-3.5 w-3.5" /> {m.label}
             </span>
           ))}
         </div>
       ) : (
-        <p className="text-sm text-ink-500">No badges earned yet — keep watching!</p>
+        <p className="text-sm" style={{ color: "var(--text-dim)" }}>No badges earned yet — keep watching!</p>
       )}
       {upcoming.length > 0 && (
         <div className="mt-3 flex flex-wrap gap-2">
           {upcoming.map((m) => (
             <span
               key={m.label}
-              className="flex items-center gap-1.5 rounded-full border border-ink-100 bg-ink-50 px-3 py-1.5 text-xs font-medium text-ink-500"
+              className="flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium"
+              style={{ border: "1px solid var(--border)", background: "var(--surface-strong)", color: "var(--text-dim)" }}
             >
               <m.icon className="h-3.5 w-3.5" /> {m.label} ({m.value}/{m.threshold})
             </span>
@@ -325,43 +332,5 @@ function MilestoneBadges({
         </div>
       )}
     </section>
-  );
-}
-
-function StatCard({
-  label,
-  value,
-  icon: Icon,
-  color,
-  suffix = "",
-}: {
-  label: string;
-  value: number;
-  icon: typeof Film;
-  color: "red" | "violet" | "amber" | "emerald";
-  suffix?: string;
-}) {
-  const colorMap = {
-    red: { bg: "from-claw-500/10", border: "border-claw-500/20", icon: "text-claw-500" },
-    violet: { bg: "from-plum-500/10", border: "border-plum-500/20", icon: "text-plum-500" },
-    amber: { bg: "from-amber-500/10", border: "border-amber-500/20", icon: "text-amber-400" },
-    emerald: { bg: "from-emerald-500/10", border: "border-emerald-500/20", icon: "text-emerald-400" },
-  };
-  const c = colorMap[color];
-
-  return (
-    <div className={`rounded-2xl border ${c.border} bg-gradient-to-br ${c.bg} bg-cream-50 p-5 shadow-sm`}>
-      <div className="flex items-center gap-3">
-        <div className={`flex h-10 w-10 items-center justify-center rounded-xl bg-ink-100 ${c.icon}`}>
-          <Icon className="h-5 w-5" />
-        </div>
-        <div>
-          <span className="text-2xl font-bold text-ink-900 tabular-nums">
-            {value.toLocaleString()}{suffix}
-          </span>
-          <p className="text-xs text-ink-500 font-medium">{label}</p>
-        </div>
-      </div>
-    </div>
   );
 }


### PR DESCRIPTION
## Summary
This PR significantly restructures the dashboard UI with a new navigation paradigm, introducing a collapsible sidebar, command palette for global search/navigation, and a redesigned stats section. The changes modernize the information architecture while maintaining all existing functionality.

## Key Changes

### Navigation & Layout
- **New Sidebar Component**: Added a collapsible sidebar (`Sidebar.tsx`) with pinnable state that persists to localStorage. Expands on hover or when pinned, showing full navigation labels.
- **Command Palette**: Implemented a global command palette (`CommandPalette.tsx`) accessible via `Cmd/Ctrl+K` for searching titles and navigating to main sections.
- **Top Bar Redesign**: Simplified header with integrated search button that opens the command palette. Adjusted for sidebar layout with `sm:pl-16` offset.
- **Mobile-First**: Sidebar hidden on mobile, command palette available on all screen sizes.

### Dashboard Stats Redesign
- **Removed Overview Card**: Eliminated the large unified overview card with 5 stat blocks and genre section.
- **Removed Streak Card**: Consolidated streak display into the new stat strip.
- **New StatStrip Component**: Replaced with a compact 4-column grid of "ticket tile" stats (day streak, movies watched, episodes watched, top genre) with perforated edge notches for visual interest.
- **TicketTile Component**: New reusable component for individual stat tiles with optional mini bar charts and subtitles.

### Component Extraction
- **Poster Component**: Extracted `Poster` component to its own file (`Poster.tsx`) for reusability across the app. Handles image loading failures with gradient fallback using initials.
- **Utility Imports**: Removed unused imports (`getInitials`, `getGradient`) from DashboardPage, now imported by Poster component.

### Visual Enhancements
- **Hero Section**: Redesigned "Now Watching" banner with blurred background image, larger poster, and repositioned action buttons.
- **Discovery Cards**: Added subtle scale transform on hover (`group-hover:scale-[1.03]`), improved rating badge styling (circular with glow effect), and enhanced overlay with title display.
- **Section Reordering**: Moved "Trending Now" section before "Recently Watched" for better content hierarchy.
- **Removed Star Icon**: Eliminated star icon from rating badges, using circular badge with numeric display instead.

### Code Organization
- Removed `StatBlock` and `OverviewCard` components (no longer needed).
- Removed `StreakCard` component (functionality merged into StatStrip).
- Cleaned up unused icon imports (removed `Star`).
- Maintained all data fetching and state management logic.

## Implementation Details
- Command palette debounces search queries (250ms) and merges movie/series results up to 8 items.
- Sidebar uses CSS transitions for smooth expand/collapse animation.
- All new components follow existing design system variables (`--bg-0`, `--text`, `--border`, etc.).
- Keyboard navigation in command palette (arrow keys, Enter, Escape).
- Poster component reuses existing gradient and initials utilities from carousel-utils.

https://claude.ai/code/session_01VS33qSshUFbLJocrTD2u7o