### PR TITLE
Add comprehensive error logging and CSRF protection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,10 @@ TRAKT_REDIRECT_URI=
 # this unset disables those endpoints (they reject all requests).
 WEBHOOK_SECRET=
 
+# Contact address sent to push services (Chrome FCM, Mozilla Push) to
+# identify this server. Defaults to mailto:admin@cataloggy.local.
+VAPID_SUBJECT=
+
 # ── Other Postgres settings ────────────────────────────────────────────────
 
 POSTGRES_DB=cataloggy

--- a/apps/addon/Dockerfile
+++ b/apps/addon/Dockerfile
@@ -19,6 +19,7 @@ RUN pnpm --filter @cataloggy/shared build
 RUN cd apps/addon && pnpm exec tsc -p tsconfig.json
 RUN addgroup -S app && adduser -S app -G app && chown -R app:app /app
 USER app
+ENV NODE_ENV=production
 
 EXPOSE 7001
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s CMD wget -q --spider http://127.0.0.1:7001/health || exit 1

--- a/apps/addon/src/index.ts
+++ b/apps/addon/src/index.ts
@@ -140,7 +140,8 @@ const fetchGenres = async (): Promise<string[]> => {
     const payload = await apiGet<{ genres: string[] }>("/genres");
     cachedGenres = { data: payload.genres, expiry: now + GENRES_CACHE_TTL_MS };
     return payload.genres;
-  } catch {
+  } catch (error) {
+    app.log.warn(error, "Failed to fetch genres, using cached value");
     return cachedGenres?.data ?? [];
   }
 };
@@ -153,7 +154,8 @@ const fetchRpdbConfig = async (): Promise<RpdbConfig> => {
     const payload = await apiGet<RpdbConfig>("/rpdb/config");
     cachedRpdb = { data: payload, expiry: now + RPDB_CACHE_TTL_MS };
     return payload;
-  } catch {
+  } catch (error) {
+    app.log.warn(error, "Failed to fetch RPDB config, using cached value");
     const fallback: RpdbConfig = { enabled: false, apiKey: null };
     return cachedRpdb?.data ?? fallback;
   }
@@ -216,7 +218,8 @@ const fetchDiscoveryMetas = async (catalogId: string): Promise<StremioMetaPrevie
     }));
     trendingPopularCache.set(catalogId, { data: metas, expiry: now + TRENDING_CACHE_TTL_MS });
     return metas;
-  } catch {
+  } catch (error) {
+    app.log.warn(error, `Failed to fetch discovery catalog ${catalogId}, using cached value`);
     return cached?.data ?? [];
   }
 };
@@ -237,7 +240,8 @@ const fetchEnabledCatalogs = async (): Promise<string[] | null> => {
     const catalogs = res.config.enabledCatalogs;
     cachedEnabledCatalogs = { data: catalogs, expiry: now + ENABLED_CATALOGS_CACHE_TTL_MS };
     return catalogs;
-  } catch {
+  } catch (error) {
+    app.log.warn(error, "Failed to fetch enabled catalogs, using cached value");
     return cachedEnabledCatalogs?.data ?? null;
   }
 };
@@ -443,7 +447,8 @@ const isSpoilerProtectionEnabled = async (): Promise<boolean> => {
     const enabled = prefs.spoilerProtection === true;
     cachedSpoilerProtection = { data: enabled, expiry: now + SPOILER_CACHE_TTL_MS };
     return enabled;
-  } catch {
+  } catch (error) {
+    app.log.warn(error, "Failed to fetch spoiler protection setting, using cached value");
     return cachedSpoilerProtection?.data ?? false;
   }
 };
@@ -502,8 +507,8 @@ app.get<{ Params: { type: string; id: string } }>("/meta/:type/:id.json", async 
         }
       }
       // No progress row = not started = hide
-    } catch {
-      // Error fetching progress = hide to be safe
+    } catch (error) {
+      request.log.debug(error, "Failed to fetch series progress for spoiler check, hiding description");
     }
     if (shouldHide) {
       description = spoilerMsg;
@@ -575,6 +580,19 @@ app.get<{ Params: { type: string; id: string } }>("/subtitles/:type/:id.json", a
   return reply.send({ subtitles: [] });
 });
 
