### PR TITLE
Extract proxy utilities to shared package

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+.git
+.env
+.env.*
+!.env.example
+backups/
+.claude/
+*.log
+coverage
+*.tsbuildinfo

--- a/.github/workflows/dockerpublish.yml
+++ b/.github/workflows/dockerpublish.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Typecheck
         run: pnpm typecheck
 
+      - name: Test
+        run: pnpm test
+
       - name: Build
         run: pnpm build
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,13 @@ To schedule automatic backups, add a cron entry that runs `backup.sh` on a sched
 
 In addition to full database backups, Settings → Data lets you export your lists, watch history, series progress, and ratings as a single JSON file, and re-import it later (e.g. after a fresh install, or to migrate to a new instance). The API also accepts CSV watch-history imports (columns: `imdbId`, `type`, `watchedAt`, with optional `season`/`episode`) for importing history exported from other tools.
 
+## Security
+
+Cataloggy is designed for self-hosting on a trusted local network (LAN), not for direct exposure to the internet. Known limitations:
+
+- The web client stores its API bearer token in `localStorage`. Any JavaScript running on the page (e.g. via an XSS vulnerability in a dependency) could read this token. Since the token only grants access to your own local API, this is an acceptable tradeoff for a LAN-only app, but it is not suitable for an internet-facing deployment without further hardening (e.g. a Content-Security-Policy header, or migrating to httpOnly session cookies backed by a session store).
+- If you do expose Cataloggy beyond your LAN, put it behind a reverse proxy with TLS and consider implementing a proper session-based auth flow.
+
 ## Useful Commands
 
 - Run apps in dev mode from root:

--- a/apps/addon/Dockerfile
+++ b/apps/addon/Dockerfile
@@ -8,11 +8,14 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json eslint.c
 COPY apps/addon/package.json ./apps/addon/package.json
 COPY apps/api/package.json ./apps/api/package.json
 COPY apps/web/package.json ./apps/web/package.json
+COPY packages/shared/package.json ./packages/shared/package.json
 
 RUN pnpm install --frozen-lockfile
 
 COPY apps/addon ./apps/addon
+COPY packages/shared ./packages/shared
 
+RUN pnpm --filter @cataloggy/shared build
 RUN cd apps/addon && pnpm exec tsc -p tsconfig.json
 RUN addgroup -S app && adduser -S app -G app && chown -R app:app /app
 USER app

--- a/apps/addon/package.json
+++ b/apps/addon/package.json
@@ -11,6 +11,7 @@
     "lint": "eslint src"
   },
   "dependencies": {
+    "@cataloggy/shared": "workspace:*",
     "@fastify/rate-limit": "^11.0.0",
     "fastify": "^5.1.0"
   },

--- a/apps/addon/src/index.ts
+++ b/apps/addon/src/index.ts
@@ -1,16 +1,6 @@
 import Fastify, { type FastifyRequest, type FastifyReply, type RawRequestDefaultExpression } from "fastify";
 import rateLimit from "@fastify/rate-limit";
-
-const parseProxyPathPrefixes = (raw: string | undefined, fallback: readonly string[]) => {
-  const parsed = (raw ?? "")
-    .split(",")
-    .map((prefix) => prefix.trim())
-    .filter(Boolean)
-    .map((prefix) => (prefix.startsWith("/") ? prefix : `/${prefix}`))
-    .map((prefix) => (prefix.length > 1 ? prefix.replace(/\/+$/, "") : prefix));
-
-  return parsed.length > 0 ? parsed : [...fallback];
-};
+import { parseProxyPathPrefixes, normalizeProxyPath, parseTrustProxy } from "@cataloggy/shared";
 
 const CATALOGGY_API_BASE = process.env.CATALOGGY_API_BASE ?? "http://api:7000";
 const CATALOGGY_API_TOKEN = process.env.CATALOGGY_API_TOKEN;
@@ -18,44 +8,10 @@ const ADDON_PUBLIC_BASE = process.env.ADDON_PUBLIC_BASE;
 const WEB_PUBLIC_BASE = process.env.CATALOGGY_WEB_PUBLIC ?? process.env.WEB_PUBLIC_BASE;
 const PROXY_PATH_PREFIXES = parseProxyPathPrefixes(process.env.PROXY_PATH_PREFIXES, ["/addon"] as const);
 
