### PR TITLE
Fix profile scoping, race condition, PIN lockout persistence, and addon feedback

### DIFF
--- a/apps/addon/src/index.ts
+++ b/apps/addon/src/index.ts
@@ -626,6 +626,11 @@ const MINIMAL_SRT = `1
 Marked as watched on Cataloggy
 `;
 
+const SERIES_NO_EPISODE_SRT = `1
+00:00:00,000 --> 00:00:03,000
+Cannot mark a series as watched — select a specific episode first
+`;
+
 app.get<{ Params: { type: string; imdbId: string } }>("/mark-watched/:type/:imdbId.srt", async (request, reply) => {
   reply.header("Access-Control-Allow-Origin", "*");
   reply.header("Content-Type", "text/srt; charset=utf-8");
@@ -635,9 +640,12 @@ app.get<{ Params: { type: string; imdbId: string } }>("/mark-watched/:type/:imdb
   try {
     if (type === "movie") {
       await apiPost("/watch", { type: "movie", imdbId });
+      request.log.info({ type, imdbId }, "Marked as watched from Stremio");
+    } else {
+      // For series without episode info, return honest feedback instead of a silent no-op
+      request.log.info({ type, imdbId }, "Series mark-watched requested without episode info — no-op");
+      return reply.send(SERIES_NO_EPISODE_SRT);
     }
-    // For series without episode info, just log it
-    request.log.info({ type, imdbId }, "Marked as watched from Stremio");
   } catch (error) {
     request.log.error(error, "Failed to mark as watched");
   }

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -196,10 +196,11 @@ const start = async () => {
 
   const refreshAiRecommendations = async () => {
     if (!(await isAiConfigured())) return;
+    const profileId = await getDefaultProfileId();
     trendingCacheDeletePrefix("ai-recs:");
     await Promise.allSettled([
-      getAiRecommendations("movie", 15),
-      getAiRecommendations("series", 15),
+      getAiRecommendations("movie", 15, profileId),
+      getAiRecommendations("series", 15, profileId),
     ]);
   };
 

--- a/apps/api/src/lib/ai.ts
+++ b/apps/api/src/lib/ai.ts
@@ -161,7 +161,7 @@ const callAiProvider = async (config: AiProviderConfig, prompt: string): Promise
   const data = await response.json() as { choices?: Array<{ message?: { content?: string } }> };
   let content = data.choices?.[0]?.message?.content ?? "";
 
-  content = content.replace(/<[\s\S]*?<\/think>/gi, "");
+  content = content.replace(/<think>[\s\S]*?<\/think>/gi, "");
   content = content.replace(/^```(?:json)?\s*/i, "").replace(/\s*```\s*$/i, "").trim();
 
   return content;

--- a/apps/api/src/lib/ai.ts
+++ b/apps/api/src/lib/ai.ts
@@ -47,8 +47,9 @@ export const shouldRefreshAiRecs = async (): Promise<boolean> => {
   return hoursSinceLastGen >= 6;
 };
 
-export const buildTasteProfile = async () => {
+export const buildTasteProfile = async (profileId?: string) => {
   const recentEvents = await prisma.watchEvent.findMany({
+    where: profileId ? { profileId } : undefined,
     orderBy: { watchedAt: "desc" },
     take: 50,
     distinct: ["imdbId"],
@@ -160,7 +161,7 @@ const callAiProvider = async (config: AiProviderConfig, prompt: string): Promise
   const data = await response.json() as { choices?: Array<{ message?: { content?: string } }> };
   let content = data.choices?.[0]?.message?.content ?? "";
 
-  content = content.replace(/<think>[\s\S]*?<\/think>/gi, "");
+  content = content.replace(/<[\s\S]*?<\/think>/gi, "");
   content = content.replace(/^```(?:json)?\s*/i, "").replace(/\s*```\s*$/i, "").trim();
 
   return content;
@@ -176,9 +177,10 @@ const parseRecsFromContent = (content: string): AiRecItem[] => {
 
 export const getAiRecommendations = async (
   type: "movie" | "series",
-  limit = 10
+  limit = 10,
+  profileId?: string
 ): Promise<{ metas: StremioMetaPreview[]; reasons: Record<string, string> } | null> => {
-  const cacheKey = `ai-recs:${type}:${limit}`;
+  const cacheKey = `ai-recs:${type}:${limit}${profileId ? `:${profileId}` : ""}`;
   const cached = trendingCacheGet(cacheKey);
   if (cached) return { metas: cached.data, reasons: cached.reasons ?? {} };
 
@@ -186,7 +188,7 @@ export const getAiRecommendations = async (
   if (!config) return null;
 
   try {
-    const profile = await buildTasteProfile();
+    const profile = await buildTasteProfile(profileId);
     const avgRatingStr = profile.avgRating !== null ? `${profile.avgRating}/10` : "unrated";
     const typeLabel = type === "movie" ? "movies" : "TV series";
 

--- a/apps/api/src/lib/watch-event.ts
+++ b/apps/api/src/lib/watch-event.ts
@@ -75,8 +75,8 @@ export const recordWatchEvent = async (params: RecordWatchParams) => {
         if (await shouldRefreshAiRecs()) {
           trendingCacheDeletePrefix("ai-recs:");
           await Promise.allSettled([
-            getAiRecommendations("movie", 15),
-            getAiRecommendations("series", 15),
+            getAiRecommendations("movie", 15, profileId),
+            getAiRecommendations("series", 15, profileId),
           ]);
         }
       } catch { /* never let this affect the watch event response */ }
@@ -113,8 +113,8 @@ export const recordWatchEvent = async (params: RecordWatchParams) => {
       if (await shouldRefreshAiRecs()) {
         trendingCacheDeletePrefix("ai-recs:");
         await Promise.allSettled([
-          getAiRecommendations("movie", 15),
-          getAiRecommendations("series", 15),
+          getAiRecommendations("movie", 15, profileId),
+          getAiRecommendations("series", 15, profileId),
         ]);
       }
     } catch { /* never let this affect the watch event response */ }

--- a/apps/api/src/routes/ai.ts
+++ b/apps/api/src/routes/ai.ts
@@ -13,10 +13,13 @@ import {
   redactAiConfig,
   getAiRecommendations,
 } from "../lib/ai.js";
+import { resolveProfile } from "../lib/profile.js";
 import { getMetadataType } from "../lib/types.js";
 import type { StremioMetaPreview, StremioMetaType } from "../lib/types.js";
 
 const aiRoutes: FastifyPluginAsync = async (app) => {
+  app.addHook("preHandler", resolveProfile);
+
   app.get<{ Querystring: { imdbId?: string; type?: string } }>(
     "/recommendations",
     async (request, reply) => {
@@ -60,22 +63,24 @@ const aiRoutes: FastifyPluginAsync = async (app) => {
       const type = getMetadataType(rawType);
       if (!type) return { metas: [] };
       const limit = Math.min(Math.max(Number(request.query.limit) || 20, 1), 40);
+      const profileId = request.profileId!;
 
       if (await isAiConfigured()) {
-        const aiResult = await getAiRecommendations(rawType as "movie" | "series", limit);
+        const aiResult = await getAiRecommendations(rawType as "movie" | "series", limit, profileId);
         if (aiResult) return { metas: aiResult.metas };
       }
 
       const recentItems =
         rawType === "movie"
           ? await prisma.watchEvent.findMany({
-              where: { type: "movie" },
+              where: { type: "movie", profileId },
               orderBy: { watchedAt: "desc" },
               take: 5,
               distinct: ["imdbId"],
               select: { imdbId: true },
             })
           : await prisma.seriesProgress.findMany({
+              where: { profileId },
               orderBy: { lastWatchedAt: "desc" },
               take: 5,
               select: { seriesImdbId: true },
@@ -180,18 +185,20 @@ const aiRoutes: FastifyPluginAsync = async (app) => {
       if (rawType !== "movie" && rawType !== "series") return { metas: [], reasons: {} };
       const type = rawType as "movie" | "series";
       const limit = Math.min(Math.max(Number(request.query.limit) || 10, 1), 20);
+      const profileId = request.profileId!;
 
       if (!(await isAiConfigured())) {
         const recentItems =
           type === "movie"
             ? await prisma.watchEvent.findMany({
-                where: { type: "movie" },
+                where: { type: "movie", profileId },
                 orderBy: { watchedAt: "desc" },
                 take: 3,
                 distinct: ["imdbId"],
                 select: { imdbId: true },
               })
             : await prisma.seriesProgress.findMany({
+                where: { profileId },
                 orderBy: { lastWatchedAt: "desc" },
                 take: 3,
                 select: { seriesImdbId: true },
@@ -242,7 +249,7 @@ const aiRoutes: FastifyPluginAsync = async (app) => {
         }
       }
 
-      const result = await getAiRecommendations(type, limit);
+      const result = await getAiRecommendations(type, limit, profileId);
       if (!result) return { metas: [], reasons: {} };
       return { metas: result.metas, reasons: result.reasons };
     }

--- a/apps/api/src/routes/profiles.ts
+++ b/apps/api/src/routes/profiles.ts
@@ -17,38 +17,62 @@ const pinMatches = (pin: string, pinHash: string): boolean => {
 const MAX_PIN_ATTEMPTS = 5;
 const PIN_LOCKOUT_MS = 5 * 60 * 1000;
 
-const pinAttempts = new Map<string, { count: number; lockedUntil: number }>();
+const pinAttemptKey = (profileId: string) => `pinattempts:${profileId}`;
 
-// Only purge entries whose lockout has fully expired (lockedUntil > 0 acts as
-// the "is/was locked" marker). Entries below MAX_PIN_ATTEMPTS default to
-// lockedUntil 0, and 0 <= Date.now() is always true, so checking lockedUntil
-// alone would wipe in-progress failed-attempt counters on every call.
-const pruneExpiredPinLockouts = (): void => {
-  const now = Date.now();
-  for (const [profileId, entry] of pinAttempts) {
-    if (entry.lockedUntil > 0 && entry.lockedUntil <= now) pinAttempts.delete(profileId);
+type PinAttemptData = { count: number; lockedUntil: string };
+
+const getPinLockout = async (profileId: string): Promise<{ locked: boolean; retryAfterSec: number }> => {
+  const row = await prisma.kV.findUnique({ where: { key: pinAttemptKey(profileId) } });
+  if (!row) return { locked: false, retryAfterSec: 0 };
+
+  try {
+    const data = JSON.parse(row.value) as PinAttemptData;
+    if (data.lockedUntil && new Date(data.lockedUntil).getTime() > Date.now()) {
+      const retryAfterSec = Math.ceil((new Date(data.lockedUntil).getTime() - Date.now()) / 1000);
+      return { locked: true, retryAfterSec };
+    }
+  } catch { /* invalid data — treat as not locked */ }
+
+  return { locked: false, retryAfterSec: 0 };
+};
+
+const recordPinFailure = async (profileId: string): Promise<void> => {
+  const key = pinAttemptKey(profileId);
+  const now = new Date();
+  const nowIso = now.toISOString();
+
+  const row = await prisma.kV.findUnique({ where: { key } });
+  let data: PinAttemptData;
+
+  if (row) {
+    try {
+      data = JSON.parse(row.value) as PinAttemptData;
+      // If a previous lockout has expired, reset count
+      if (data.lockedUntil && new Date(data.lockedUntil).getTime() <= Date.now()) {
+        data = { count: 0, lockedUntil: "" };
+      }
+    } catch {
+      data = { count: 0, lockedUntil: "" };
+    }
+  } else {
+    data = { count: 0, lockedUntil: "" };
   }
-};
 
-const getPinLockout = (profileId: string): { locked: boolean; retryAfterSec: number } => {
-  pruneExpiredPinLockouts();
-  const entry = pinAttempts.get(profileId);
-  if (!entry || entry.lockedUntil <= Date.now()) return { locked: false, retryAfterSec: 0 };
-  return { locked: true, retryAfterSec: Math.ceil((entry.lockedUntil - Date.now()) / 1000) };
-};
-
-const recordPinFailure = (profileId: string): void => {
-  const entry = pinAttempts.get(profileId) ?? { count: 0, lockedUntil: 0 };
-  entry.count += 1;
-  if (entry.count >= MAX_PIN_ATTEMPTS) {
-    entry.lockedUntil = Date.now() + PIN_LOCKOUT_MS;
-    entry.count = 0;
+  data.count += 1;
+  if (data.count >= MAX_PIN_ATTEMPTS) {
+    data.lockedUntil = new Date(Date.now() + PIN_LOCKOUT_MS).toISOString();
+    data.count = 0;
   }
-  pinAttempts.set(profileId, entry);
+
+  await prisma.kV.upsert({
+    where: { key },
+    create: { key, value: JSON.stringify(data), updatedAt: now },
+    update: { value: JSON.stringify(data), updatedAt: now },
+  });
 };
 
-const clearPinAttempts = (profileId: string): void => {
-  pinAttempts.delete(profileId);
+const clearPinAttempts = async (profileId: string): Promise<void> => {
+  await prisma.kV.deleteMany({ where: { key: pinAttemptKey(profileId) } });
 };
 
 const profilesRoutes: FastifyPluginAsync = async (app) => {
@@ -98,7 +122,7 @@ const profilesRoutes: FastifyPluginAsync = async (app) => {
       return reply.code(200).send({ id: profile.id, name: profile.name });
     }
 
-    const lockout = getPinLockout(profile.id);
+    const lockout = await getPinLockout(profile.id);
     if (lockout.locked) {
       return reply
         .code(429)
@@ -108,11 +132,11 @@ const profilesRoutes: FastifyPluginAsync = async (app) => {
     const body = (request.body ?? {}) as { pin?: unknown };
     const pin = typeof body.pin === "string" ? body.pin.trim() : "";
     if (!pin || !pinMatches(pin, profile.pinHash)) {
-      recordPinFailure(profile.id);
+      await recordPinFailure(profile.id);
       return reply.code(401).send({ error: "Incorrect PIN" });
     }
 
-    clearPinAttempts(profile.id);
+    await clearPinAttempts(profile.id);
     return reply.code(200).send({ id: profile.id, name: profile.name });
   });
 
@@ -130,6 +154,9 @@ const profilesRoutes: FastifyPluginAsync = async (app) => {
     }
 
     await prisma.profile.delete({ where: { id: profile.id } });
+
+    // Clean up any PIN attempt records for the deleted profile
+    await clearPinAttempts(profile.id);
 
     return reply.code(204).send();
   });

--- a/apps/api/src/routes/profiles.ts
+++ b/apps/api/src/routes/profiles.ts
@@ -39,35 +39,42 @@ const getPinLockout = async (profileId: string): Promise<{ locked: boolean; retr
 const recordPinFailure = async (profileId: string): Promise<void> => {
   const key = pinAttemptKey(profileId);
   const now = new Date();
-  const nowIso = now.toISOString();
 
-  const row = await prisma.kV.findUnique({ where: { key } });
-  let data: PinAttemptData;
+  await prisma.$transaction(async (tx) => {
+    // Lock the row for the duration of this transaction so concurrent
+    // attempts can't read the same stale count. If the row doesn't exist
+    // yet, we create it first and then lock it via the upsert below — the
+    // unique constraint on KV.key ensures only one row wins the race.
+    await tx.$executeRaw`SELECT value FROM "KV" WHERE key = ${key} FOR UPDATE`;
 
-  if (row) {
-    try {
-      data = JSON.parse(row.value) as PinAttemptData;
-      // If a previous lockout has expired, reset count
-      if (data.lockedUntil && new Date(data.lockedUntil).getTime() <= Date.now()) {
+    const row = await tx.kV.findUnique({ where: { key } });
+    let data: PinAttemptData;
+
+    if (row) {
+      try {
+        data = JSON.parse(row.value) as PinAttemptData;
+        // If a previous lockout has expired, reset count
+        if (data.lockedUntil && new Date(data.lockedUntil).getTime() <= Date.now()) {
+          data = { count: 0, lockedUntil: "" };
+        }
+      } catch {
         data = { count: 0, lockedUntil: "" };
       }
-    } catch {
+    } else {
       data = { count: 0, lockedUntil: "" };
     }
-  } else {
-    data = { count: 0, lockedUntil: "" };
-  }
 
-  data.count += 1;
-  if (data.count >= MAX_PIN_ATTEMPTS) {
-    data.lockedUntil = new Date(Date.now() + PIN_LOCKOUT_MS).toISOString();
-    data.count = 0;
-  }
+    data.count += 1;
+    if (data.count >= MAX_PIN_ATTEMPTS) {
+      data.lockedUntil = new Date(Date.now() + PIN_LOCKOUT_MS).toISOString();
+      data.count = 0;
+    }
 
-  await prisma.kV.upsert({
-    where: { key },
-    create: { key, value: JSON.stringify(data), updatedAt: now },
-    update: { value: JSON.stringify(data), updatedAt: now },
+    await tx.kV.upsert({
+      where: { key },
+      create: { key, value: JSON.stringify(data), updatedAt: now },
+      update: { value: JSON.stringify(data), updatedAt: now },
+    });
   });
 };
 

--- a/apps/api/src/routes/scrobble.ts
+++ b/apps/api/src/routes/scrobble.ts
@@ -24,15 +24,16 @@ export const cleanupStaleSessions = async () => {
   }
 };
 
-const CHECKIN_KV_KEY = "checkin:active";
+const checkinKey = (profileId: string) => `checkin:active:${profileId}`;
 
 const scrobbleRoutes: FastifyPluginAsync = async (app) => {
   app.addHook("preHandler", resolveProfile);
 
   // ─── Check-in ───
 
-  app.get("/checkin", async () => {
-    const row = await prisma.kV.findUnique({ where: { key: CHECKIN_KV_KEY } });
+  app.get("/checkin", async (request) => {
+    const key = checkinKey(request.profileId!);
+    const row = await prisma.kV.findUnique({ where: { key } });
     if (!row) return { checkin: null };
     try {
       return { checkin: JSON.parse(row.value) as CheckInData };
@@ -57,16 +58,18 @@ const scrobbleRoutes: FastifyPluginAsync = async (app) => {
     const startedAt = new Date().toISOString();
     const expiresAt = runtime ? new Date(Date.now() + runtime * 60 * 1000).toISOString() : undefined;
     const checkin: CheckInData = { type, imdbId, seriesImdbId, name, poster, season, episode, startedAt, expiresAt };
+    const key = checkinKey(request.profileId!);
     await prisma.kV.upsert({
-      where: { key: CHECKIN_KV_KEY },
-      create: { key: CHECKIN_KV_KEY, value: JSON.stringify(checkin), updatedAt: new Date() },
+      where: { key },
+      create: { key, value: JSON.stringify(checkin), updatedAt: new Date() },
       update: { value: JSON.stringify(checkin), updatedAt: new Date() },
     });
     return { checkin };
   });
 
   app.delete<{ Querystring: { log?: string } }>("/checkin", async (request, reply) => {
-    const row = await prisma.kV.findUnique({ where: { key: CHECKIN_KV_KEY } });
+    const key = checkinKey(request.profileId!);
+    const row = await prisma.kV.findUnique({ where: { key } });
     if (row && request.query.log === "true") {
       try {
         const checkin = JSON.parse(row.value) as CheckInData;
@@ -83,7 +86,7 @@ const scrobbleRoutes: FastifyPluginAsync = async (app) => {
         });
       } catch { /* best-effort */ }
     }
-    await prisma.kV.deleteMany({ where: { key: CHECKIN_KV_KEY } });
+    await prisma.kV.deleteMany({ where: { key } });
     return reply.code(204).send();
   });
 

--- a/apps/api/src/routes/watch.ts
+++ b/apps/api/src/routes/watch.ts
@@ -80,7 +80,7 @@ const watchRoutes: FastifyPluginAsync = async (app) => {
     const dayEnd = new Date(watchedAt);
     dayEnd.setUTCHours(23, 59, 59, 999);
 
-    const watchEvent = await prisma.$transaction(async (tx) => {
+    const { watchEvent, wasCreated } = await prisma.$transaction(async (tx) => {
       const existing = await tx.watchEvent.findFirst({
         where: { profileId, imdbId, season, episode, watchedAt: { gte: dayStart, lte: dayEnd } },
       });
@@ -90,12 +90,13 @@ const watchRoutes: FastifyPluginAsync = async (app) => {
           where: { id: existing.id },
           data: { plays: { increment: 1 }, watchedAt },
         });
-        return updated;
+        return { watchEvent: updated, wasCreated: false };
       }
 
-      return tx.watchEvent.create({
+      const created = await tx.watchEvent.create({
         data: { type, imdbId, seriesImdbId, season, episode, watchedAt, profileId },
       });
+      return { watchEvent: created, wasCreated: true };
     });
 
     syncWatchEventToTrakt(watchEvent, { type, imdbId, seriesImdbId, season, episode }, request.log);
@@ -108,7 +109,7 @@ const watchRoutes: FastifyPluginAsync = async (app) => {
       });
     }
 
-    return reply.code(existing ? 200 : 201).send({ watchEvent: serializeWatchEvent(watchEvent) });
+    return reply.code(wasCreated ? 201 : 200).send({ watchEvent: serializeWatchEvent(watchEvent) });
   });
 
   app.delete<{ Params: { eventId: string } }>("/watch/:eventId", async (request, reply) => {

--- a/apps/api/src/routes/watch.ts
+++ b/apps/api/src/routes/watch.ts
@@ -80,22 +80,25 @@ const watchRoutes: FastifyPluginAsync = async (app) => {
     const dayEnd = new Date(watchedAt);
     dayEnd.setUTCHours(23, 59, 59, 999);
 
-    const existing = await prisma.watchEvent.findFirst({
-      where: { profileId, imdbId, season, episode, watchedAt: { gte: dayStart, lte: dayEnd } },
-    });
-
-    if (existing) {
-      const updated = await prisma.watchEvent.update({
-        where: { id: existing.id },
-        data: { plays: existing.plays + 1 },
+    const watchEvent = await prisma.$transaction(async (tx) => {
+      const existing = await tx.watchEvent.findFirst({
+        where: { profileId, imdbId, season, episode, watchedAt: { gte: dayStart, lte: dayEnd } },
       });
-      syncWatchEventToTrakt(updated, { type, imdbId, seriesImdbId, season, episode }, request.log);
-      return reply.code(200).send({ watchEvent: serializeWatchEvent(updated) });
-    }
 
-    const watchEvent = await prisma.watchEvent.create({
-      data: { type, imdbId, seriesImdbId, season, episode, watchedAt, profileId },
+      if (existing) {
+        const updated = await tx.watchEvent.update({
+          where: { id: existing.id },
+          data: { plays: { increment: 1 }, watchedAt },
+        });
+        return updated;
+      }
+
+      return tx.watchEvent.create({
+        data: { type, imdbId, seriesImdbId, season, episode, watchedAt, profileId },
+      });
     });
+
+    syncWatchEventToTrakt(watchEvent, { type, imdbId, seriesImdbId, season, episode }, request.log);
 
     if (type === "episode" && seriesImdbId && season !== null && episode !== null) {
       await upsertSeriesProgressIfNewer(profileId, seriesImdbId, {
@@ -105,9 +108,7 @@ const watchRoutes: FastifyPluginAsync = async (app) => {
       });
     }
 
-    syncWatchEventToTrakt(watchEvent, { type, imdbId, seriesImdbId, season, episode }, request.log);
-
-    return reply.code(201).send({ watchEvent: serializeWatchEvent(watchEvent) });
+    return reply.code(existing ? 200 : 201).send({ watchEvent: serializeWatchEvent(watchEvent) });
   });
 
   app.delete<{ Params: { eventId: string } }>("/watch/:eventId", async (request, reply) => {


### PR DESCRIPTION
## Summary

Fixes five GitHub issues related to profile-scoped data leaks, a race condition, and security hardening.

## Issues Addressed

### #157 — Check-in is not profile-scoped (Critical)
- **File:** `apps/api/src/routes/scrobble.ts`
- **Change:** Replaced the global `CHECKIN_KV_KEY = "checkin:active"` constant with a `checkinKey(profileId)` function that produces `checkin:active:{profileId}`. Updated `GET /checkin`, `POST /checkin`, and `DELETE /checkin` to use `request.profileId` in the KV key. Profiles can no longer see or interfere with each other's active check-ins.

### #158 — buildTasteProfile ignores profileId (Critical, Security)
- **Files:** `apps/api/src/lib/ai.ts`, `apps/api/src/routes/ai.ts`, `apps/api/src/index.ts`, `apps/api/src/lib/watch-event.ts`
- **Change:** `buildTasteProfile()` now accepts an optional `profileId` and adds it to the `prisma.watchEvent.findMany` `where` clause. `getAiRecommendations()` accepts and passes through `profileId`. The in-memory cache key is now `ai-recs:{type}:{limit}:{profileId}` to prevent cross-profile cache collisions.
- Updated all callers:
  - `routes/ai.ts` — `/recommendations/personal` and `/recommendations/ai` pass `request.profileId` (added `resolveProfile` preHandler hook)
  - `index.ts` — scheduled AI refresh passes `getDefaultProfileId()`
  - `lib/watch-event.ts` — post-watch AI refresh passes `profileId`
- Ratings remain intentionally instance-global (per commit history), only watch history is now scoped.

### #159 — Race condition in POST /watch (Critical)
- **File:** `apps/api/src/routes/watch.ts`
- **Change:** Replaced the read-then-write pattern (`existing.plays + 1`) with `prisma.$transaction` + `data: { plays: { increment: 1 } }`, making the plays increment atomic. This matches the approach already used in `lib/watch-event.ts`.

### #174 — Addon mark-watched for series silently succeeds (Minor)
- **File:** `apps/addon/src/index.ts`
- **Change:** When a Stremio user clicks "Mark Watched" on a series without episode info, the addon now returns a different SRT subtitle: "Cannot mark a series as watched — select a specific episode first" instead of the misleading "Marked as watched on Cataloggy".

### #156 — PIN brute-force lockout resets on restart (Critical, Security)
- **File:** `apps/api/src/routes/profiles.ts`
- **Change:** Replaced the in-memory `Map<string, { count, lockedUntil }>` with KV table storage (`pinattempts:{profileId}`). All lockout state (attempt count, locked-until timestamp) now persists across API restarts. Also cleans up attempt records when a profile is deleted.

## Verification

- No Prisma schema changes needed — all fixes use the existing `KV` table and existing columns
- No new migrations required
- The `ai.ts` route module now registers `resolveProfile` as a preHandler, consistent with other profile-scoped routes

## Test plan

1. **#157:** Create two profiles. Start a check-in as Profile A. `GET /checkin` as Profile B should return `{ checkin: null }`.
2. **#158:** With AI configured, `GET /recommendations/ai?type=movie` as different profiles should produce different recommendations based on each profile's watch history.
3. **#159:** Send two concurrent `POST /watch` requests for the same movie on the same day. Verify `plays` is 2, not 1.
4. **#174:** In Stremio, click "Mark Watched" on a series (not an episode). The subtitle should say "Cannot mark a series as watched — select a specific episode first".
5. **#156:** Make 5 failed PIN attempts on a profile. Restart the API. The profile should still be locked out.