+// ─── CSRF guard for mutation endpoints ───
+// Stremio (desktop/mobile app, not a browser) doesn't send an Origin header
+// when calling subtitle/scrobble URLs. Browsers always send one for
+// cross-origin fetch/img requests, so reject those to stop arbitrary web
+// pages from triggering mark-watched/scrobble side effects via CORS *.
+const STREMIO_WEB_ORIGINS = ["https://web.strem.io", "https://app.strem.io"];
+
+const isAllowedMutationOrigin = (request: FastifyRequest): boolean => {
+  const origin = request.headers.origin;
+  if (!origin) return true;
+  return STREMIO_WEB_ORIGINS.includes(origin);
+};
+
 // ─── Mark watched endpoints (return minimal SRT after recording) ───
 
 const MINIMAL_SRT = `1
@@ -592,6 +610,11 @@ app.get<{ Params: { type: string; imdbId: string } }>("/mark-watched/:type/:imdb
   reply.header("Content-Type", "text/srt; charset=utf-8");
 
   const { type, imdbId } = request.params;
+
+  if (!isAllowedMutationOrigin(request)) {
+    request.log.warn({ origin: request.headers.origin }, "Rejected mark-watched request from disallowed origin");
+    return reply.send(MINIMAL_SRT);
+  }
 
   try {
     if (type === "movie") {
@@ -618,6 +641,11 @@ app.get<{ Params: { type: string; imdbId: string; season: string; episode: strin
     const { imdbId, season: seasonStr, episode: episodeStr } = request.params;
     const season = parseInt(seasonStr, 10);
     const episode = parseInt(episodeStr, 10);
+
+    if (!isAllowedMutationOrigin(request)) {
+      request.log.warn({ origin: request.headers.origin }, "Rejected mark-watched request from disallowed origin");
+      return reply.send(MINIMAL_SRT);
+    }
 
     try {
       await apiPost("/watch", {
@@ -646,6 +674,11 @@ app.post<{ Body: unknown }>("/scrobble/:action", async (request, reply) => {
   const action = (request.params as { action: string }).action as ScrobbleAction;
   if (!["start", "pause", "stop"].includes(action)) {
     return reply.code(400).send({ error: "action must be one of: start, pause, stop" });
+  }
+
+  if (!isAllowedMutationOrigin(request)) {
+    request.log.warn({ origin: request.headers.origin }, "Rejected scrobble request from disallowed origin");
+    return reply.code(403).send({ error: "Origin not allowed" });
   }
 
   if (!request.body || typeof request.body !== "object") {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -143,7 +143,7 @@ const start = async () => {
   }
 
   setInterval(() => {
-    void cleanupStaleSessions().catch((error) => {
+    void cleanupStaleSessions(app.log).catch((error) => {
       app.log.error(error, "Scrobble session cleanup failed");
     });
   }, SCROBBLE_CLEANUP_INTERVAL_MS);

--- a/apps/api/src/lib/ai.ts
+++ b/apps/api/src/lib/ai.ts
@@ -1,4 +1,5 @@
 import { MetadataType } from "@prisma/client";
+import type { FastifyBaseLogger } from "fastify";
 import { prisma } from "./prisma.js";
 import { trendingCacheGet, trendingCacheSet } from "./cache.js";
 import { getTmdb } from "./tmdb-client.js";
@@ -47,7 +48,7 @@ export const shouldRefreshAiRecs = async (): Promise<boolean> => {
   return hoursSinceLastGen >= 6;
 };
 
-export const buildTasteProfile = async (profileId?: string) => {
+export const buildTasteProfile = async (profileId?: string, logger?: FastifyBaseLogger) => {
   const recentEvents = await prisma.watchEvent.findMany({
     where: profileId ? { profileId } : undefined,
     orderBy: { watchedAt: "desc" },
@@ -86,7 +87,9 @@ export const buildTasteProfile = async (profileId?: string) => {
       if (parsed.imdbId && typeof parsed.rating === "number") {
         ratings.push({ imdbId: parsed.imdbId, rating: parsed.rating });
       }
-    } catch { /* skip */ }
+    } catch (error) {
+      logger?.debug({ error, key: row.key }, "Skipped malformed rating row");
+    }
   }
 
   const genreFreq = new Map<string, number>();
@@ -178,7 +181,8 @@ const parseRecsFromContent = (content: string): AiRecItem[] => {
 export const getAiRecommendations = async (
   type: "movie" | "series",
   limit = 10,
-  profileId?: string
+  profileId?: string,
+  logger?: FastifyBaseLogger
 ): Promise<{ metas: StremioMetaPreview[]; reasons: Record<string, string> } | null> => {
   const cacheKey = `ai-recs:${type}:${limit}${profileId ? `:${profileId}` : ""}`;
   const cached = trendingCacheGet(cacheKey);
@@ -188,7 +192,7 @@ export const getAiRecommendations = async (
   if (!config) return null;
 
   try {
-    const profile = await buildTasteProfile(profileId);
+    const profile = await buildTasteProfile(profileId, logger);
     const avgRatingStr = profile.avgRating !== null ? `${profile.avgRating}/10` : "unrated";
     const typeLabel = type === "movie" ? "movies" : "TV series";
 
@@ -240,7 +244,9 @@ Return ONLY a JSON array, no other text, no markdown:
           rating: first.rating ?? undefined,
         });
         reasons[first.imdbId] = rec.reason;
-      } catch { /* skip failed lookups */ }
+      } catch (error) {
+        logger?.debug({ error, title: rec.title }, "Skipped failed AI recommendation lookup");
+      }
     }
 
     trendingCacheSet(cacheKey, { data: metas, reasons }, AI_RECS_TTL_MS);
@@ -254,7 +260,7 @@ Return ONLY a JSON array, no other text, no markdown:
 
     return { metas, reasons };
   } catch (err) {
-    console.error("AI recommendations generation failed", err);
+    logger?.error(err, "AI recommendations generation failed");
     return null;
   }
 };

--- a/apps/api/src/lib/push.ts
+++ b/apps/api/src/lib/push.ts
@@ -3,7 +3,7 @@ import { Prisma } from "@prisma/client";
 import { prisma } from "./prisma.js";
 
 const VAPID_KEYS_KV = "push:vapidKeys";
-const VAPID_SUBJECT = "mailto:admin@cataloggy.local";
+const VAPID_SUBJECT = process.env.VAPID_SUBJECT ?? "mailto:admin@cataloggy.local";
 
 let configured: { publicKey: string } | null = null;
 

--- a/apps/api/src/lib/watch-event.ts
+++ b/apps/api/src/lib/watch-event.ts
@@ -75,11 +75,13 @@ export const recordWatchEvent = async (params: RecordWatchParams) => {
         if (await shouldRefreshAiRecs()) {
           trendingCacheDeletePrefix("ai-recs:");
           await Promise.allSettled([
-            getAiRecommendations("movie", 15, profileId),
-            getAiRecommendations("series", 15, profileId),
+            getAiRecommendations("movie", 15, profileId, req.log),
+            getAiRecommendations("series", 15, profileId, req.log),
           ]);
         }
-      } catch { /* never let this affect the watch event response */ }
+      } catch (error) {
+        req.log.warn(error, "Background AI recs refresh failed");
+      }
     })();
 
     return { status: "recorded" as const, watchEvent, wasCreated };
@@ -113,11 +115,13 @@ export const recordWatchEvent = async (params: RecordWatchParams) => {
       if (await shouldRefreshAiRecs()) {
         trendingCacheDeletePrefix("ai-recs:");
         await Promise.allSettled([
-          getAiRecommendations("movie", 15, profileId),
-          getAiRecommendations("series", 15, profileId),
+          getAiRecommendations("movie", 15, profileId, req.log),
+          getAiRecommendations("series", 15, profileId, req.log),
         ]);
       }
-    } catch { /* never let this affect the watch event response */ }
+    } catch (error) {
+      req.log.warn(error, "Background AI recs refresh failed");
+    }
   })();
 
   return { status: "recorded" as const, watchEvent, wasCreated };

--- a/apps/api/src/routes/ai.ts
+++ b/apps/api/src/routes/ai.ts
@@ -66,7 +66,7 @@ const aiRoutes: FastifyPluginAsync = async (app) => {
       const profileId = request.profileId!;
 
       if (await isAiConfigured()) {
-        const aiResult = await getAiRecommendations(rawType as "movie" | "series", limit, profileId);
+        const aiResult = await getAiRecommendations(rawType as "movie" | "series", limit, profileId, request.log);
         if (aiResult) return { metas: aiResult.metas };
       }
 
@@ -249,7 +249,7 @@ const aiRoutes: FastifyPluginAsync = async (app) => {
         }
       }
 
-      const result = await getAiRecommendations(type, limit, profileId);
+      const result = await getAiRecommendations(type, limit, profileId, request.log);
       if (!result) return { metas: [], reasons: {} };
       return { metas: result.metas, reasons: result.reasons };
     }

--- a/apps/api/src/routes/scrobble.ts
+++ b/apps/api/src/routes/scrobble.ts
@@ -1,5 +1,5 @@
 import { ScrobbleStatus, WatchEventType } from "@prisma/client";
-import type { FastifyPluginAsync } from "fastify";
+import type { FastifyPluginAsync, FastifyBaseLogger } from "fastify";
 import { prisma } from "../lib/prisma.js";
 import { recordWatchEvent } from "../lib/watch-event.js";
 import { pushTraktScrobble } from "../lib/trakt-client.js";
@@ -10,7 +10,7 @@ export const SCROBBLE_COMPLETE_THRESHOLD = 80;
 export const SCROBBLE_STALE_TTL_MS = 24 * 60 * 60 * 1000;
 export const SCROBBLE_CLEANUP_INTERVAL_MS = 60 * 60 * 1000;
 
-export const cleanupStaleSessions = async () => {
+export const cleanupStaleSessions = async (logger?: FastifyBaseLogger) => {
   const cutoff = new Date(Date.now() - SCROBBLE_STALE_TTL_MS);
   const { count } = await prisma.scrobbleSession.updateMany({
     where: {
@@ -20,7 +20,7 @@ export const cleanupStaleSessions = async () => {
     data: { status: ScrobbleStatus.stopped },
   });
   if (count > 0) {
-    console.info(`Cleaned up ${count} stale scrobble sessions`);
+    logger?.info(`Cleaned up ${count} stale scrobble sessions`);
   }
 };
 
@@ -37,7 +37,8 @@ const scrobbleRoutes: FastifyPluginAsync = async (app) => {
     if (!row) return { checkin: null };
     try {
       return { checkin: JSON.parse(row.value) as CheckInData };
-    } catch {
+    } catch (error) {
+      request.log.debug({ error }, "Failed to parse stored check-in data");
       return { checkin: null };
     }
   });
@@ -84,7 +85,9 @@ const scrobbleRoutes: FastifyPluginAsync = async (app) => {
           source: "checkin",
           request,
         });
-      } catch { /* best-effort */ }
+      } catch (error) {
+        request.log.warn(error, "Failed to log watch event from check-in");
+      }
     }
     await prisma.kV.deleteMany({ where: { key } });
     return reply.code(204).send();


### PR DESCRIPTION
## Summary
This PR enhances error observability across the codebase and adds CSRF protection to mutation endpoints in the addon service. All bare `catch` blocks are now properly logged, and sensitive endpoints are protected against cross-origin attacks.

## Key Changes

### Error Logging Improvements
- **Addon service** (`apps/addon/src/index.ts`):
  - Added error logging to all cache fetch operations (`fetchGenres`, `fetchRpdbConfig`, `fetchDiscoveryMetas`, `fetchEnabledCatalogs`, `isSpoilerProtectionEnabled`)
  - Added debug logging for spoiler protection check failures
  - All catch blocks now capture and log the error object with contextual messages

- **API service** (`apps/api/src/lib/ai.ts`):
  - Added optional `logger` parameter to `buildTasteProfile()` and `getAiRecommendations()` functions
  - Replaced `console.error()` with proper Fastify logger in AI recommendations generation
  - Added debug logging for malformed rating rows and failed recommendation lookups

- **Watch event tracking** (`apps/api/src/lib/watch-event.ts`):
  - Added logger parameter to `getAiRecommendations()` calls
  - Added warning logs for background AI refresh failures

- **Scrobble routes** (`apps/api/src/routes/scrobble.ts`):
  - Added logger parameter to `cleanupStaleSessions()` function
  - Replaced `console.info()` with proper logger
  - Added debug logging for check-in data parsing failures
  - Added warning logs for watch event recording failures

### CSRF Protection
- **Addon service** (`apps/addon/src/index.ts`):
  - Implemented `isAllowedMutationOrigin()` guard function that validates Origin headers
  - Allows requests without Origin header (native Stremio apps) or from whitelisted Stremio web origins
  - Applied protection to `/mark-watched/:type/:imdbId`, `/mark-watched/:type/:imdbId/:season/:episode`, and `/scrobble/:action` endpoints
  - Rejects disallowed origins with appropriate responses (minimal SRT for mark-watched, 403 for scrobble)

### Configuration
- **Environment variables** (`.env.example`):
  - Added `VAPID_SUBJECT` configuration option for push notification service identification
  - Defaults to `mailto:admin@cataloggy.local` if not set

- **Docker** (`apps/addon/Dockerfile`):
  - Added `NODE_ENV=production` environment variable for production builds

## Implementation Details
- All error logging uses structured logging with the Fastify logger when available
- CSRF protection uses Origin header validation rather than token-based CSRF (appropriate for API endpoints)
- Whitelisted origins are limited to official Stremio web applications
- Background operations (AI recommendations refresh) are non-blocking and failures don't affect primary responses

https://claude.ai/code/session_01TQ4YTZSHffzN5qcmHZ8Eaa