-const stripProxyPrefix = (url: string, prefix: string) => {
-  if (url === prefix) {
-    return "/";
-  }
-
-  if (!url.startsWith(`${prefix}/`)) {
-    return null;
-  }
-
-  return url.slice(prefix.length) || "/";
-};
-
-const normalizeProxyPath = (rawUrl: string) => {
-  for (const prefix of PROXY_PATH_PREFIXES) {
-    const stripped = stripProxyPrefix(rawUrl, prefix);
-    if (stripped) {
-      return stripped;
-    }
-  }
-
-  return rawUrl;
-};
-
-// Only trust X-Forwarded-* headers from explicitly configured proxies, so
-// request.ip (used as the rate-limit key) can't be spoofed by clients when
-// there's no reverse proxy in front of this service.
-const parseTrustProxy = (raw: string | undefined): boolean | string[] | undefined => {
-  if (!raw) return undefined;
-  const trimmed = raw.trim();
-  if (trimmed === "true") return true;
-  if (trimmed === "false") return false;
-  return trimmed.split(",").map((entry) => entry.trim()).filter(Boolean);
-};
-
 const app = Fastify({
   logger: true,
   trustProxy: parseTrustProxy(process.env.TRUST_PROXY),
-  rewriteUrl: (request: RawRequestDefaultExpression) => normalizeProxyPath(request.url ?? "/")
+  rewriteUrl: (request: RawRequestDefaultExpression) => normalizeProxyPath(request.url ?? "/", PROXY_PATH_PREFIXES)
 });
 
 // ─── Rate limiting ───

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -8,12 +8,15 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json eslint.c
 COPY apps/api/package.json ./apps/api/package.json
 COPY apps/addon/package.json ./apps/addon/package.json
 COPY apps/web/package.json ./apps/web/package.json
+COPY packages/shared/package.json ./packages/shared/package.json
 
 RUN pnpm install --frozen-lockfile
 
 COPY apps/api ./apps/api
+COPY packages/shared ./packages/shared
 
 RUN pnpm exec prisma generate --schema=apps/api/prisma/schema.prisma
