### PR TITLE
Exclude config.js from service worker cache

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,7 +15,9 @@
     "lucide-react": "^0.577.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.28.1"
+    "react-router-dom": "^6.28.1",
+    "workbox-routing": "^7.4.1",
+    "workbox-strategies": "^7.4.1"
   },
   "devDependencies": {
     "@types/react": "^18.3.12",

--- a/apps/web/src/sw.js
+++ b/apps/web/src/sw.js
@@ -1,6 +1,12 @@
 import { precacheAndRoute } from "workbox-precaching";
+import { registerRoute } from "workbox-routing";
+import { NetworkOnly } from "workbox-strategies";
 
 precacheAndRoute(self.__WB_MANIFEST);
+
+// Injected at container startup with the live VITE_API_BASE value — must
+// never be served from cache, or env var changes won't reach the browser.
+registerRoute(({ url }) => url.pathname === "/config.js", new NetworkOnly());
 
 self.addEventListener("push", (event) => {
   let payload = { title: "Cataloggy", body: "", url: "/" };

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -23,7 +23,8 @@ export default defineConfig({
       srcDir: "src",
       filename: "sw.js",
       injectManifest: {
-        globPatterns: ["**/*.{js,css,html,ico,png,svg,woff2}"]
+        globPatterns: ["**/*.{js,css,html,ico,png,svg,woff2}"],
+        globIgnores: ["config.js"]
       },
       includeAssets: ["favicon.ico", "icons/icon-192.png", "icons/icon-512.png"],
       manifest: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,6 +97,12 @@ importers:
       react-router-dom:
         specifier: ^6.28.1
         version: 6.30.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      workbox-routing:
+        specifier: ^7.4.1
+        version: 7.4.1
+      workbox-strategies:
+        specifier: ^7.4.1
+        version: 7.4.1
     devDependencies:
       '@types/react':
         specifier: ^18.3.12


### PR DESCRIPTION
## Summary
Ensures that `config.js` is always fetched from the network in the service worker, preventing stale configuration from being served to the browser when environment variables change.

## Changes
- **Service Worker (`sw.js`)**: Added a route handler using Workbox's `NetworkOnly` strategy for `/config.js` to guarantee fresh configuration is always retrieved from the server
- **Vite Config (`vite.config.ts`)**: Added `config.js` to `globIgnores` in the precache manifest to prevent it from being included in the service worker's static asset cache
- **Dependencies (`package.json`)**: Added `workbox-routing` and `workbox-strategies` packages to support dynamic route handling in the service worker

## Implementation Details
The `config.js` file is injected at container startup with live `VITE_API_BASE` values. By using the `NetworkOnly` strategy, any requests to this file will always bypass the cache and fetch from the network, ensuring environment variable changes are immediately reflected in the browser without requiring a service worker update.

https://claude.ai/code/session_014rvEVWnQXZdzWAjo92UbyM