### PR TITLE
Document webhook security requirements and secret generation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,13 @@ TRAKT_REDIRECT_URI=
 
 # Shared secret required by the Plex/Jellyfin webhook endpoints. Leaving
 # this unset disables those endpoints (they reject all requests).
+# Generate one with: openssl rand -hex 32
+#
+# SECURITY: Plex/Jellyfin do not sign their webhook requests, so this
+# shared secret is the only verification available (no HMAC signature to
+# check). Do NOT expose /webhooks/plex or /webhooks/jellyfin to the public
+# internet — keep them reachable only from your LAN or reverse-proxy-
+# internal network, alongside Plex/Jellyfin themselves.
 WEBHOOK_SECRET=
 
 # Contact address sent to push services (Chrome FCM, Mozilla Push) to

--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Cataloggy is designed for self-hosting on a trusted local network (LAN), not for
 
 - The web client stores its API bearer token in `localStorage`. Any JavaScript running on the page (e.g. via an XSS vulnerability in a dependency) could read this token. Since the token only grants access to your own local API, this is an acceptable tradeoff for a LAN-only app, but it is not suitable for an internet-facing deployment without further hardening (e.g. a Content-Security-Policy header, or migrating to httpOnly session cookies backed by a session store).
 - If you do expose Cataloggy beyond your LAN, put it behind a reverse proxy with TLS and consider implementing a proper session-based auth flow.
+- The Plex/Jellyfin webhook endpoints (`/webhooks/plex`, `/webhooks/jellyfin`) authenticate with a single shared secret (`WEBHOOK_SECRET`) sent as a query param or header — neither Plex nor Jellyfin support signing outgoing webhooks, so this is the strongest verification available. Treat `WEBHOOK_SECRET` like a password and **do not expose these endpoints to the public internet**; keep them reachable only from your LAN/reverse-proxy-internal network, where Plex/Jellyfin themselves run.
 
 ## Useful Commands
 


### PR DESCRIPTION
## Summary
This PR adds security documentation for the Plex/Jellyfin webhook endpoints, clarifying the authentication mechanism and providing guidance on safe deployment.

## Changes
- **`.env.example`**: Added comprehensive security notes for `WEBHOOK_SECRET`:
  - Instructions for generating a secure secret using `openssl rand -hex 32`
  - Clear warning that Plex/Jellyfin webhooks are unsigned, making the shared secret the only verification mechanism
  - Explicit guidance to keep webhook endpoints isolated to LAN/internal networks only
  
- **`README.md`**: Expanded the Security section with webhook-specific guidance:
  - Documented the webhook authentication model (shared secret via query param or header)
  - Emphasized that webhook endpoints must not be exposed to the public internet
  - Clarified that these endpoints should only be reachable from the same network where Plex/Jellyfin run

## Implementation Details
The changes are purely documentation-focused, highlighting an existing security constraint: since Plex and Jellyfin do not support HMAC-signed webhook requests, the shared secret is the sole defense against unauthorized webhook access. This makes network isolation critical for security.

https://claude.ai/code/session_017xppSPwsvacJUuHWv7j8cL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced security guidance for webhook endpoint configuration, including authentication via shared secrets and best practices for restricting webhook routes to internal/LAN networks only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->