+RUN pnpm --filter @cataloggy/shared build
 RUN pnpm --filter @cataloggy/api build
 RUN addgroup -S app && adduser -S app -G app && chown -R app:app /app
 USER app

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -14,6 +14,7 @@
     "prisma:push": "prisma db push"
   },
   "dependencies": {
+    "@cataloggy/shared": "workspace:*",
     "@fastify/rate-limit": "^11.0.0",
     "@prisma/client": "^5.22.0",
     "fastify": "^5.1.0",

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,5 +1,6 @@
 import Fastify from "fastify";
 import rateLimit from "@fastify/rate-limit";
+import { parseProxyPathPrefixes, normalizeProxyPath, parseTrustProxy } from "@cataloggy/shared";
 import { prisma } from "./lib/prisma.js";
 import { applyCorsHeaders } from "./lib/cors.js";
 import { verifyToken } from "./lib/auth.js";
@@ -36,47 +37,12 @@ const TRAKT_POLL_INTERVAL_SEC = Number(process.env.TRAKT_POLL_INTERVAL_SEC ?? 30
 const AI_REFRESH_INTERVAL_SEC = Number(process.env.AI_REFRESH_INTERVAL_SEC ?? 86400);
 const NOTIFICATION_CHECK_INTERVAL_SEC = Number(process.env.NOTIFICATION_CHECK_INTERVAL_SEC ?? 3600);
 
-const parseProxyPathPrefixes = (raw: string | undefined, fallback: readonly string[]) => {
-  const parsed = (raw ?? "")
-    .split(",")
-    .map((prefix) => prefix.trim())
-    .filter(Boolean)
-    .map((prefix) => (prefix.startsWith("/") ? prefix : `/${prefix}`));
-
-  return parsed.length > 0 ? parsed : [...fallback];
-};
-
 const PROXY_PATH_PREFIXES = parseProxyPathPrefixes(process.env.PROXY_PATH_PREFIXES, ["/api"] as const);
-
-const stripProxyPrefix = (url: string, prefix: string) => {
-  if (url === prefix) return "/";
-  if (!url.startsWith(`${prefix}/`)) return null;
-  return url.slice(prefix.length) || "/";
-};
-
-const normalizeProxyPath = (rawUrl: string) => {
-  for (const prefix of PROXY_PATH_PREFIXES) {
-    const stripped = stripProxyPrefix(rawUrl, prefix);
-    if (stripped) return stripped;
-  }
-  return rawUrl;
-};
-
-// Only trust X-Forwarded-* headers from explicitly configured proxies, so
-// request.ip (used as the rate-limit key) can't be spoofed by clients when
-// there's no reverse proxy in front of this service.
-const parseTrustProxy = (raw: string | undefined): boolean | string[] | undefined => {
-  if (!raw) return undefined;
-  const trimmed = raw.trim();
-  if (trimmed === "true") return true;
-  if (trimmed === "false") return false;
-  return trimmed.split(",").map((entry) => entry.trim()).filter(Boolean);
-};
 
 const app = Fastify({
   logger: true,
   trustProxy: parseTrustProxy(process.env.TRUST_PROXY),
-  rewriteUrl: (request) => normalizeProxyPath(request.url ?? "/"),
+  rewriteUrl: (request) => normalizeProxyPath(request.url ?? "/", PROXY_PATH_PREFIXES),
 });
 
 // ─── Rate limiting ───

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "pnpm -r --parallel dev",
     "build": "pnpm -r build",
-    "typecheck": "pnpm -r typecheck",
+    "typecheck": "pnpm --filter @cataloggy/shared build && pnpm -r typecheck",
     "lint": "pnpm -r lint",
     "test": "pnpm -r --if-present test",
     "smoke": "tsx scripts/smoke.ts"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -2,5 +2,18 @@
   "name": "@cataloggy/shared",
   "version": "0.1.0",
   "private": true,
-  "type": "module"
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "lint": "eslint src"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.2"
+  }
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./proxy.js";

--- a/packages/shared/src/proxy.ts
+++ b/packages/shared/src/proxy.ts
@@ -1,0 +1,44 @@
+export const parseProxyPathPrefixes = (raw: string | undefined, fallback: readonly string[]) => {
+  const parsed = (raw ?? "")
+    .split(",")
+    .map((prefix) => prefix.trim())
+    .filter(Boolean)
+    .map((prefix) => (prefix.startsWith("/") ? prefix : `/${prefix}`))
+    .map((prefix) => (prefix.length > 1 ? prefix.replace(/\/+$/, "") : prefix));
+
+  return parsed.length > 0 ? parsed : [...fallback];
+};
+
+export const stripProxyPrefix = (url: string, prefix: string) => {
+  if (url === prefix) {
+    return "/";
+  }
+
+  if (!url.startsWith(`${prefix}/`)) {
+    return null;
+  }
+
+  return url.slice(prefix.length) || "/";
+};
+
+export const normalizeProxyPath = (rawUrl: string, prefixes: readonly string[]) => {
+  for (const prefix of prefixes) {
+    const stripped = stripProxyPrefix(rawUrl, prefix);
+    if (stripped) {
+      return stripped;
+    }
+  }
+
+  return rawUrl;
+};
+
+// Only trust X-Forwarded-* headers from explicitly configured proxies, so
+// request.ip (used as the rate-limit key) can't be spoofed by clients when
+// there's no reverse proxy in front of this service.
+export const parseTrustProxy = (raw: string | undefined): boolean | string[] | undefined => {
+  if (!raw) return undefined;
+  const trimmed = raw.trim();
+  if (trimmed === "true") return true;
+  if (trimmed === "false") return false;
+  return trimmed.split(",").map((entry) => entry.trim()).filter(Boolean);
+};

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "noEmit": false,
+    "declaration": true,
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
 
   apps/addon:
     dependencies:
+      '@cataloggy/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
       '@fastify/rate-limit':
         specifier: ^11.0.0
         version: 11.0.0
@@ -45,6 +48,9 @@ importers:
 
   apps/api:
     dependencies:
+      '@cataloggy/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
       '@fastify/rate-limit':
         specifier: ^11.0.0
         version: 11.0.0
@@ -122,6 +128,12 @@ importers:
       workbox-precaching:
         specifier: ^7.4.1
         version: 7.4.1
+
+  packages/shared:
+    devDependencies:
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
 
 packages:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 packages:
   - "apps/*"
+  - "packages/*"


### PR DESCRIPTION
## Summary
Refactored proxy-related utility functions into a new shared package to eliminate code duplication between the API and addon services. This improves maintainability and ensures consistent behavior across services.

## Key Changes
- Created `@cataloggy/shared` package with proxy utilities:
  - `parseProxyPathPrefixes()` - parses and normalizes proxy path prefix configuration
  - `stripProxyPrefix()` - removes a proxy prefix from a URL path
  - `normalizeProxyPath()` - normalizes URLs by stripping configured proxy prefixes
  - `parseTrustProxy()` - parses trust proxy configuration for rate limiting
- Updated `apps/addon` and `apps/api` to import these utilities from `@cataloggy/shared` instead of defining them locally
- Modified `normalizeProxyPath()` signature to accept `prefixes` as a parameter instead of relying on module-level state, improving testability
- Updated Docker build configurations to include the shared package in the build pipeline
- Added `.dockerignore` file to exclude unnecessary files from Docker builds
- Updated CI workflow to run tests before building
- Added security documentation to README regarding LAN-only deployment and token storage

## Implementation Details
- The shared package is configured as a TypeScript library with proper build and type declaration outputs
- Both services now pass `PROXY_PATH_PREFIXES` explicitly to `normalizeProxyPath()`, making the dependency explicit
- The shared package is added to the pnpm workspace configuration for proper monorepo integration

https://claude.ai/code/session_01XxvqnbzCd4tWLy63hvQr2V