### PR TITLE
Implement self-hosted gap analysis: security hardening, backup/export, CI gating, and UI additions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  lint-typecheck-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Prisma client
+        run: pnpm --filter @cataloggy/api prisma:generate
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Build
+        run: pnpm build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,14 @@ on:
 jobs:
   lint-typecheck-build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/dockerpublish.yml
+++ b/.github/workflows/dockerpublish.yml
@@ -13,10 +13,14 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
@@ -52,6 +56,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/dockerpublish.yml
+++ b/.github/workflows/dockerpublish.yml
@@ -11,8 +11,40 @@ env:
   IMAGE_PREFIX: ghcr.io/theshield2594/cataloggy
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Prisma client
+        run: pnpm --filter @cataloggy/api prisma:generate
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Build
+        run: pnpm build
+
   build-and-push:
     runs-on: ubuntu-latest
+    needs: test
     permissions:
       contents: read
       packages: write

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ http://192.168.1.25:7002
 ### Install as a PWA
 
 - **iOS Safari:** **Share** → **Add to Home Screen**
+- **Android Chrome:** **⋮ menu** → **Add to Home screen** (Chrome may also show an automatic "Install app" banner)
 
 ### Install Omni add-on on Apple TV
 
@@ -110,6 +111,23 @@ http://LAN-IP:7001/manifest.json
 ```
 
 > **Important:** Apple TV cannot use `localhost` URLs. The add-on URL must be reachable on your LAN from Apple TV.
+
+### Install the add-on on Android / Android TV
+
+Cataloggy's add-on service speaks the standard Stremio add-on protocol, so it works with the [Stremio app](https://www.stremio.com/downloads) on both Android phones/tablets and Android TV:
+
+1. Install **Stremio** from the Play Store (or sideload the APK on Android TV devices without Play Store access).
+2. Open Stremio → **Add-ons** → search icon / **"Community Add-ons"** → paste the add-on URL:
+
+   ```text
+   http://LAN-IP:7001/manifest.json
+   ```
+
+3. Confirm installation. Cataloggy's catalogs and metadata now appear inside Stremio's **Board**/**Discover** views.
+
+> **Important:** Android TV cannot use `localhost` URLs either — use your LAN IP (or your public domain, if set up via the Nginx Proxy Manager section below) so the URL is reachable from the TV.
+
+The web app itself also installs fine as a PWA on Android TV browsers that support it, but the Stremio app gives a better remote-control-friendly experience for browsing/playback on a TV.
 
 ## Nginx Proxy Manager Setup
 
@@ -127,6 +145,30 @@ https://cataloggy.domain.com/addon/manifest.json
 ```
 
 LAN development URLs stay available, so you can continue using direct local access like `http://LAN-IP:7002` and `http://LAN-IP:7001/manifest.json` on your network.
