### PR TITLE
Remove unnecessary node_modules copy from shared package in Docker build

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -35,7 +35,6 @@ COPY --from=build /app/apps/api/dist ./apps/api/dist
 COPY --from=build /app/apps/api/prisma ./apps/api/prisma
 COPY --from=build /app/packages/shared/package.json ./packages/shared/package.json
 COPY --from=build /app/packages/shared/dist ./packages/shared/dist
-COPY --from=build /app/packages/shared/node_modules ./packages/shared/node_modules
 
 RUN addgroup -S app && adduser -S app -G app && chown -R app:app /app
 USER app


### PR DESCRIPTION
## Summary
Removed the unnecessary copying of `node_modules` from the shared package during the Docker multi-stage build process.

## Key Changes
- Removed `COPY --from=build /app/packages/shared/node_modules ./packages/shared/node_modules` from the Dockerfile

## Details
The `node_modules` directory from the shared package is not needed in the final runtime image. The built distribution files (`dist`) are already being copied, which is sufficient for the application to function. This change:
- Reduces the final Docker image size by excluding unnecessary dependencies
- Simplifies the build configuration by removing redundant file copying
- Maintains functionality since only the compiled output is required at runtime

https://claude.ai/code/session_01NYvU5RNUj59iyhqjS5wXiq