### PR TITLE
Improve accessibility: add focus trap and keyboard navigation

### DIFF
--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { BarChart3, Clapperboard, Film, List, Search, Settings, Tv } from "lucide-react";
 import { api, SearchResult } from "../api";
 import { Poster } from "./Poster";
+import { useFocusTrap } from "../hooks/useFocusTrap";
 
 type Action = {
   id: string;
@@ -40,6 +41,7 @@ export function CommandPalette({ open, onClose }: { open: boolean; onClose: () =
   const [results, setResults] = useState<SearchResult[]>([]);
   const [searching, setSearching] = useState(false);
   const [activeIndex, setActiveIndex] = useState(0);
+  const dialogRef = useFocusTrap<HTMLDivElement>(open);
 
   useEffect(() => {
     if (open) {
@@ -133,6 +135,8 @@ export function CommandPalette({ open, onClose }: { open: boolean; onClose: () =
     >
       <div className="absolute inset-0 bg-black/40 backdrop-blur-sm" />
       <div
+        ref={dialogRef}
+        tabIndex={-1}
         className="relative w-full max-w-lg overflow-hidden rounded-2xl shadow-feature"
         style={{ background: "var(--bg-0)", border: "1px solid var(--border-strong)" }}
         onClick={(e) => e.stopPropagation()}

--- a/apps/web/src/components/MediaDetailPanel.tsx
+++ b/apps/web/src/components/MediaDetailPanel.tsx
@@ -13,6 +13,7 @@ import { CheckInBlock } from "./media-detail/CheckInBlock";
 import { WatchHistorySection } from "./media-detail/WatchHistorySection";
 import { DropShowButton } from "./media-detail/DropShowButton";
 import { formatRuntime, statusColor, WatchLogTarget } from "./media-detail/detailPanelUtils";
+import { useFocusTrap } from "../hooks/useFocusTrap";
 
 export { StarRating };
 
@@ -36,6 +37,7 @@ export function DetailPanel({
   onHistoryChange: (events: WatchEvent[]) => void;
 }) {
   const listNames = item.lists.map((id) => listMap.get(id)?.name).filter(Boolean) as string[];
+  const dialogRef = useFocusTrap<HTMLDivElement>();
 
   // Lock background scroll while the panel is open
   useEffect(() => {
@@ -43,6 +45,12 @@ export function DetailPanel({
     document.body.style.overflow = "hidden";
     return () => { document.body.style.overflow = previousOverflow; };
   }, []);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [onClose]);
 
   // Cast
   const [cast, setCast] = useState<CastMember[]>([]);
@@ -198,9 +206,11 @@ export function DetailPanel({
         onClick={onClose}
       >
         <div
+          ref={dialogRef}
           role="dialog"
           aria-modal="true"
           aria-label={item.name}
+          tabIndex={-1}
           onClick={(e) => e.stopPropagation()}
           className="relative flex h-full w-full max-h-screen flex-col overflow-hidden bg-cream-50 shadow-feature sm:h-auto sm:max-h-[85vh] sm:max-w-4xl sm:flex-row sm:rounded-3xl sm:border sm:border-ink-100 lg:max-w-5xl"
         >

--- a/apps/web/src/components/MediaList.tsx
+++ b/apps/web/src/components/MediaList.tsx
@@ -75,7 +75,19 @@ export function MediaList({ title, items, count, onSeeAll, onAddItem }: Props) {
       ) : (
         <div
           ref={ref}
-          className="flex overflow-x-auto gap-4 pb-2 scroll-smooth scrollbar-hide"
+          tabIndex={0}
+          role="group"
+          aria-label={`${title} carousel`}
+          onKeyDown={(e) => {
+            if (e.key === "ArrowRight") {
+              e.preventDefault();
+              scroll("right");
+            } else if (e.key === "ArrowLeft") {
+              e.preventDefault();
+              scroll("left");
+            }
+          }}
+          className="flex overflow-x-auto gap-4 pb-2 scroll-smooth scrollbar-hide focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 rounded-xl"
         >
           {items.map((item) => (
             <div

--- a/apps/web/src/components/carousel-utils.ts
+++ b/apps/web/src/components/carousel-utils.ts
@@ -68,7 +68,8 @@ export function useHorizontalScroll() {
     const el = ref.current;
     if (!el) return;
     const amount = el.clientWidth * 0.75;
-    el.scrollBy({ left: direction === "left" ? -amount : amount, behavior: "smooth" });
+    const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    el.scrollBy({ left: direction === "left" ? -amount : amount, behavior: reduceMotion ? "auto" : "smooth" });
   }, []);
 
   return { ref: setRef, canScrollLeft, canScrollRight, scroll, checkScroll };

--- a/apps/web/src/components/media-detail/CheckInModal.tsx
+++ b/apps/web/src/components/media-detail/CheckInModal.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { Radio, X } from "lucide-react";
+import { useFocusTrap } from "../../hooks/useFocusTrap";
 
 export function CheckInModal({
   seriesName,
@@ -18,6 +19,7 @@ export function CheckInModal({
   const [episode, setEpisode] = useState(String(defaultEpisode));
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const dialogRef = useFocusTrap<HTMLDivElement>();
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
@@ -43,9 +45,11 @@ export function CheckInModal({
   return (
     <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/70 backdrop-blur-sm p-4" onClick={onClose}>
       <div
+        ref={dialogRef}
         role="dialog"
         aria-modal="true"
         aria-labelledby="checkin-modal-title"
+        tabIndex={-1}
         className="w-full max-w-sm rounded-2xl border border-ink-100 bg-cream-50 shadow-md"
         onClick={(e) => e.stopPropagation()}
       >

--- a/apps/web/src/components/media-detail/WatchDateModal.tsx
+++ b/apps/web/src/components/media-detail/WatchDateModal.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { X } from "lucide-react";
 import { WatchLogTarget } from "./detailPanelUtils";
+import { useFocusTrap } from "../../hooks/useFocusTrap";
 
 export function WatchDateModal({
   target,
@@ -15,6 +16,7 @@ export function WatchDateModal({
   const [customDate, setCustomDate] = useState(() => new Date().toISOString().slice(0, 10));
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const dialogRef = useFocusTrap<HTMLDivElement>();
 
   // For episode mode: let user pick season+episode
   const [season, setSeason] = useState(target.kind === "episode" ? target.season : 1);
@@ -41,9 +43,11 @@ export function WatchDateModal({
       onClick={onClose}
     >
       <div
+        ref={dialogRef}
         role="dialog"
         aria-modal="true"
         aria-labelledby="watch-date-modal-title"
+        tabIndex={-1}
         className="w-full max-w-sm rounded-2xl border border-ink-100 bg-cream-50 p-6 shadow-md"
         onClick={(e) => e.stopPropagation()}
       >

--- a/apps/web/src/hooks/useFocusTrap.ts
+++ b/apps/web/src/hooks/useFocusTrap.ts
@@ -1,0 +1,54 @@
+import { useEffect, useRef } from "react";
+
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+/**
+ * Traps Tab/Shift+Tab focus within the returned ref's subtree and restores
+ * focus to the previously focused element on unmount. Intended for modal dialogs.
+ */
+export function useFocusTrap<T extends HTMLElement>(active = true) {
+  const containerRef = useRef<T>(null);
+
+  useEffect(() => {
+    if (!active) return;
+    const container = containerRef.current;
+    if (!container) return;
+
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+
+    const getFocusable = () =>
+      Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
+        (el) => el.offsetParent !== null || el === document.activeElement
+      );
+
+    if (!container.contains(document.activeElement)) {
+      const focusable = getFocusable();
+      (focusable[0] ?? container).focus();
+    }
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== "Tab") return;
+      const focusable = getFocusable();
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+
+    container.addEventListener("keydown", handleKeyDown);
+    return () => {
+      container.removeEventListener("keydown", handleKeyDown);
+      previouslyFocused?.focus();
+    };
+  }, [active]);
+
+  return containerRef;
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -171,9 +171,22 @@ body {
 }
 
 @media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
+
   .star-pop,
   .star-shake-target:hover {
     animation: none;
+  }
+
+  .card-lift:hover {
+    transform: none;
   }
 }
 

--- a/apps/web/src/pages/ListsPage.tsx
+++ b/apps/web/src/pages/ListsPage.tsx
@@ -1,6 +1,7 @@
 import { FormEvent, useCallback, useEffect, useRef, useState } from "react";
 import { AlertTriangle, Film, FolderOpen, Plus, Search, Trash2, Tv, X } from "lucide-react";
 import { api, CatalogList, ListItemWithMeta, MediaType, SearchResult } from "../api";
+import { useFocusTrap } from "../hooks/useFocusTrap";
 
 function AddItemModal({
   listId,
@@ -21,15 +22,10 @@ function AddItemModal({
   const [error, setError] = useState<string | null>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout>>();
   const inputRef = useRef<HTMLInputElement>(null);
-
-  const previousFocusRef = useRef<HTMLElement | null>(null);
+  const dialogRef = useFocusTrap<HTMLDivElement>();
 
   useEffect(() => {
-    previousFocusRef.current = document.activeElement as HTMLElement | null;
     inputRef.current?.focus();
-    return () => {
-      previousFocusRef.current?.focus();
-    };
   }, []);
 
   useEffect(() => {
@@ -85,9 +81,11 @@ function AddItemModal({
   return (
     <div className="fixed inset-0 z-50 flex items-start justify-center bg-black/70 backdrop-blur-sm pt-[10vh]" onClick={onClose}>
       <div
+        ref={dialogRef}
         role="dialog"
         aria-modal="true"
         aria-labelledby="add-item-modal-title"
+        tabIndex={-1}
         className="w-full max-w-lg rounded-2xl border border-ink-100 bg-white shadow-sm"
         onClick={(e) => e.stopPropagation()}
       >
@@ -262,13 +260,13 @@ export function ListsPage() {
   };
 
   return (
-    <div className="flex flex-col gap-6 lg:flex-row lg:gap-8">
+    <div className="flex flex-col gap-6 md:flex-row md:gap-8">
       {/* Sidebar */}
-      <aside className="w-full shrink-0 lg:w-64">
+      <aside className="w-full shrink-0 md:w-56 lg:w-64">
         {/* Mobile: horizontal scrollable tabs */}
-        <div className="flex gap-2 overflow-x-auto pb-2 scrollbar-hide lg:flex-col lg:overflow-x-visible lg:pb-0">
+        <div className="flex gap-2 overflow-x-auto pb-2 scrollbar-hide md:flex-col md:overflow-x-visible md:pb-0">
           {lists.map((list) => (
-            <div key={list.id} className="relative flex-none lg:w-full">
+            <div key={list.id} className="relative flex-none md:w-full">
               {confirmDeleteId === list.id && list.kind === "custom" ? (
                 <div className="rounded-xl border border-rose-500/40 bg-rose-500/10 px-4 py-3">
                   <div className="flex items-center gap-2 mb-2">
@@ -295,7 +293,7 @@ export function ListsPage() {
                   </div>
                 </div>
               ) : (
-                <div className={`group flex items-center rounded-xl border transition-all lg:w-full ${
+                <div className={`group flex items-center rounded-xl border transition-all md:w-full ${
                   selectedListId === list.id
                     ? "border-claw-500/40 bg-claw-100/60"
                     : "border-ink-100 bg-white hover:border-ink-200 hover:bg-cream-50"

--- a/apps/web/src/pages/SearchPage.tsx
+++ b/apps/web/src/pages/SearchPage.tsx
@@ -377,7 +377,7 @@ export function SearchPage() {
 
         {/* Advanced filters panel */}
         {filtersOpen && (
-          <div className="mt-3 grid grid-cols-2 gap-3 rounded-xl border border-ink-100 bg-cream-50 p-3 sm:grid-cols-3 lg:grid-cols-6">
+          <div className="mt-3 grid grid-cols-2 gap-3 rounded-xl border border-ink-100 bg-cream-50 p-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6">
             {/* Genre */}
             <FilterSelect
               label="Genre"
@@ -664,6 +664,8 @@ function ResultCard({
           }}
           className="absolute bottom-3 right-3 z-20 flex h-9 w-9 items-center justify-center rounded-full bg-claw-500 text-white opacity-100 sm:opacity-0 sm:group-hover:opacity-100 focus:opacity-100 focus-visible:opacity-100 shadow-lg transition-all duration-300 hover:bg-claw-600 hover:scale-110 focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-300 focus-visible:ring-offset-2"
           aria-label={`Add ${result.name} to a list`}
+          aria-haspopup="menu"
+          aria-expanded={isOpen}
         >
           <Plus className="h-4 w-4" strokeWidth={3} />
         </button>
@@ -679,7 +681,7 @@ function ResultCard({
       {/* Quick-add dropdown */}
       {isOpen && (
         <div ref={dropdownRef} className="relative z-30 mt-1">
-          <div className="absolute left-0 right-0 overflow-hidden rounded-xl border border-ink-100 bg-white shadow-lg">
+          <div role="menu" aria-label={`Add ${result.name} to a list`} className="absolute left-0 right-0 overflow-hidden rounded-xl border border-ink-100 bg-white shadow-lg">
             <p className="border-b border-ink-100 px-3 py-2.5 text-2xs font-semibold uppercase tracking-wider text-ink-500">
               Add to list
             </p>
@@ -691,6 +693,7 @@ function ResultCard({
                 <button
                   key={list.id}
                   type="button"
+                  role="menuitem"
                   disabled={already || pending}
                   onClick={(e) => {
                     e.stopPropagation();


### PR DESCRIPTION
## Summary
This PR enhances the application's accessibility by implementing focus trapping in modal dialogs, adding keyboard navigation support, and improving motion preferences handling.

## Key Changes

- **New `useFocusTrap` hook**: Created a reusable hook that traps Tab/Shift+Tab focus within modal dialogs and restores focus to the previously focused element on unmount. Applied to:
  - `AddItemModal` in ListsPage
  - `DetailPanel` in MediaDetailPanel
  - `CommandPalette`
  - `CheckInModal`
  - `WatchDateModal`

- **Keyboard navigation improvements**:
  - Added Escape key handler to close detail panels and modals
  - Implemented Arrow Left/Right keyboard navigation for media carousels in `MediaList`
  - Added proper ARIA attributes (`aria-haspopup`, `aria-expanded`, `role="menu"`, `role="menuitem"`) to dropdown menus in SearchPage

- **Motion preferences**: Updated `prefers-reduced-motion` media query handling to disable smooth scrolling and animations when users have reduced motion enabled

- **Responsive layout adjustments**: Changed breakpoints from `lg:` to `md:` for sidebar layout in ListsPage to improve mobile/tablet experience, and adjusted filter grid columns for medium screens

- **Dialog accessibility**: Added `tabIndex={-1}` and `role="dialog"` attributes to modal containers for proper semantic structure

## Implementation Details

The `useFocusTrap` hook:
- Queries focusable elements using a comprehensive selector that excludes disabled and hidden elements
- Automatically focuses the first focusable element when the modal opens
- Wraps focus at boundaries (Shift+Tab on first element goes to last, Tab on last goes to first)
- Restores previous focus on unmount for better UX

All modal dialogs now use this hook with proper ARIA attributes for screen reader support.

https://claude.ai/code/session_01WtB4rPPCNbNGTK8JD3Dn7y