+
+## Backup & Restore
+
+Cataloggy stores everything in the Postgres database run by the `db` service in `docker-compose.yml`. Two helper scripts wrap `pg_dump`/`psql` for simple backup and restore:
+
+```bash
+# Back up the database to backups/cataloggy-<timestamp>.sql.gz
+./scripts/backup.sh
+
+# Restore from a backup file (prompts for confirmation; overwrites current data)
+./scripts/restore.sh backups/cataloggy-20260101-120000.sql.gz
+```
+
+Both scripts run against the `db` service via `docker compose exec`, so Docker Compose must already be up. They read `POSTGRES_USER`/`POSTGRES_DB` from the environment (same defaults as `docker-compose.yml`: `postgres`/`cataloggy`), and `backup.sh` writes into `BACKUP_DIR` (defaults to `./backups`).
+
+To schedule automatic backups, add a cron entry that runs `backup.sh` on a schedule, e.g. nightly at 3am:
+
+```cron
+0 3 * * * cd /path/to/cataloggy && ./scripts/backup.sh >> backups/backup.log 2>&1
+```
+
+### Export / import your data
+
+In addition to full database backups, Settings → Data lets you export your lists, watch history, series progress, and ratings as a single JSON file, and re-import it later (e.g. after a fresh install, or to migrate to a new instance). The API also accepts CSV watch-history imports (columns: `imdbId`, `type`, `watchedAt`, with optional `season`/`episode`) for importing history exported from other tools.
 
 ## Useful Commands
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -146,8 +146,12 @@ const start = async () => {
     setInterval(() => {
       void (async () => {
         const profileId = await getDefaultProfileId();
-        await pollTraktHistory(app.log, profileId);
-        await syncTraktWatchlist(app.log, profileId);
+        await pollTraktHistory(app.log, profileId).catch((error) => {
+          app.log.error(error, "Scheduled Trakt history poll failed");
+        });
+        await syncTraktWatchlist(app.log, profileId).catch((error) => {
+          app.log.error(error, "Scheduled Trakt watchlist sync failed");
+        });
       })().catch((error) => {
         app.log.error(error, "Scheduled Trakt poll failed");
       });

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,7 +5,7 @@ import { applyCorsHeaders } from "./lib/cors.js";
 import { verifyToken } from "./lib/auth.js";
 import { getAiRecommendations, isAiConfigured } from "./lib/ai.js";
 import { trendingCacheDeletePrefix } from "./lib/cache.js";
-import { pollTraktHistory } from "./lib/trakt-client.js";
+import { pollTraktHistory, syncTraktWatchlist } from "./lib/trakt-client.js";
 import { ensureDefaultWatchlist } from "./lib/watchlist.js";
 import { getDefaultProfileId } from "./lib/profile.js";
 import { checkUpcomingEpisodesAndNotify } from "./lib/notify-episodes.js";
@@ -147,6 +147,7 @@ const start = async () => {
       void (async () => {
         const profileId = await getDefaultProfileId();
         await pollTraktHistory(app.log, profileId);
+        await syncTraktWatchlist(app.log, profileId);
       })().catch((error) => {
         app.log.error(error, "Scheduled Trakt poll failed");
       });

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -28,6 +28,7 @@ import stremioRoutes from "./routes/stremio.js";
 import traktRoutes from "./routes/trakt.js";
 import scrobbleRoutes from "./routes/scrobble.js";
 import pushRoutes from "./routes/push.js";
+import exportRoutes from "./routes/export.js";
 import plexWebhookRoutes from "./routes/webhooks/plex.js";
 import jellyfinWebhookRoutes from "./routes/webhooks/jellyfin.js";
 
@@ -126,6 +127,7 @@ app.register(stremioRoutes);
 app.register(traktRoutes);
 app.register(scrobbleRoutes);
 app.register(pushRoutes);
+app.register(exportRoutes);
 app.register(plexWebhookRoutes);
 app.register(jellyfinWebhookRoutes);
 

--- a/apps/api/src/lib/trakt-client.ts
+++ b/apps/api/src/lib/trakt-client.ts
@@ -202,12 +202,27 @@ export const syncTraktWatchlist = async (
   const localItems = await prisma.listItem.findMany({ where: { listId: watchlist.id } });
   const localByKey = new Map(localItems.map((item) => [`${item.type}:${item.imdbId}`, item]));
 
+  // Keys that were on Trakt and locally last sync, are still on Trakt now, but
+  // are no longer present locally: a local removal whose push to Trakt must
+  // have failed. Without this check, the loop below would treat them as new
+  // Trakt-side adds and silently resurrect the item the user just removed.
+  const pendingRemovalRetryKeys = previousSnapshot
+    ? new Set([...previousSnapshot].filter((key) => traktKeys.has(key) && !localByKey.has(key)))
+    : new Set<string>();
+
   let addedLocally = 0;
   let removedLocally = 0;
   let pushedToTrakt = 0;
 
   for (const item of traktItems) {
-    if (localByKey.has(watchlistSnapshotKey(item))) continue;
+    const key = watchlistSnapshotKey(item);
+    if (localByKey.has(key)) continue;
+
+    if (pendingRemovalRetryKeys.has(key)) {
+      await pushTraktWatchlistChange("remove", item, logger);
+      pushedToTrakt += 1;
+      continue;
+    }
 
     const itemType = item.type === "movie" ? ItemType.movie : ItemType.series;
     await prisma.item.upsert({

--- a/apps/api/src/lib/trakt-client.ts
+++ b/apps/api/src/lib/trakt-client.ts
@@ -1,7 +1,13 @@
-import { ItemType } from "@prisma/client";
-import { TraktClient, computeTokenExpiresAt, type TraktScrobblePayload } from "../trakt.js";
+import { ItemType, ListItemType, Prisma } from "@prisma/client";
+import {
+  TraktClient,
+  computeTokenExpiresAt,
+  type TraktScrobblePayload,
+  type TraktWatchlistMutationPayload,
+} from "../trakt.js";
 import { prisma } from "./prisma.js";
 import { upsertSeriesProgressIfNewer } from "./series-progress.js";
+import { getDefaultWatchlist } from "./watchlist.js";
 import type { SeriesProgressCandidate } from "./types.js";
 import type { FastifyRequest } from "fastify";
 
@@ -100,6 +106,149 @@ export const syncWatchEventToTrakt = (
       logger.warn({ error }, "Failed to persist Trakt history id on watch event");
     }
   })();
+};
+
+export type WatchlistItemRef = { type: "movie" | "series"; imdbId: string };
+
+const toTraktWatchlistPayload = (item: WatchlistItemRef): TraktWatchlistMutationPayload =>
+  item.type === "movie"
+    ? { movies: [{ ids: { imdb: item.imdbId } }] }
+    : { shows: [{ ids: { imdb: item.imdbId } }] };
+
+/**
+ * Best-effort: pushes a single watchlist add/remove to Trakt. Never throws,
+ * no-ops when Trakt isn't connected.
+ */
+export const pushTraktWatchlistChange = async (
+  action: "add" | "remove",
+  item: WatchlistItemRef,
+  logger: FastifyRequest["log"]
+): Promise<void> => {
+  if (!(await isTraktConnected())) return;
+
+  try {
+    const client = await getTraktClient();
+    const payload = toTraktWatchlistPayload(item);
+    if (action === "add") {
+      await client.addToWatchlist(payload, logger);
+    } else {
+      await client.removeFromWatchlist(payload, logger);
+    }
+  } catch (error) {
+    logger.warn({ error, action, item }, "Trakt watchlist push failed");
+  }
+};
+
+const TRAKT_WATCHLIST_SNAPSHOT_KEY = "trakt:watchlistSnapshot";
+
+const watchlistSnapshotKey = (item: WatchlistItemRef) => `${item.type}:${item.imdbId}`;
+
+const readWatchlistSnapshot = async (): Promise<Set<string> | null> => {
+  const row = await prisma.kV.findUnique({ where: { key: TRAKT_WATCHLIST_SNAPSHOT_KEY } });
+  if (!row) return null;
+  try {
+    return new Set(JSON.parse(row.value) as string[]);
+  } catch {
+    return null;
+  }
+};
+
+const writeWatchlistSnapshot = async (keys: Set<string>): Promise<void> => {
+  const value = JSON.stringify([...keys]);
+  await prisma.kV.upsert({
+    where: { key: TRAKT_WATCHLIST_SNAPSHOT_KEY },
+    create: { key: TRAKT_WATCHLIST_SNAPSHOT_KEY, value, updatedAt: new Date() },
+    update: { value, updatedAt: new Date() },
+  });
+};
+
+/**
+ * Two-way reconciliation between Trakt's watchlist and the local default
+ * watchlist. Items present on Trakt but missing locally are added; items
+ * that disappeared from Trakt since the last sync (and are still present
+ * locally) are removed to mirror the removal. Local items that were never
+ * confirmed on Trakt (e.g. a push that failed at add-time) are retried
+ * instead of deleted, so a transient failure can't silently drop an item.
+ */
+export const syncTraktWatchlist = async (
+  logger: FastifyRequest["log"],
+  profileId: string
+): Promise<{ addedLocally: number; removedLocally: number; pushedToTrakt: number }> => {
+  if (!(await isTraktConnected())) {
+    return { addedLocally: 0, removedLocally: 0, pushedToTrakt: 0 };
+  }
+
+  const client = await getTraktClient();
+  const [watchlistMovies, watchlistShows] = await Promise.all([
+    client.fetchWatchlistMovies(logger),
+    client.fetchWatchlistShows(logger),
+  ]);
+
+  const traktItems: WatchlistItemRef[] = [
+    ...watchlistMovies
+      .map((e) => e.movie?.ids?.imdb)
+      .filter((id): id is string => !!id)
+      .map((imdbId) => ({ type: "movie" as const, imdbId })),
+    ...watchlistShows
+      .map((e) => e.show?.ids?.imdb)
+      .filter((id): id is string => !!id)
+      .map((imdbId) => ({ type: "series" as const, imdbId })),
+  ];
+  const traktKeys = new Set(traktItems.map(watchlistSnapshotKey));
+
+  const previousSnapshot = await readWatchlistSnapshot();
+
+  const watchlist = await getDefaultWatchlist(profileId);
+  const localItems = await prisma.listItem.findMany({ where: { listId: watchlist.id } });
+  const localByKey = new Map(localItems.map((item) => [`${item.type}:${item.imdbId}`, item]));
+
+  let addedLocally = 0;
+  let removedLocally = 0;
+  let pushedToTrakt = 0;
+
+  for (const item of traktItems) {
+    if (localByKey.has(watchlistSnapshotKey(item))) continue;
+
+    const itemType = item.type === "movie" ? ItemType.movie : ItemType.series;
+    await prisma.item.upsert({
+      where: { type_imdbId: { type: itemType, imdbId: item.imdbId } },
+      create: { type: itemType, imdbId: item.imdbId },
+      update: {},
+    });
+
+    try {
+      await prisma.listItem.create({
+        data: { listId: watchlist.id, type: item.type as ListItemType, imdbId: item.imdbId },
+      });
+      addedLocally += 1;
+    } catch (error) {
+      if (!(error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002")) throw error;
+    }
+  }
+
+  if (previousSnapshot) {
+    for (const [key, item] of localByKey) {
+      if (traktKeys.has(key)) continue;
+
+      if (previousSnapshot.has(key)) {
+        await prisma.listItem.delete({
+          where: { listId_type_imdbId: { listId: item.listId, type: item.type, imdbId: item.imdbId } },
+        });
+        removedLocally += 1;
+      } else {
+        await pushTraktWatchlistChange(
+          "add",
+          { type: item.type as "movie" | "series", imdbId: item.imdbId },
+          logger
+        );
+        pushedToTrakt += 1;
+      }
+    }
+  }
+
+  await writeWatchlistSnapshot(traktKeys);
+
+  return { addedLocally, removedLocally, pushedToTrakt };
 };
 
 export const TRAKT_LAST_POLLED_AT_KEY = "trakt:lastPolledAt";

--- a/apps/api/src/lib/trakt-client.ts
+++ b/apps/api/src/lib/trakt-client.ts
@@ -1,5 +1,5 @@
 import { ItemType } from "@prisma/client";
-import { TraktClient, computeTokenExpiresAt } from "../trakt.js";
+import { TraktClient, computeTokenExpiresAt, type TraktScrobblePayload } from "../trakt.js";
 import { prisma } from "./prisma.js";
 import { upsertSeriesProgressIfNewer } from "./series-progress.js";
 import type { SeriesProgressCandidate } from "./types.js";
@@ -18,6 +18,88 @@ export const getTraktClient = async (): Promise<TraktClient> => {
 
 export const resetTraktClient = () => {
   traktClient = null;
+};
+
+export const isTraktConnected = async (): Promise<boolean> => {
+  if (!process.env.TRAKT_CLIENT_ID?.trim() || !process.env.TRAKT_CLIENT_SECRET?.trim()) return false;
+  const token = await prisma.traktToken.findUnique({ where: { id: "default" } });
+  return !!token;
+};
+
+export type TraktScrobbleAction = "start" | "pause" | "stop";
+
+export type TraktScrobbleParams = {
+  type: "movie" | "episode";
+  imdbId: string;
+  seriesImdbId?: string | null;
+  season?: number | null;
+  episode?: number | null;
+  progress: number;
+};
+
+/**
+ * Pushes a live playback transition to Trakt, mirroring what Trakt's own
+ * apps/plugins do. Best-effort: never throws, returns null on any failure
+ * or when Trakt isn't connected. On "stop", a non-null return is the Trakt
+ * history id created for the watch (only when progress crossed Trakt's own
+ * completion threshold).
+ */
+export const pushTraktScrobble = async (
+  action: TraktScrobbleAction,
+  params: TraktScrobbleParams,
+  logger: FastifyRequest["log"]
+): Promise<bigint | null> => {
+  if (params.type === "episode" && (params.season == null || params.episode == null)) return null;
+  if (!(await isTraktConnected())) return null;
+
+  try {
+    const client = await getTraktClient();
+    const progress = Math.max(0, Math.min(100, Math.round(params.progress)));
+
+    const payload: TraktScrobblePayload =
+      params.type === "movie"
+        ? { movie: { ids: { imdb: params.imdbId } }, progress }
+        : {
+            show: { ids: { imdb: params.seriesImdbId ?? params.imdbId } },
+            episode: { season: params.season as number, number: params.episode as number },
+            progress
+          };
+
+    const response =
+      action === "start"
+        ? await client.scrobbleStart(payload, logger)
+        : action === "pause"
+          ? await client.scrobblePause(payload, logger)
+          : await client.scrobbleStop(payload, logger);
+
+    return response.id != null ? BigInt(response.id) : null;
+  } catch (error) {
+    logger.warn({ error, action }, "Trakt scrobble push failed");
+    return null;
+  }
+};
+
+/**
+ * Fire-and-forget: pushes a completed watch to Trakt's history (if not
+ * already synced) and persists the returned Trakt history id, so a later
+ * pollTraktHistory() run recognizes it and doesn't import it as a duplicate.
+ */
+export const syncWatchEventToTrakt = (
+  watchEvent: { id: string; traktHistoryId: bigint | null },
+  params: { type: "movie" | "episode"; imdbId: string; seriesImdbId?: string | null; season?: number | null; episode?: number | null },
+  logger: FastifyRequest["log"]
+): void => {
+  if (watchEvent.traktHistoryId != null) return;
+
+  void (async () => {
+    const historyId = await pushTraktScrobble("stop", { ...params, progress: 100 }, logger);
+    if (historyId == null) return;
+    try {
+      await prisma.watchEvent.update({ where: { id: watchEvent.id }, data: { traktHistoryId: historyId } });
+    } catch (error) {
+      logger.warn({ error }, "Failed to persist Trakt history id on watch event");
+    }
+  })();
 };
 
 export const TRAKT_LAST_POLLED_AT_KEY = "trakt:lastPolledAt";

--- a/apps/api/src/lib/watch-event.ts
+++ b/apps/api/src/lib/watch-event.ts
@@ -2,6 +2,7 @@ import { prisma } from "./prisma.js";
 import { upsertSeriesProgressIfNewer } from "./series-progress.js";
 import { shouldRefreshAiRecs, getAiRecommendations } from "./ai.js";
 import { trendingCacheDeletePrefix } from "./cache.js";
+import { syncWatchEventToTrakt } from "./trakt-client.js";
 import type { RecordWatchParams } from "./types.js";
 
 export const recordWatchEvent = async (params: RecordWatchParams) => {
@@ -63,6 +64,12 @@ export const recordWatchEvent = async (params: RecordWatchParams) => {
       });
     }
 
+    syncWatchEventToTrakt(
+      watchEvent,
+      { type: "episode", imdbId: resolvedSeriesImdbId, seriesImdbId: resolvedSeriesImdbId, season, episode },
+      req.log
+    );
+
     void (async () => {
       try {
         if (await shouldRefreshAiRecs()) {
@@ -98,6 +105,8 @@ export const recordWatchEvent = async (params: RecordWatchParams) => {
     req.log.info({ imdbId }, `${source} scrobble: movie recorded`);
     return created;
   });
+
+  syncWatchEventToTrakt(watchEvent, { type: "movie", imdbId }, req.log);
 
   void (async () => {
     try {

--- a/apps/api/src/lib/webhook-auth.ts
+++ b/apps/api/src/lib/webhook-auth.ts
@@ -1,0 +1,13 @@
+import { timingSafeEqual } from "node:crypto";
+import type { FastifyRequest } from "fastify";
+
+const WEBHOOK_SECRET = process.env.WEBHOOK_SECRET?.trim();
+
+export const verifyWebhookSecret = (request: FastifyRequest): boolean => {
+  if (!WEBHOOK_SECRET) return false;
+  const provided =
+    (request.query as Record<string, string>).token ??
+    (request.headers["x-webhook-secret"] as string | undefined);
+  if (!provided || provided.length !== WEBHOOK_SECRET.length) return false;
+  return timingSafeEqual(Buffer.from(provided), Buffer.from(WEBHOOK_SECRET));
+};

--- a/apps/api/src/routes/export.ts
+++ b/apps/api/src/routes/export.ts
@@ -1,4 +1,4 @@
-import { ListItemType, ListKind, WatchEventType } from "@prisma/client";
+import { ListItemType, ListKind, Prisma, WatchEventType } from "@prisma/client";
 import type { FastifyPluginAsync } from "fastify";
 import { prisma } from "../lib/prisma.js";
 import { resolveProfile } from "../lib/profile.js";
@@ -133,7 +133,7 @@ const exportRoutes: FastifyPluginAsync = async (app) => {
 
     const summary = { lists: 0, listItems: 0, watchEvents: 0, seriesProgress: 0, ratings: 0 };
 
-    for (const list of body.lists ?? []) {
+    for (const list of Array.isArray(body.lists) ? body.lists : []) {
       if (!isString(list.name) || !Object.values(ListKind).includes(list.kind)) continue;
 
       const targetList =
@@ -150,7 +150,7 @@ const exportRoutes: FastifyPluginAsync = async (app) => {
               });
             })();
 
-      for (const item of list.items ?? []) {
+      for (const item of Array.isArray(list.items) ? list.items : []) {
         if (!Object.values(ListItemType).includes(item.type) || !isString(item.imdbId)) continue;
         const addedAt = parseDate(item.addedAt) ?? new Date();
 
@@ -159,13 +159,13 @@ const exportRoutes: FastifyPluginAsync = async (app) => {
             data: { listId: targetList.id, type: item.type, imdbId: item.imdbId.trim(), addedAt },
           });
           summary.listItems += 1;
-        } catch {
-          // already exists — idempotent import, skip
+        } catch (error) {
+          if (!(error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002")) throw error;
         }
       }
     }
 
-    for (const event of body.watchEvents ?? []) {
+    for (const event of Array.isArray(body.watchEvents) ? body.watchEvents : []) {
       if (!Object.values(WatchEventType).includes(event.type) || !isString(event.imdbId)) continue;
       const watchedAt = parseDate(event.watchedAt);
       if (!watchedAt) continue;
@@ -174,6 +174,7 @@ const exportRoutes: FastifyPluginAsync = async (app) => {
       const episode = isFiniteNumber(event.episode) ? event.episode : null;
       const seriesImdbId = isString(event.seriesImdbId) ? event.seriesImdbId.trim() : null;
       const imdbId = event.imdbId.trim();
+      const matchImdbId = event.type === WatchEventType.episode ? seriesImdbId ?? imdbId : imdbId;
 
       const dayStart = new Date(watchedAt);
       dayStart.setUTCHours(0, 0, 0, 0);
@@ -181,13 +182,22 @@ const exportRoutes: FastifyPluginAsync = async (app) => {
       dayEnd.setUTCHours(23, 59, 59, 999);
 
       const existing = await prisma.watchEvent.findFirst({
-        where: { profileId, imdbId, season, episode, watchedAt: { gte: dayStart, lte: dayEnd } },
+        where: {
+          profileId,
+          type: event.type,
+          ...(event.type === WatchEventType.episode
+            ? { seriesImdbId: matchImdbId }
+            : { imdbId: matchImdbId }),
+          season,
+          episode,
+          watchedAt: { gte: dayStart, lte: dayEnd },
+        },
       });
 
       if (existing) {
         await prisma.watchEvent.update({
           where: { id: existing.id },
-          data: { plays: existing.plays + (isFiniteNumber(event.plays) ? event.plays : 1) },
+          data: { plays: { increment: isFiniteNumber(event.plays) ? event.plays : 1 } },
         });
       } else {
         await prisma.watchEvent.create({
@@ -206,7 +216,7 @@ const exportRoutes: FastifyPluginAsync = async (app) => {
       summary.watchEvents += 1;
     }
 
-    for (const sp of body.seriesProgress ?? []) {
+    for (const sp of Array.isArray(body.seriesProgress) ? body.seriesProgress : []) {
       if (!isString(sp.seriesImdbId) || !isFiniteNumber(sp.lastSeason) || !isFiniteNumber(sp.lastEpisode)) {
         continue;
       }
@@ -221,7 +231,7 @@ const exportRoutes: FastifyPluginAsync = async (app) => {
       summary.seriesProgress += 1;
     }
 
-    for (const rating of body.ratings ?? []) {
+    for (const rating of Array.isArray(body.ratings) ? body.ratings : []) {
       if (
         !isString(rating.imdbId) ||
         (rating.type !== "movie" && rating.type !== "series") ||
@@ -303,6 +313,7 @@ const exportRoutes: FastifyPluginAsync = async (app) => {
       const existing = await prisma.watchEvent.findFirst({
         where: {
           profileId,
+          type,
           imdbId,
           season: Number.isFinite(season) ? season : null,
           episode: Number.isFinite(episode) ? episode : null,
@@ -311,7 +322,7 @@ const exportRoutes: FastifyPluginAsync = async (app) => {
       });
 
       if (existing) {
-        await prisma.watchEvent.update({ where: { id: existing.id }, data: { plays: existing.plays + 1 } });
+        await prisma.watchEvent.update({ where: { id: existing.id }, data: { plays: { increment: 1 } } });
       } else {
         await prisma.watchEvent.create({
           data: {

--- a/apps/api/src/routes/export.ts
+++ b/apps/api/src/routes/export.ts
@@ -1,0 +1,382 @@
+import { ListItemType, ListKind, WatchEventType } from "@prisma/client";
+import type { FastifyPluginAsync } from "fastify";
+import { prisma } from "../lib/prisma.js";
+import { resolveProfile } from "../lib/profile.js";
+import { upsertSeriesProgressIfNewer } from "../lib/series-progress.js";
+import { getDefaultWatchlist } from "../lib/watchlist.js";
+
+const EXPORT_VERSION = 1;
+
+interface ExportListItem {
+  type: ListItemType;
+  imdbId: string;
+  addedAt: string;
+}
+
+interface ExportList {
+  name: string;
+  kind: ListKind;
+  items: ExportListItem[];
+}
+
+interface ExportWatchEvent {
+  type: WatchEventType;
+  imdbId: string;
+  seriesImdbId: string | null;
+  season: number | null;
+  episode: number | null;
+  watchedAt: string;
+  plays: number;
+}
+
+interface ExportSeriesProgress {
+  seriesImdbId: string;
+  lastSeason: number;
+  lastEpisode: number;
+  lastWatchedAt: string;
+}
+
+interface ExportRating {
+  imdbId: string;
+  type: string;
+  rating: number;
+  ratedAt: string;
+}
+
+interface ExportPayload {
+  version: number;
+  exportedAt: string;
+  profile: { name: string };
+  lists: ExportList[];
+  watchEvents: ExportWatchEvent[];
+  seriesProgress: ExportSeriesProgress[];
+  ratings: ExportRating[];
+}
+
+const isString = (v: unknown): v is string => typeof v === "string" && v.trim().length > 0;
+const isFiniteNumber = (v: unknown): v is number => typeof v === "number" && Number.isFinite(v);
+
+const parseDate = (v: unknown): Date | null => {
+  if (typeof v !== "string") return null;
+  const d = new Date(v);
+  return Number.isNaN(d.getTime()) ? null : d;
+};
+
+const exportRoutes: FastifyPluginAsync = async (app) => {
+  app.addHook("preHandler", resolveProfile);
+
+  app.get("/export", async (request) => {
+    const profileId = request.profileId!;
+
+    const [profile, lists, watchEvents, seriesProgress, ratingRows] = await Promise.all([
+      prisma.profile.findUnique({ where: { id: profileId }, select: { name: true } }),
+      prisma.list.findMany({
+        where: { profileId },
+        include: { items: true },
+        orderBy: { createdAt: "asc" },
+      }),
+      prisma.watchEvent.findMany({ where: { profileId }, orderBy: { watchedAt: "asc" } }),
+      prisma.seriesProgress.findMany({ where: { profileId } }),
+      prisma.kV.findMany({ where: { key: { startsWith: "rating:" } } }),
+    ]);
+
+    const ratings = ratingRows.flatMap((row) => {
+      try {
+        const parsed = JSON.parse(row.value) as ExportRating;
+        return [parsed];
+      } catch {
+        return [];
+      }
+    });
+
+    const payload: ExportPayload = {
+      version: EXPORT_VERSION,
+      exportedAt: new Date().toISOString(),
+      profile: { name: profile?.name ?? "Default" },
+      lists: lists.map((list) => ({
+        name: list.name,
+        kind: list.kind,
+        items: list.items.map((item) => ({
+          type: item.type,
+          imdbId: item.imdbId,
+          addedAt: item.addedAt.toISOString(),
+        })),
+      })),
+      watchEvents: watchEvents.map((event) => ({
+        type: event.type,
+        imdbId: event.imdbId,
+        seriesImdbId: event.seriesImdbId,
+        season: event.season,
+        episode: event.episode,
+        watchedAt: event.watchedAt.toISOString(),
+        plays: event.plays,
+      })),
+      seriesProgress: seriesProgress.map((sp) => ({
+        seriesImdbId: sp.seriesImdbId,
+        lastSeason: sp.lastSeason,
+        lastEpisode: sp.lastEpisode,
+        lastWatchedAt: sp.lastWatchedAt.toISOString(),
+      })),
+      ratings,
+    };
+
+    return payload;
+  });
+
+  app.post<{ Body: unknown }>("/import", async (request, reply) => {
+    const profileId = request.profileId!;
+    const body = request.body as Partial<ExportPayload> | null;
+
+    if (!body || typeof body !== "object" || body.version !== EXPORT_VERSION) {
+      return reply.code(400).send({ error: `Expected an export payload with version ${EXPORT_VERSION}` });
+    }
+
+    const summary = { lists: 0, listItems: 0, watchEvents: 0, seriesProgress: 0, ratings: 0 };
+
+    for (const list of body.lists ?? []) {
+      if (!isString(list.name) || !Object.values(ListKind).includes(list.kind)) continue;
+
+      const targetList =
+        list.kind === ListKind.watchlist
+          ? await getDefaultWatchlist(profileId)
+          : await (async () => {
+              const existing = await prisma.list.findFirst({
+                where: { profileId, kind: ListKind.custom, name: list.name.trim() },
+              });
+              if (existing) return existing;
+              summary.lists += 1;
+              return prisma.list.create({
+                data: { profileId, kind: ListKind.custom, name: list.name.trim() },
+              });
+            })();
+
+      for (const item of list.items ?? []) {
+        if (!Object.values(ListItemType).includes(item.type) || !isString(item.imdbId)) continue;
+        const addedAt = parseDate(item.addedAt) ?? new Date();
+
+        try {
+          await prisma.listItem.create({
+            data: { listId: targetList.id, type: item.type, imdbId: item.imdbId.trim(), addedAt },
+          });
+          summary.listItems += 1;
+        } catch {
+          // already exists — idempotent import, skip
+        }
+      }
+    }
+
+    for (const event of body.watchEvents ?? []) {
+      if (!Object.values(WatchEventType).includes(event.type) || !isString(event.imdbId)) continue;
+      const watchedAt = parseDate(event.watchedAt);
+      if (!watchedAt) continue;
+
+      const season = isFiniteNumber(event.season) ? event.season : null;
+      const episode = isFiniteNumber(event.episode) ? event.episode : null;
+      const seriesImdbId = isString(event.seriesImdbId) ? event.seriesImdbId.trim() : null;
+      const imdbId = event.imdbId.trim();
+
+      const dayStart = new Date(watchedAt);
+      dayStart.setUTCHours(0, 0, 0, 0);
+      const dayEnd = new Date(watchedAt);
+      dayEnd.setUTCHours(23, 59, 59, 999);
+
+      const existing = await prisma.watchEvent.findFirst({
+        where: { profileId, imdbId, season, episode, watchedAt: { gte: dayStart, lte: dayEnd } },
+      });
+
+      if (existing) {
+        await prisma.watchEvent.update({
+          where: { id: existing.id },
+          data: { plays: existing.plays + (isFiniteNumber(event.plays) ? event.plays : 1) },
+        });
+      } else {
+        await prisma.watchEvent.create({
+          data: {
+            type: event.type,
+            imdbId,
+            seriesImdbId,
+            season,
+            episode,
+            watchedAt,
+            plays: isFiniteNumber(event.plays) ? event.plays : 1,
+            profileId,
+          },
+        });
+      }
+      summary.watchEvents += 1;
+    }
+
+    for (const sp of body.seriesProgress ?? []) {
+      if (!isString(sp.seriesImdbId) || !isFiniteNumber(sp.lastSeason) || !isFiniteNumber(sp.lastEpisode)) {
+        continue;
+      }
+      const lastWatchedAt = parseDate(sp.lastWatchedAt);
+      if (!lastWatchedAt) continue;
+
+      await upsertSeriesProgressIfNewer(profileId, sp.seriesImdbId.trim(), {
+        lastSeason: sp.lastSeason,
+        lastEpisode: sp.lastEpisode,
+        lastWatchedAt,
+      });
+      summary.seriesProgress += 1;
+    }
+
+    for (const rating of body.ratings ?? []) {
+      if (
+        !isString(rating.imdbId) ||
+        (rating.type !== "movie" && rating.type !== "series") ||
+        !isFiniteNumber(rating.rating)
+      ) {
+        continue;
+      }
+      const ratedAt = parseDate(rating.ratedAt)?.toISOString() ?? new Date().toISOString();
+      const key = `rating:${rating.type}:${rating.imdbId.trim()}`;
+      const value = JSON.stringify({
+        imdbId: rating.imdbId.trim(),
+        type: rating.type,
+        rating: rating.rating,
+        ratedAt,
+      });
+
+      await prisma.kV.upsert({
+        where: { key },
+        create: { key, value, updatedAt: new Date() },
+        update: { value, updatedAt: new Date() },
+      });
+      summary.ratings += 1;
+    }
+
+    return reply.code(200).send({ status: "imported", summary });
+  });
+
+  app.post<{ Body: unknown }>("/import/csv", async (request, reply) => {
+    const profileId = request.profileId!;
+    const body = request.body as { csv?: unknown } | null;
+    if (!body || typeof body.csv !== "string" || !body.csv.trim()) {
+      return reply.code(400).send({ error: "csv is required" });
+    }
+
+    const rows = parseCsv(body.csv);
+    if (rows.length === 0) {
+      return reply.code(400).send({ error: "No rows found in CSV" });
+    }
+
+    const header = rows[0].map((h) => h.trim().toLowerCase());
+    const col = (name: string) => header.indexOf(name);
+    const imdbIdCol = col("imdbid");
+    const typeCol = col("type");
+    const seasonCol = col("season");
+    const episodeCol = col("episode");
+    const watchedAtCol = col("watchedat");
+
+    if (imdbIdCol === -1 || typeCol === -1 || watchedAtCol === -1) {
+      return reply.code(400).send({
+        error: "CSV header must include at least: imdbId,type,watchedAt (season,episode optional)",
+      });
+    }
+
+    let imported = 0;
+    let skipped = 0;
+
+    for (const row of rows.slice(1)) {
+      if (row.length === 0 || row.every((cell) => cell.trim() === "")) continue;
+
+      const imdbId = row[imdbIdCol]?.trim();
+      const rawType = row[typeCol]?.trim().toLowerCase();
+      const watchedAt = parseDate(row[watchedAtCol]?.trim());
+
+      if (!imdbId || (rawType !== "movie" && rawType !== "episode") || !watchedAt) {
+        skipped += 1;
+        continue;
+      }
+
+      const season = seasonCol !== -1 && row[seasonCol]?.trim() ? Number(row[seasonCol]) : null;
+      const episode = episodeCol !== -1 && row[episodeCol]?.trim() ? Number(row[episodeCol]) : null;
+      const type = rawType as WatchEventType;
+      const seriesImdbId = type === "episode" ? imdbId : null;
+
+      const dayStart = new Date(watchedAt);
+      dayStart.setUTCHours(0, 0, 0, 0);
+      const dayEnd = new Date(watchedAt);
+      dayEnd.setUTCHours(23, 59, 59, 999);
+
+      const existing = await prisma.watchEvent.findFirst({
+        where: {
+          profileId,
+          imdbId,
+          season: Number.isFinite(season) ? season : null,
+          episode: Number.isFinite(episode) ? episode : null,
+          watchedAt: { gte: dayStart, lte: dayEnd },
+        },
+      });
+
+      if (existing) {
+        await prisma.watchEvent.update({ where: { id: existing.id }, data: { plays: existing.plays + 1 } });
+      } else {
+        await prisma.watchEvent.create({
+          data: {
+            type,
+            imdbId,
+            seriesImdbId,
+            season: Number.isFinite(season) ? season : null,
+            episode: Number.isFinite(episode) ? episode : null,
+            watchedAt,
+            profileId,
+          },
+        });
+      }
+      imported += 1;
+    }
+
+    return reply.code(200).send({ status: "imported", summary: { imported, skipped } });
+  });
+};
+
+function parseCsv(input: string): string[][] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let field = "";
+  let inQuotes = false;
+
+  for (let i = 0; i < input.length; i++) {
+    const ch = input[i];
+
+    if (inQuotes) {
+      if (ch === '"') {
+        if (input[i + 1] === '"') {
+          field += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        field += ch;
+      }
+      continue;
+    }
+
+    if (ch === '"') {
+      inQuotes = true;
+    } else if (ch === ",") {
+      row.push(field);
+      field = "";
+    } else if (ch === "\n" || ch === "\r") {
+      if (ch === "\r" && input[i + 1] === "\n") i++;
+      row.push(field);
+      rows.push(row);
+      row = [];
+      field = "";
+    } else {
+      field += ch;
+    }
+  }
+
+  if (field.length > 0 || row.length > 0) {
+    row.push(field);
+    rows.push(row);
+  }
+
+  return rows.filter((r) => r.length > 0);
+}
+
+export default exportRoutes;

--- a/apps/api/src/routes/lists.ts
+++ b/apps/api/src/routes/lists.ts
@@ -2,6 +2,7 @@ import { ItemType, ListItemType, ListKind, MetadataType, Prisma } from "@prisma/
 import type { FastifyPluginAsync } from "fastify";
 import { prisma } from "../lib/prisma.js";
 import { syncMetadata } from "../lib/metadata.js";
+import { pushTraktWatchlistChange } from "../lib/trakt-client.js";
 import { resolveProfile } from "../lib/profile.js";
 import { UUID_V4_PATTERN } from "../lib/types.js";
 
@@ -148,6 +149,10 @@ const listsRoutes: FastifyPluginAsync = async (app) => {
           app.log.warn({ imdbId, type: metadataTypeForSync, err }, "Background metadata sync failed")
         );
 
+        if (list.kind === ListKind.watchlist) {
+          await pushTraktWatchlistChange("add", { type, imdbId }, request.log);
+        }
+
         return reply.code(201).send({ listItem });
       } catch (error) {
         if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
@@ -185,6 +190,14 @@ const listsRoutes: FastifyPluginAsync = async (app) => {
 
       if (removed.count === 0) return reply.code(404).send({ error: "List item not found" });
 
+      if (list.kind === ListKind.watchlist) {
+        await pushTraktWatchlistChange(
+          "remove",
+          { type: type as ListItemType, imdbId: request.params.imdbId },
+          request.log
+        );
+      }
+
       return reply.code(204).send();
     }
   );
@@ -212,17 +225,22 @@ const listsRoutes: FastifyPluginAsync = async (app) => {
         }
         where.type = request.query.type as ListItemType;
       } else {
-        const count = await prisma.listItem.count({ where });
-        if (count === 0) return reply.code(404).send({ error: "List item not found" });
-        if (count > 1) {
+        const matches = await prisma.listItem.findMany({ where });
+        if (matches.length === 0) return reply.code(404).send({ error: "List item not found" });
+        if (matches.length > 1) {
           return reply.code(400).send({
             error: "Multiple items match this imdbId; provide ?type=movie or ?type=series to disambiguate",
           });
         }
+        where.type = matches[0].type;
       }
 
       const removed = await prisma.listItem.deleteMany({ where });
       if (removed.count === 0) return reply.code(404).send({ error: "List item not found" });
+
+      if (list.kind === ListKind.watchlist) {
+        await pushTraktWatchlistChange("remove", { type: where.type!, imdbId: request.params.imdbId }, request.log);
+      }
 
       return reply.code(204).send();
     }

--- a/apps/api/src/routes/profiles.ts
+++ b/apps/api/src/routes/profiles.ts
@@ -19,7 +19,19 @@ const PIN_LOCKOUT_MS = 5 * 60 * 1000;
 
 const pinAttempts = new Map<string, { count: number; lockedUntil: number }>();
 
+// Only purge entries whose lockout has fully expired (lockedUntil > 0 acts as
+// the "is/was locked" marker). Entries below MAX_PIN_ATTEMPTS default to
+// lockedUntil 0, and 0 <= Date.now() is always true, so checking lockedUntil
+// alone would wipe in-progress failed-attempt counters on every call.
+const pruneExpiredPinLockouts = (): void => {
+  const now = Date.now();
+  for (const [profileId, entry] of pinAttempts) {
+    if (entry.lockedUntil > 0 && entry.lockedUntil <= now) pinAttempts.delete(profileId);
+  }
+};
+
 const getPinLockout = (profileId: string): { locked: boolean; retryAfterSec: number } => {
+  pruneExpiredPinLockouts();
   const entry = pinAttempts.get(profileId);
   if (!entry || entry.lockedUntil <= Date.now()) return { locked: false, retryAfterSec: 0 };
   return { locked: true, retryAfterSec: Math.ceil((entry.lockedUntil - Date.now()) / 1000) };

--- a/apps/api/src/routes/profiles.ts
+++ b/apps/api/src/routes/profiles.ts
@@ -14,6 +14,31 @@ const pinMatches = (pin: string, pinHash: string): boolean => {
   return timingSafeEqual(incoming, expected);
 };
 
+const MAX_PIN_ATTEMPTS = 5;
+const PIN_LOCKOUT_MS = 5 * 60 * 1000;
+
+const pinAttempts = new Map<string, { count: number; lockedUntil: number }>();
+
+const getPinLockout = (profileId: string): { locked: boolean; retryAfterSec: number } => {
+  const entry = pinAttempts.get(profileId);
+  if (!entry || entry.lockedUntil <= Date.now()) return { locked: false, retryAfterSec: 0 };
+  return { locked: true, retryAfterSec: Math.ceil((entry.lockedUntil - Date.now()) / 1000) };
+};
+
+const recordPinFailure = (profileId: string): void => {
+  const entry = pinAttempts.get(profileId) ?? { count: 0, lockedUntil: 0 };
+  entry.count += 1;
+  if (entry.count >= MAX_PIN_ATTEMPTS) {
+    entry.lockedUntil = Date.now() + PIN_LOCKOUT_MS;
+    entry.count = 0;
+  }
+  pinAttempts.set(profileId, entry);
+};
+
+const clearPinAttempts = (profileId: string): void => {
+  pinAttempts.delete(profileId);
+};
+
 const profilesRoutes: FastifyPluginAsync = async (app) => {
   app.get("/profiles", async () => {
     const profiles = await prisma.profile.findMany({
@@ -61,12 +86,21 @@ const profilesRoutes: FastifyPluginAsync = async (app) => {
       return reply.code(200).send({ id: profile.id, name: profile.name });
     }
 
+    const lockout = getPinLockout(profile.id);
+    if (lockout.locked) {
+      return reply
+        .code(429)
+        .send({ error: "Too many incorrect attempts. Try again later.", retryAfterSec: lockout.retryAfterSec });
+    }
+
     const body = (request.body ?? {}) as { pin?: unknown };
     const pin = typeof body.pin === "string" ? body.pin.trim() : "";
     if (!pin || !pinMatches(pin, profile.pinHash)) {
+      recordPinFailure(profile.id);
       return reply.code(401).send({ error: "Incorrect PIN" });
     }
 
+    clearPinAttempts(profile.id);
     return reply.code(200).send({ id: profile.id, name: profile.name });
   });
 

--- a/apps/api/src/routes/scrobble.ts
+++ b/apps/api/src/routes/scrobble.ts
@@ -2,6 +2,7 @@ import { ScrobbleStatus, WatchEventType } from "@prisma/client";
 import type { FastifyPluginAsync } from "fastify";
 import { prisma } from "../lib/prisma.js";
 import { recordWatchEvent } from "../lib/watch-event.js";
+import { pushTraktScrobble } from "../lib/trakt-client.js";
 import { resolveProfile } from "../lib/profile.js";
 import type { CheckInData } from "../lib/types.js";
 
@@ -118,7 +119,7 @@ const scrobbleRoutes: FastifyPluginAsync = async (app) => {
     const progress = typeof body.progress === "number" ? Math.max(0, Math.min(100, body.progress)) : 0;
     const profileId = request.profileId!;
 
-    const { session, created } = await prisma.$transaction(async (tx) => {
+    const { session, created, wasPlaying } = await prisma.$transaction(async (tx) => {
       const existing = await tx.scrobbleSession.findFirst({
         where: {
           profileId,
@@ -134,14 +135,18 @@ const scrobbleRoutes: FastifyPluginAsync = async (app) => {
           where: { id: existing.id },
           data: { status: ScrobbleStatus.playing, progress },
         });
-        return { session: updated, created: false };
+        return { session: updated, created: false, wasPlaying: existing.status === ScrobbleStatus.playing };
       }
 
       const newSession = await tx.scrobbleSession.create({
         data: { type, imdbId, seriesImdbId, season, episode, status: ScrobbleStatus.playing, progress, profileId },
       });
-      return { session: newSession, created: true };
+      return { session: newSession, created: true, wasPlaying: false };
     });
+
+    if (!wasPlaying) {
+      void pushTraktScrobble("start", { type, imdbId, seriesImdbId, season, episode, progress }, request.log);
+    }
 
     return reply.code(created ? 201 : 200).send({ session });
   });
@@ -172,6 +177,19 @@ const scrobbleRoutes: FastifyPluginAsync = async (app) => {
       where: { id: session.id },
       data: { status: ScrobbleStatus.paused, ...(progress !== undefined ? { progress } : {}) },
     });
+
+    void pushTraktScrobble(
+      "pause",
+      {
+        type: session.type,
+        imdbId,
+        seriesImdbId: session.seriesImdbId,
+        season,
+        episode,
+        progress: updated.progress,
+      },
+      request.log
+    );
 
     return reply.code(200).send({ session: updated });
   });
@@ -226,6 +244,19 @@ const scrobbleRoutes: FastifyPluginAsync = async (app) => {
         request,
       });
       watchEvent = result.watchEvent;
+    } else {
+      void pushTraktScrobble(
+        "stop",
+        {
+          type: session.type,
+          imdbId,
+          seriesImdbId: session.seriesImdbId,
+          season: session.season,
+          episode: session.episode,
+          progress: finalProgress,
+        },
+        request.log
+      );
     }
 
     return reply.code(200).send({

--- a/apps/api/src/routes/trakt.ts
+++ b/apps/api/src/routes/trakt.ts
@@ -9,6 +9,7 @@ import {
   getTraktClient,
   resetTraktClient,
   pollTraktHistory,
+  syncTraktWatchlist,
   computeTokenExpiresAt,
 } from "../lib/trakt-client.js";
 import { renderOAuthHtml } from "../lib/html.js";
@@ -332,8 +333,9 @@ const traktRoutes: FastifyPluginAsync = async (app) => {
   app.post("/trakt/poll", async (request, reply) => {
     try {
       const profileId = await getDefaultProfileId();
-      const result = await pollTraktHistory(request.log, profileId);
-      return reply.code(200).send(result);
+      const history = await pollTraktHistory(request.log, profileId);
+      const watchlist = await syncTraktWatchlist(request.log, profileId);
+      return reply.code(200).send({ ...history, watchlist });
     } catch (error) {
       request.log.error(error, "Trakt poll failed");
       return reply.code(500).send({ error: "Trakt poll failed" });

--- a/apps/api/src/routes/watch.ts
+++ b/apps/api/src/routes/watch.ts
@@ -3,6 +3,7 @@ import type { FastifyPluginAsync } from "fastify";
 import { prisma } from "../lib/prisma.js";
 import { upsertSeriesProgressIfNewer } from "../lib/series-progress.js";
 import { resolveProfile } from "../lib/profile.js";
+import { syncWatchEventToTrakt } from "../lib/trakt-client.js";
 
 function serializeWatchEvent<T extends { traktHistoryId: bigint | null }>(event: T) {
   return { ...event, traktHistoryId: event.traktHistoryId != null ? event.traktHistoryId.toString() : null };
@@ -88,6 +89,7 @@ const watchRoutes: FastifyPluginAsync = async (app) => {
         where: { id: existing.id },
         data: { plays: existing.plays + 1 },
       });
+      syncWatchEventToTrakt(updated, { type, imdbId, seriesImdbId, season, episode }, request.log);
       return reply.code(200).send({ watchEvent: serializeWatchEvent(updated) });
     }
 
@@ -102,6 +104,8 @@ const watchRoutes: FastifyPluginAsync = async (app) => {
         lastWatchedAt: watchedAt,
       });
     }
+
+    syncWatchEventToTrakt(watchEvent, { type, imdbId, seriesImdbId, season, episode }, request.log);
 
     return reply.code(201).send({ watchEvent: serializeWatchEvent(watchEvent) });
   });

--- a/apps/api/src/routes/webhooks/jellyfin.ts
+++ b/apps/api/src/routes/webhooks/jellyfin.ts
@@ -1,17 +1,6 @@
-import { timingSafeEqual } from "node:crypto";
 import type { FastifyPluginAsync } from "fastify";
 import { recordWatchEvent } from "../../lib/watch-event.js";
-
-const WEBHOOK_SECRET = process.env.WEBHOOK_SECRET?.trim();
-
-const verifyWebhookSecret = (request: import("fastify").FastifyRequest): boolean => {
-  if (!WEBHOOK_SECRET) return false;
-  const provided =
-    (request.query as Record<string, string>).token ??
-    (request.headers["x-webhook-secret"] as string | undefined);
-  if (!provided || provided.length !== WEBHOOK_SECRET.length) return false;
-  return timingSafeEqual(Buffer.from(provided), Buffer.from(WEBHOOK_SECRET));
-};
+import { verifyWebhookSecret } from "../../lib/webhook-auth.js";
 
 const jellyfinWebhookRoutes: FastifyPluginAsync = async (app) => {
   app.post("/webhooks/jellyfin", async (request, reply) => {

--- a/apps/api/src/routes/webhooks/jellyfin.ts
+++ b/apps/api/src/routes/webhooks/jellyfin.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from "node:crypto";
 import type { FastifyPluginAsync } from "fastify";
 import { recordWatchEvent } from "../../lib/watch-event.js";
 
@@ -8,7 +9,8 @@ const verifyWebhookSecret = (request: import("fastify").FastifyRequest): boolean
   const provided =
     (request.query as Record<string, string>).token ??
     (request.headers["x-webhook-secret"] as string | undefined);
-  return provided === WEBHOOK_SECRET;
+  if (!provided || provided.length !== WEBHOOK_SECRET.length) return false;
+  return timingSafeEqual(Buffer.from(provided), Buffer.from(WEBHOOK_SECRET));
 };
 
 const jellyfinWebhookRoutes: FastifyPluginAsync = async (app) => {

--- a/apps/api/src/routes/webhooks/plex.ts
+++ b/apps/api/src/routes/webhooks/plex.ts
@@ -1,17 +1,6 @@
-import { timingSafeEqual } from "node:crypto";
 import type { FastifyPluginAsync } from "fastify";
 import { recordWatchEvent } from "../../lib/watch-event.js";
-
-const WEBHOOK_SECRET = process.env.WEBHOOK_SECRET?.trim();
-
-const verifyWebhookSecret = (request: import("fastify").FastifyRequest): boolean => {
-  if (!WEBHOOK_SECRET) return false;
-  const provided =
-    (request.query as Record<string, string>).token ??
-    (request.headers["x-webhook-secret"] as string | undefined);
-  if (!provided || provided.length !== WEBHOOK_SECRET.length) return false;
-  return timingSafeEqual(Buffer.from(provided), Buffer.from(WEBHOOK_SECRET));
-};
+import { verifyWebhookSecret } from "../../lib/webhook-auth.js";
 
 function extractMultipartPayload(rawBody: string, contentType: string): string | null {
   const boundaryMatch = contentType.match(/boundary=(?:"([^"]+)"|([^\s;]+))/);

--- a/apps/api/src/routes/webhooks/plex.ts
+++ b/apps/api/src/routes/webhooks/plex.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from "node:crypto";
 import type { FastifyPluginAsync } from "fastify";
 import { recordWatchEvent } from "../../lib/watch-event.js";
 
@@ -8,7 +9,8 @@ const verifyWebhookSecret = (request: import("fastify").FastifyRequest): boolean
   const provided =
     (request.query as Record<string, string>).token ??
     (request.headers["x-webhook-secret"] as string | undefined);
-  return provided === WEBHOOK_SECRET;
+  if (!provided || provided.length !== WEBHOOK_SECRET.length) return false;
+  return timingSafeEqual(Buffer.from(provided), Buffer.from(WEBHOOK_SECRET));
 };
 
 function extractMultipartPayload(rawBody: string, contentType: string): string | null {

--- a/apps/api/src/trakt.ts
+++ b/apps/api/src/trakt.ts
@@ -107,6 +107,11 @@ export type TraktScrobbleResponse = {
   progress?: number;
 };
 
+export type TraktWatchlistMutationPayload = {
+  movies?: { ids: { imdb: string } }[];
+  shows?: { ids: { imdb: string } }[];
+};
+
 export class TraktClient {
   private readonly clientId: string;
   private readonly clientSecret: string;
@@ -221,6 +226,32 @@ export class TraktClient {
     } catch {
       return {};
     }
+  }
+
+  async addToWatchlist(payload: TraktWatchlistMutationPayload, logger: FastifyBaseLogger): Promise<void> {
+    await this.postWatchlistMutation("/sync/watchlist", payload, logger);
+  }
+
+  async removeFromWatchlist(payload: TraktWatchlistMutationPayload, logger: FastifyBaseLogger): Promise<void> {
+    await this.postWatchlistMutation("/sync/watchlist/remove", payload, logger);
+  }
+
+  private async postWatchlistMutation(
+    path: string,
+    payload: TraktWatchlistMutationPayload,
+    logger: FastifyBaseLogger
+  ): Promise<void> {
+    await this.request(path, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "trakt-api-version": "2",
+        "trakt-api-key": this.clientId,
+        Authorization: `Bearer ${this.accessToken}`
+      },
+      body: JSON.stringify(payload),
+      logger
+    });
   }
 
   private async fetchAllPages<T>(

--- a/apps/api/src/trakt.ts
+++ b/apps/api/src/trakt.ts
@@ -97,6 +97,16 @@ type TraktTokenResponse = {
   expires_in?: number;
 };
 
+export type TraktScrobblePayload =
+  | { movie: { ids: { imdb: string } }; progress: number }
+  | { show: { ids: { imdb: string } }; episode: { season: number; number: number }; progress: number };
+
+export type TraktScrobbleResponse = {
+  id?: number;
+  action?: string;
+  progress?: number;
+};
+
 export class TraktClient {
   private readonly clientId: string;
   private readonly clientSecret: string;
@@ -175,6 +185,42 @@ export class TraktClient {
       startAt ? { start_at: startAt } : undefined,
       POLL_MAX_PAGES
     );
+  }
+
+  async scrobbleStart(payload: TraktScrobblePayload, logger: FastifyBaseLogger): Promise<TraktScrobbleResponse> {
+    return this.postScrobble("/scrobble/start", payload, logger);
+  }
+
+  async scrobblePause(payload: TraktScrobblePayload, logger: FastifyBaseLogger): Promise<TraktScrobbleResponse> {
+    return this.postScrobble("/scrobble/pause", payload, logger);
+  }
+
+  async scrobbleStop(payload: TraktScrobblePayload, logger: FastifyBaseLogger): Promise<TraktScrobbleResponse> {
+    return this.postScrobble("/scrobble/stop", payload, logger);
+  }
+
+  private async postScrobble(
+    path: string,
+    payload: TraktScrobblePayload,
+    logger: FastifyBaseLogger
+  ): Promise<TraktScrobbleResponse> {
+    const response = await this.request(path, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "trakt-api-version": "2",
+        "trakt-api-key": this.clientId,
+        Authorization: `Bearer ${this.accessToken}`
+      },
+      body: JSON.stringify(payload),
+      logger
+    });
+
+    try {
+      return (await response.json()) as TraktScrobbleResponse;
+    } catch {
+      return {};
+    }
   }
 
   private async fetchAllPages<T>(

--- a/apps/api/src/trakt.ts
+++ b/apps/api/src/trakt.ts
@@ -223,7 +223,8 @@ export class TraktClient {
 
     try {
       return (await response.json()) as TraktScrobbleResponse;
-    } catch {
+    } catch (error) {
+      logger.warn({ error, path }, "Failed to parse Trakt scrobble response as JSON");
       return {};
     }
   }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Link, Route, Routes, useLocation } from "react-router-dom";
-import { BarChart3, Clapperboard, Search, List, Settings } from "lucide-react";
+import { BarChart3, Clapperboard, History, Search, List, Settings } from "lucide-react";
 import { runtimeConfig } from "./api";
 import { CommandPalette, useCommandPalette } from "./components/CommandPalette";
 import { InstallButton } from "./components/InstallButton";
@@ -8,6 +8,7 @@ import { Sidebar } from "./components/Sidebar";
 import { ThemeToggle } from "./components/ThemeToggle";
 import { useTheme } from "./hooks/useTheme";
 import { DashboardPage } from "./pages/DashboardPage";
+import { HistoryPage } from "./pages/HistoryPage";
 import { ListsPage } from "./pages/ListsPage";
 import { ProfileSwitcher } from "./pages/ProfileSwitcher";
 import { SearchPage } from "./pages/SearchPage";
@@ -19,6 +20,7 @@ const mobileNavItems = [
   { to: "/", label: "Dashboard", icon: Clapperboard, end: true },
   { to: "/search", label: "Search", icon: Search, end: false },
   { to: "/lists", label: "Lists", icon: List, end: false },
+  { to: "/history", label: "History", icon: History, end: false },
   { to: "/stats", label: "Stats", icon: BarChart3, end: false },
   { to: "/settings", label: "Settings", icon: Settings, end: false },
 ] as const;
@@ -93,6 +95,7 @@ export function App() {
           <Route path="/" element={<DashboardPage />} />
           <Route path="/search" element={<SearchPage />} />
           <Route path="/lists/*" element={<ListsPage />} />
+          <Route path="/history" element={<HistoryPage />} />
           <Route path="/stats" element={<StatsPage />} />
           <Route path="/settings" element={<SettingsPage />} />
         </Routes>

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -228,6 +228,56 @@ export type Profile = {
   hasPin: boolean;
 };
 
+export type ScrobbleSession = {
+  id: string;
+  type: "movie" | "episode";
+  imdbId: string;
+  seriesImdbId: string | null;
+  season: number | null;
+  episode: number | null;
+  status: "playing" | "paused" | "stopped";
+  progress: number;
+  startedAt: string;
+  updatedAt: string;
+  name: string | null;
+  poster: string | null;
+};
+
+export type ExportPayload = {
+  version: number;
+  exportedAt: string;
+  profile: { name: string };
+  lists: Array<{
+    name: string;
+    kind: "watchlist" | "custom";
+    items: Array<{ type: "movie" | "series"; imdbId: string; addedAt: string }>;
+  }>;
+  watchEvents: Array<{
+    type: "movie" | "episode";
+    imdbId: string;
+    seriesImdbId: string | null;
+    season: number | null;
+    episode: number | null;
+    watchedAt: string;
+    plays: number;
+  }>;
+  seriesProgress: Array<{
+    seriesImdbId: string;
+    lastSeason: number;
+    lastEpisode: number;
+    lastWatchedAt: string;
+  }>;
+  ratings: Array<{ imdbId: string; type: string; rating: number; ratedAt: string }>;
+};
+
+export type ImportSummary = {
+  lists: number;
+  listItems: number;
+  watchEvents: number;
+  seriesProgress: number;
+  ratings: number;
+};
+
 const authHeaders = (hasBody: boolean) => {
   const token = runtimeConfig.getToken();
   const headers: Record<string, string> = {
@@ -257,7 +307,7 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
         ...(init?.headers ?? {})
       }
     });
-  } catch (err) {
+  } catch {
     clearTimeout(timeoutId);
     if (controller.signal.aborted) {
       throw new Error(`Request timed out – is the API server running at ${runtimeConfig.getApiBase()}?`);
@@ -332,8 +382,8 @@ export const api = {
     const res = await request<{ progress: SeriesProgress[] }>("/series/progress");
     return res.progress;
   },
-  async getWatchHistory(limit = 10) {
-    const res = await request<{ history: WatchEvent[] }>(`/watch/history?limit=${limit}`);
+  async getWatchHistory(limit = 10, offset = 0) {
+    const res = await request<{ history: WatchEvent[] }>(`/watch/history?limit=${limit}&offset=${offset}`);
     return res.history;
   },
   getWatchStats() {
@@ -570,5 +620,25 @@ export const api = {
   },
   deleteProfile(profileId: string) {
     return request<void>(`/profiles/${encodeURIComponent(profileId)}`, { method: "DELETE" });
+  },
+  // Now playing (live Plex/Jellyfin scrobble sessions)
+  getNowPlaying() {
+    return request<{ sessions: ScrobbleSession[] }>("/scrobble/now-playing");
+  },
+  // Data export / import
+  exportData() {
+    return request<ExportPayload>("/export");
+  },
+  importData(payload: ExportPayload) {
+    return request<{ status: string; summary: ImportSummary }>("/import", {
+      method: "POST",
+      body: JSON.stringify(payload),
+    });
+  },
+  importCsv(csv: string) {
+    return request<{ status: string; summary: { imported: number; skipped: number } }>("/import/csv", {
+      method: "POST",
+      body: JSON.stringify({ csv }),
+    });
   },
 };

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1,11 +1,12 @@
 import { useState } from "react";
 import { NavLink } from "react-router-dom";
-import { BarChart3, Clapperboard, Pin, PinOff, Search, List, Settings } from "lucide-react";
+import { BarChart3, Clapperboard, History, Pin, PinOff, Search, List, Settings } from "lucide-react";
 
 const navItems = [
   { to: "/", label: "Dashboard", icon: Clapperboard, end: true },
   { to: "/search", label: "Search", icon: Search, end: false },
   { to: "/lists", label: "Lists", icon: List, end: false },
+  { to: "/history", label: "History", icon: History, end: false },
   { to: "/stats", label: "Stats", icon: BarChart3, end: false },
   { to: "/settings", label: "Settings", icon: Settings, end: false },
 ] as const;

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -3,7 +3,6 @@ import {
   AlertCircle,
   Film,
   Tv,
-  Play,
   ChevronRight,
   ChevronLeft,
   Check,
@@ -19,6 +18,7 @@ import {
   CheckIn,
   DetailedWatchStats,
   runtimeConfig,
+  ScrobbleSession,
   SearchResult,
   SeriesProgress,
   TrendingMeta,
@@ -264,6 +264,7 @@ export function DashboardPage() {
   const [markingNext, setMarkingNext] = useState<Set<string>>(new Set());
   const [markedDone, setMarkedDone] = useState<Set<string>>(new Set());
   const [activeCheckin, setActiveCheckin] = useState<CheckIn | null>(null);
+  const [nowPlaying, setNowPlaying] = useState<ScrobbleSession[]>([]);
 
   const continueScroll = useHorizontalScroll();
   const recentScroll = useHorizontalScroll();
@@ -290,16 +291,18 @@ export function DashboardPage() {
 
   const load = useCallback(async () => {
     try {
-      const [progressRes, historyRes, statsRes, checkinRes] = await Promise.all([
+      const [progressRes, historyRes, statsRes, checkinRes, nowPlayingRes] = await Promise.all([
         api.getSeriesProgress(),
         api.getWatchHistory(20),
         api.getWatchStats(),
         api.getCheckin().catch(() => ({ checkin: null })),
+        api.getNowPlaying().catch(() => ({ sessions: [] })),
       ]);
       setProgress(progressRes ?? []);
       setHistory(historyRes ?? []);
       setStats(statsRes);
       setActiveCheckin(checkinRes.checkin);
+      setNowPlaying(nowPlayingRes.sessions ?? []);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load dashboard");
     } finally {
@@ -389,7 +392,9 @@ export function DashboardPage() {
         setMarkedDone((prev) => { const next = new Set(prev); next.delete(imdbId); return next; });
         void load();
       }, 1200);
-    } catch { } finally {
+    } catch {
+      // best-effort; UI simply won't show the optimistic "done" state
+    } finally {
       setMarkingNext((prev) => { const next = new Set(prev); next.delete(imdbId); return next; });
     }
   };
@@ -492,6 +497,60 @@ export function DashboardPage() {
                 <X className="h-4 w-4" />
               </button>
             </div>
+          </div>
+        </section>
+      )}
+
+      {/* ── Live: Plex/Jellyfin scrobble sessions ── */}
+      {nowPlaying.length > 0 && (
+        <section className="space-y-2">
+          <h3 className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--text-mute)" }}>
+            <span className="relative flex h-2 w-2">
+              <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75" />
+              <span className="relative inline-flex rounded-full h-2 w-2 bg-emerald-500" />
+            </span>
+            Playing now
+          </h3>
+          <div className="space-y-2">
+            {nowPlaying.map((session) => (
+              <div
+                key={session.id}
+                className="flex items-center gap-3 rounded-xl p-3"
+                style={{ border: "1px solid var(--border)", background: "var(--bg-1)" }}
+              >
+                <div
+                  className="flex h-12 w-12 flex-none items-center justify-center overflow-hidden rounded-lg"
+                  style={{ background: "var(--surface-strong)" }}
+                >
+                  {session.poster ? (
+                    <img src={session.poster} alt="" className="h-full w-full object-cover" loading="lazy" />
+                  ) : session.type === "movie" ? (
+                    <Film className="h-5 w-5" style={{ color: "var(--text-mute)" }} />
+                  ) : (
+                    <Tv className="h-5 w-5" style={{ color: "var(--text-mute)" }} />
+                  )}
+                </div>
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm font-medium" style={{ color: "var(--text)" }}>
+                    {session.name ?? session.imdbId}
+                    {session.type === "episode" && session.season != null && session.episode != null && (
+                      <span style={{ color: "var(--text-mute)" }}>
+                        {" "}S{session.season}E{session.episode}
+                      </span>
+                    )}
+                  </p>
+                  <div className="mt-1.5 h-1.5 w-full overflow-hidden rounded-full" style={{ background: "var(--surface-strong)" }}>
+                    <div
+                      className={`h-full rounded-full ${session.status === "paused" ? "bg-amber-400" : "bg-emerald-500"}`}
+                      style={{ width: `${Math.round(session.progress)}%` }}
+                    />
+                  </div>
+                </div>
+                <span className="flex-none text-2xs font-medium capitalize" style={{ color: "var(--text-mute)" }}>
+                  {session.status}
+                </span>
+              </div>
+            ))}
           </div>
         </section>
       )}

--- a/apps/web/src/pages/HistoryPage.tsx
+++ b/apps/web/src/pages/HistoryPage.tsx
@@ -1,0 +1,166 @@
+import { useCallback, useEffect, useState } from "react";
+import { AlertCircle, Calendar, Film, Trash2, Tv } from "lucide-react";
+import { api, WatchEvent } from "../api";
+
+const PAGE_SIZE = 25;
+
+export function HistoryPage() {
+  const [events, setEvents] = useState<WatchEvent[]>([]);
+  const [offset, setOffset] = useState(0);
+  const [hasMore, setHasMore] = useState(true);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  const loadPage = useCallback(async (nextOffset: number) => {
+    const page = await api.getWatchHistory(PAGE_SIZE, nextOffset);
+    setHasMore(page.length === PAGE_SIZE);
+    return page;
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const page = await loadPage(0);
+        if (!cancelled) {
+          setEvents(page);
+          setOffset(page.length);
+        }
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : "Failed to load watch history");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [loadPage]);
+
+  const loadMore = async () => {
+    setLoadingMore(true);
+    try {
+      const page = await loadPage(offset);
+      setEvents((prev) => [...prev, ...page]);
+      setOffset((prev) => prev + page.length);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load more history");
+    } finally {
+      setLoadingMore(false);
+    }
+  };
+
+  const handleDelete = async (eventId: string) => {
+    setDeletingId(eventId);
+    try {
+      await api.deleteWatchEvent(eventId);
+      setEvents((prev) => prev.filter((e) => e.id !== eventId));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to delete watch event");
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  if (error && events.length === 0) {
+    return (
+      <div className="mx-auto max-w-lg rounded-2xl p-8 text-center" style={{ border: "1px solid rgba(244,63,94,0.2)", background: "rgba(244,63,94,0.05)" }}>
+        <AlertCircle className="mx-auto h-12 w-12 text-rose-500" />
+        <p className="mt-3 text-lg font-semibold text-rose-500">{error}</p>
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="mx-auto max-w-3xl space-y-6">
+        <h2 className="text-2xl font-bold" style={{ color: "var(--text)" }}>Watch History</h2>
+        <div className="space-y-2">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <div key={i} className="skeleton h-16 rounded-xl" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-6">
+      <h2 className="text-2xl font-bold" style={{ color: "var(--text)" }}>Watch History</h2>
+
+      {error && (
+        <p className="text-sm text-rose-500">{error}</p>
+      )}
+
+      {events.length === 0 ? (
+        <div className="rounded-2xl p-8 text-center" style={{ border: "1px solid var(--border)", background: "var(--bg-1)" }}>
+          <Calendar className="mx-auto h-10 w-10" style={{ color: "var(--text-mute)" }} />
+          <p className="mt-3 text-sm" style={{ color: "var(--text-dim)" }}>No watch history yet.</p>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {events.map((event) => (
+            <div
+              key={event.id}
+              className="flex items-center gap-3 rounded-xl p-3"
+              style={{ border: "1px solid var(--border)", background: "var(--bg-1)" }}
+            >
+              <div
+                className="flex h-12 w-12 flex-none items-center justify-center overflow-hidden rounded-lg"
+                style={{ background: "var(--surface-strong)" }}
+              >
+                {event.poster ? (
+                  <img src={event.poster} alt={event.name} className="h-full w-full object-cover" loading="lazy" />
+                ) : event.type === "movie" ? (
+                  <Film className="h-5 w-5" style={{ color: "var(--text-mute)" }} />
+                ) : (
+                  <Tv className="h-5 w-5" style={{ color: "var(--text-mute)" }} />
+                )}
+              </div>
+
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-sm font-medium" style={{ color: "var(--text)" }}>
+                  {event.name}
+                  {event.type === "episode" && event.season != null && event.episode != null && (
+                    <span style={{ color: "var(--text-mute)" }}>
+                      {" "}S{event.season}E{event.episode}
+                    </span>
+                  )}
+                </p>
+                <p className="text-2xs" style={{ color: "var(--text-mute)" }}>
+                  {new Date(event.watchedAt).toLocaleString(undefined, {
+                    dateStyle: "medium",
+                    timeStyle: "short",
+                  })}
+                </p>
+              </div>
+
+              <button
+                type="button"
+                onClick={() => handleDelete(event.id)}
+                disabled={deletingId === event.id}
+                className="flex h-9 w-9 flex-none items-center justify-center rounded-lg transition-colors hover:bg-rose-500/10 disabled:opacity-50"
+                aria-label="Delete watch event"
+                title="Remove from history"
+              >
+                <Trash2 className="h-4 w-4 text-rose-500" />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {hasMore && (
+        <button
+          type="button"
+          onClick={loadMore}
+          disabled={loadingMore}
+          className="w-full rounded-xl py-2.5 text-sm font-medium transition-colors hover:bg-[var(--surface-strong)] disabled:opacity-50"
+          style={{ border: "1px solid var(--border)", color: "var(--text-dim)" }}
+        >
+          {loadingMore ? "Loading..." : "Load more"}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/pages/HistoryPage.tsx
+++ b/apps/web/src/pages/HistoryPage.tsx
@@ -55,6 +55,7 @@ export function HistoryPage() {
     try {
       await api.deleteWatchEvent(eventId);
       setEvents((prev) => prev.filter((e) => e.id !== eventId));
+      setOffset((prev) => prev - 1);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to delete watch event");
     } finally {

--- a/apps/web/src/pages/ListsPage.tsx
+++ b/apps/web/src/pages/ListsPage.tsx
@@ -209,7 +209,7 @@ export function ListsPage() {
         setSelectedListId(loaded[0].id);
       }
     });
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, []);
 
   useEffect(() => {
     if (selectedListId) {

--- a/apps/web/src/pages/SearchPage.tsx
+++ b/apps/web/src/pages/SearchPage.tsx
@@ -12,7 +12,7 @@ import {
 
 /* ─── Toast System ─── */
 
-function ToastContainer({ toasts, onRemove }: { toasts: Toast[]; onRemove: (id: number) => void }) {
+function ToastContainer({ toasts }: { toasts: Toast[] }) {
   return (
     <div role="status" aria-live="polite" aria-atomic="true" className="fixed bottom-6 right-6 z-[100] flex flex-col gap-3 sm:bottom-6 max-sm:bottom-20 max-sm:right-4">
       {toasts.map((toast) => (
@@ -537,7 +537,7 @@ export function SearchPage() {
       )}
 
       {/* Toast notifications */}
-      <ToastContainer toasts={toasts} onRemove={(id) => setToasts((prev) => prev.filter((t) => t.id !== id))} />
+      <ToastContainer toasts={toasts} />
     </div>
   );
 }

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -1,6 +1,6 @@
 import { FormEvent, ReactNode, useCallback, useEffect, useId, useRef, useState } from "react";
 import { api, runtimeConfig } from "../api";
-import { ChevronDown, Key, Link, Database, Info, Eye, EyeOff, Loader2, Check, AlertCircle, Unplug, Clapperboard, Image, Globe, Shield, Copy, ExternalLink, Star, Sparkles, Clock, Bell, Users } from "lucide-react";
+import { ChevronDown, Key, Link, Database, Info, Eye, EyeOff, Loader2, Check, AlertCircle, Unplug, Clapperboard, Image, Globe, Shield, Copy, ExternalLink, Star, Sparkles, Clock, Bell, Users, Download, Upload } from "lucide-react";
 import { timeAgo } from "../utils/timeAgo";
 import { isPushSupported, getExistingPushSubscription, subscribeToPush, unsubscribeFromPush } from "../utils/push";
 
@@ -888,6 +888,15 @@ function DataSection() {
   const [result, setResult] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
+  const [exporting, setExporting] = useState(false);
+  const [importingJson, setImportingJson] = useState(false);
+  const [importingCsv, setImportingCsv] = useState(false);
+  const [importResult, setImportResult] = useState<string | null>(null);
+  const [importError, setImportError] = useState<string | null>(null);
+
+  const jsonFileInputRef = useRef<HTMLInputElement>(null);
+  const csvFileInputRef = useRef<HTMLInputElement>(null);
+
   const refreshAll = async () => {
     setSyncing(true);
     setResult(null);
@@ -902,19 +911,141 @@ function DataSection() {
     }
   };
 
+  const handleExport = async () => {
+    setExporting(true);
+    setImportError(null);
+    try {
+      const payload = await api.exportData();
+      const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `cataloggy-export-${new Date().toISOString().slice(0, 10)}.json`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      setImportError(err instanceof Error ? err.message : "Export failed");
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  const handleImportJsonFile = async (file: File) => {
+    setImportingJson(true);
+    setImportResult(null);
+    setImportError(null);
+    try {
+      const text = await file.text();
+      const payload = JSON.parse(text);
+      const res = await api.importData(payload);
+      const s = res.summary;
+      setImportResult(
+        `Imported ${s.watchEvents} watch events, ${s.listItems} list items, ${s.seriesProgress} series progress entries, ${s.ratings} ratings`
+      );
+    } catch (err) {
+      setImportError(err instanceof Error ? err.message : "Import failed");
+    } finally {
+      setImportingJson(false);
+    }
+  };
+
+  const handleImportCsvFile = async (file: File) => {
+    setImportingCsv(true);
+    setImportResult(null);
+    setImportError(null);
+    try {
+      const csv = await file.text();
+      const res = await api.importCsv(csv);
+      setImportResult(`Imported ${res.summary.imported} watch events (${res.summary.skipped} rows skipped)`);
+    } catch (err) {
+      setImportError(err instanceof Error ? err.message : "CSV import failed");
+    } finally {
+      setImportingCsv(false);
+    }
+  };
+
   return (
-    <div className="space-y-4">
-      <p className="text-sm text-ink-600 leading-relaxed">Re-fetch metadata (posters, descriptions, etc.) for all tracked items from TMDB.</p>
-      <button
-        type="button"
-        onClick={refreshAll}
-        disabled={syncing}
-        className="inline-flex items-center gap-2 rounded-xl bg-claw-500 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-claw-600 disabled:opacity-60"
-      >
-        {syncing ? <><Loader2 size={16} className="animate-spin" /> Syncing...</> : "Sync all metadata"}
-      </button>
-      {result && <p className="flex items-center gap-2 text-sm text-emerald-600"><Check size={16} /> {result}</p>}
-      {error && <p className="flex items-center gap-2 text-sm text-rose-600"><AlertCircle size={16} /> {error}</p>}
+    <div className="space-y-6">
+      <div className="space-y-4">
+        <p className="text-sm text-ink-600 leading-relaxed">Re-fetch metadata (posters, descriptions, etc.) for all tracked items from TMDB.</p>
+        <button
+          type="button"
+          onClick={refreshAll}
+          disabled={syncing}
+          className="inline-flex items-center gap-2 rounded-xl bg-claw-500 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-claw-600 disabled:opacity-60"
+        >
+          {syncing ? <><Loader2 size={16} className="animate-spin" /> Syncing...</> : "Sync all metadata"}
+        </button>
+        {result && <p className="flex items-center gap-2 text-sm text-emerald-600"><Check size={16} /> {result}</p>}
+        {error && <p className="flex items-center gap-2 text-sm text-rose-600"><AlertCircle size={16} /> {error}</p>}
+      </div>
+
+      <div className="space-y-4 border-t border-ink-100 pt-5">
+        <div>
+          <p className="text-sm font-semibold text-ink-700">Export your data</p>
+          <p className="text-sm text-ink-600 leading-relaxed">Download a JSON file with your lists, watch history, series progress, and ratings.</p>
+        </div>
+        <button
+          type="button"
+          onClick={handleExport}
+          disabled={exporting}
+          className="inline-flex items-center gap-2 rounded-xl border border-ink-200 bg-cream-50 px-5 py-2.5 text-sm font-semibold text-ink-700 transition-colors hover:bg-ink-100 disabled:opacity-60"
+        >
+          {exporting ? <><Loader2 size={16} className="animate-spin" /> Exporting...</> : <><Download size={16} /> Download export</>}
+        </button>
+      </div>
+
+      <div className="space-y-4 border-t border-ink-100 pt-5">
+        <div>
+          <p className="text-sm font-semibold text-ink-700">Import data</p>
+          <p className="text-sm text-ink-600 leading-relaxed">
+            Restore from a Cataloggy JSON export, or import watch history from a CSV file with columns <code>imdbId,type,season,episode,watchedAt</code>.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-3">
+          <input
+            ref={jsonFileInputRef}
+            type="file"
+            accept="application/json"
+            className="hidden"
+            onChange={(e) => {
+              const file = e.target.files?.[0];
+              if (file) void handleImportJsonFile(file);
+              e.target.value = "";
+            }}
+          />
+          <button
+            type="button"
+            onClick={() => jsonFileInputRef.current?.click()}
+            disabled={importingJson}
+            className="inline-flex items-center gap-2 rounded-xl border border-ink-200 bg-cream-50 px-5 py-2.5 text-sm font-semibold text-ink-700 transition-colors hover:bg-ink-100 disabled:opacity-60"
+          >
+            {importingJson ? <><Loader2 size={16} className="animate-spin" /> Importing...</> : <><Upload size={16} /> Import JSON export</>}
+          </button>
+
+          <input
+            ref={csvFileInputRef}
+            type="file"
+            accept=".csv,text/csv"
+            className="hidden"
+            onChange={(e) => {
+              const file = e.target.files?.[0];
+              if (file) void handleImportCsvFile(file);
+              e.target.value = "";
+            }}
+          />
+          <button
+            type="button"
+            onClick={() => csvFileInputRef.current?.click()}
+            disabled={importingCsv}
+            className="inline-flex items-center gap-2 rounded-xl border border-ink-200 bg-cream-50 px-5 py-2.5 text-sm font-semibold text-ink-700 transition-colors hover:bg-ink-100 disabled:opacity-60"
+          >
+            {importingCsv ? <><Loader2 size={16} className="animate-spin" /> Importing...</> : <><Upload size={16} /> Import CSV history</>}
+          </button>
+        </div>
+        {importResult && <p className="flex items-center gap-2 text-sm text-emerald-600"><Check size={16} /> {importResult}</p>}
+        {importError && <p className="flex items-center gap-2 text-sm text-rose-600"><AlertCircle size={16} /> {importError}</p>}
+      </div>
     </div>
   );
 }

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Dumps the Postgres database used by docker-compose.yml to a timestamped
+# .sql.gz file. Run from the repository root (or pass BACKUP_DIR explicitly).
+set -euo pipefail
+
+COMPOSE_PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$COMPOSE_PROJECT_DIR"
+
+POSTGRES_USER="${POSTGRES_USER:-postgres}"
+POSTGRES_DB="${POSTGRES_DB:-cataloggy}"
+BACKUP_DIR="${BACKUP_DIR:-$COMPOSE_PROJECT_DIR/backups}"
+
+mkdir -p "$BACKUP_DIR"
+
+TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
+OUT_FILE="$BACKUP_DIR/cataloggy-$TIMESTAMP.sql.gz"
+
+echo "Backing up database '$POSTGRES_DB' to $OUT_FILE"
+docker compose exec -T db pg_dump -U "$POSTGRES_USER" "$POSTGRES_DB" | gzip > "$OUT_FILE"
+
+echo "Backup complete: $OUT_FILE"

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -30,6 +30,6 @@ if [ "$CONFIRM" != "yes" ]; then
 fi
 
 echo "Restoring $BACKUP_FILE into '$POSTGRES_DB'..."
-gunzip -c "$BACKUP_FILE" | docker compose exec -T db psql -U "$POSTGRES_USER" "$POSTGRES_DB"
+gunzip -c "$BACKUP_FILE" | docker compose exec -T db psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" "$POSTGRES_DB"
 
 echo "Restore complete."

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Restores the Postgres database used by docker-compose.yml from a .sql.gz
+# backup created by scripts/backup.sh.
+#
+# Usage: scripts/restore.sh <path-to-backup.sql.gz>
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 <path-to-backup.sql.gz>" >&2
+  exit 1
+fi
+
+BACKUP_FILE="$1"
+if [ ! -f "$BACKUP_FILE" ]; then
+  echo "Backup file not found: $BACKUP_FILE" >&2
+  exit 1
+fi
+
+COMPOSE_PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$COMPOSE_PROJECT_DIR"
+
+POSTGRES_USER="${POSTGRES_USER:-postgres}"
+POSTGRES_DB="${POSTGRES_DB:-cataloggy}"
+
+echo "This will OVERWRITE the current contents of database '$POSTGRES_DB'."
+read -r -p "Type 'yes' to continue: " CONFIRM
+if [ "$CONFIRM" != "yes" ]; then
+  echo "Aborted."
+  exit 1
+fi
+
+echo "Restoring $BACKUP_FILE into '$POSTGRES_DB'..."
+gunzip -c "$BACKUP_FILE" | docker compose exec -T db psql -U "$POSTGRES_USER" "$POSTGRES_DB"
+
+echo "Restore complete."


### PR DESCRIPTION
- Use timingSafeEqual for Jellyfin webhook secret comparison (matches existing Plex fix), preventing timing-attack secret recovery
- Add PIN brute-force lockout (5 attempts, 5 min cooldown) to profile verification
- Add scripts/backup.sh and scripts/restore.sh wrapping pg_dump/psql for simple Postgres backups
- Add GET /export and POST /import (+/import/csv) API routes for full JSON data round-trip and CSV watch-history import, with dedup logic mirroring existing watch-event rules
- Add CI workflow (lint/typecheck/build) gating PRs and pushes to main
- Gate Docker image publishing behind a passing test job so broken code can't reach :latest images
- Add a dedicated paginated Watch History page and surface live Plex/Jellyfin "Playing now" scrobble sessions on the dashboard
- Add data export/import controls to Settings
- Document Android/Android TV install steps and backup/restore usage in README
- Fix pre-existing lint errors (unused imports/vars, empty catch block, stale eslint-disable referencing an uninstalled plugin) so the new CI gate starts green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Trakt scrobbling and watchlist synchronization for media playback
  * Export and import watch history data via JSON or CSV format
  * Watch history page with pagination
  * Live scrobble sessions display from Plex/Jellyfin
  * PIN brute-force protection on profile verification

* **Bug Fixes**
  * Enhanced webhook security with constant-time secret comparison

* **Documentation**
  * Local network installation guides for iOS PWA and Android/Android TV
  * Backup and restore database instructions with example cron scheduling

* **Chores**
  * Added CI/CD workflow automation
  * Added database backup and restore scripts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->