### PR TITLE
Support runtime API base configuration via environment variable

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -20,10 +20,13 @@ WORKDIR /app
 RUN apk add --no-cache wget && npm install -g serve@14
 
 COPY --from=build /app/apps/web/dist ./dist
+COPY apps/web/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 RUN addgroup -S app && adduser -S app -G app && chown -R app:app /app
 USER app
 
 EXPOSE 7002
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s CMD wget -q --spider http://127.0.0.1:7002/ || exit 1
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["serve", "-s", "dist", "-l", "7002"]

--- a/apps/web/docker-entrypoint.sh
+++ b/apps/web/docker-entrypoint.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 set -e
 
-cat > /app/dist/config.js <<EOF
-window.__CATALOGGY_API_BASE__ = "${VITE_API_BASE:-}";
-EOF
+API_BASE_JSON=$(VITE_API_BASE="${VITE_API_BASE:-}" node -e 'console.log(JSON.stringify(process.env.VITE_API_BASE))')
+printf 'window.__CATALOGGY_API_BASE__ = %s;\n' "$API_BASE_JSON" > /app/dist/config.js
 
 exec "$@"

--- a/apps/web/docker-entrypoint.sh
+++ b/apps/web/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+cat > /app/dist/config.js <<EOF
+window.__CATALOGGY_API_BASE__ = "${VITE_API_BASE:-}";
+EOF
+
+exec "$@"

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -15,6 +15,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
     <title>Cataloggy</title>
+    <script src="/config.js"></script>
     <script>
       (function () {
         try {

--- a/apps/web/public/config.js
+++ b/apps/web/public/config.js
@@ -1,0 +1,4 @@
+// Overwritten at container startup from the VITE_API_BASE environment
+// variable (see docker-entrypoint.sh). Left blank for local dev so the
+// build-time import.meta.env.VITE_API_BASE default applies instead.
+window.__CATALOGGY_API_BASE__ = "";

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -5,7 +5,14 @@ export class ApiError extends Error {
   }
 }
 
-const API_BASE_DEFAULT = import.meta.env.VITE_API_BASE ?? "http://localhost:7000";
+declare global {
+  interface Window {
+    __CATALOGGY_API_BASE__?: string;
+  }
+}
+
+const API_BASE_DEFAULT =
+  window.__CATALOGGY_API_BASE__ || import.meta.env.VITE_API_BASE || "http://localhost:7000";
 const API_BASE_OVERRIDE_KEY = "cataloggy_api_base_override";
 const TOKEN_KEY = "cataloggy_token";
 const PROFILE_ID_KEY = "cataloggy_profile_id";


### PR DESCRIPTION
## Summary
This change enables the API base URL to be configured at container runtime rather than only at build time, allowing the same Docker image to be deployed to different environments without rebuilding.

## Key Changes
- **API configuration**: Modified `api.ts` to check for a runtime-injected `window.__CATALOGGY_API_BASE__` variable before falling back to build-time `VITE_API_BASE` environment variable
- **Docker entrypoint**: Added `docker-entrypoint.sh` script that generates a `config.js` file at container startup, injecting the `VITE_API_BASE` environment variable into the window object
- **Static config file**: Added `public/config.js` as a placeholder that gets overwritten at runtime
- **HTML integration**: Updated `index.html` to load the `config.js` script before application initialization
- **Dockerfile updates**: Integrated the entrypoint script into the Docker build process with proper permissions and execution

## Implementation Details
The solution uses a three-tier fallback mechanism:
1. Runtime environment variable via `window.__CATALOGGY_API_BASE__` (set by docker-entrypoint.sh)
2. Build-time environment variable via `import.meta.env.VITE_API_BASE`
3. Hardcoded default of `http://localhost:7000`

This approach maintains backward compatibility while enabling flexible deployment configurations.

https://claude.ai/code/session_01RM7zghqBktz3Szodp1bHB3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced containerized deployment configuration to support runtime API endpoint customization through environment variables, enabling flexible deployment across different environments without requiring rebuild.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->