### PR TITLE
Add Glass, Midnight Cinema, and Letterboxd themes

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -19,12 +19,14 @@
     <script>
       (function () {
         try {
+          // Keep in sync with THEMES in apps/web/src/hooks/useTheme.ts
+          var knownThemes = ["light", "dark", "glass", "midnight", "letterboxd"];
           var stored = localStorage.getItem("cataloggy:theme");
-          var theme = stored === "light" || stored === "dark"
+          var theme = knownThemes.indexOf(stored) !== -1
             ? stored
             : (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
           document.documentElement.setAttribute("data-theme", theme);
-          document.documentElement.style.colorScheme = theme;
+          document.documentElement.style.colorScheme = theme === "light" ? "light" : "dark";
         } catch (e) {}
       })();
     </script>

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -22,9 +22,7 @@
           // Keep in sync with THEMES in apps/web/src/hooks/useTheme.ts
           var knownThemes = ["light", "dark", "glass", "midnight", "letterboxd"];
           var stored = localStorage.getItem("cataloggy:theme");
-          var theme = knownThemes.indexOf(stored) !== -1
-            ? stored
-            : (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
+          var theme = knownThemes.indexOf(stored) !== -1 ? stored : "light";
           document.documentElement.setAttribute("data-theme", theme);
           document.documentElement.style.colorScheme = theme === "light" ? "light" : "dark";
         } catch (e) {}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -29,7 +29,7 @@ export function App() {
   const location = useLocation();
   const [needsSetup, setNeedsSetup] = useState(() => !runtimeConfig.getToken());
   const [needsProfile, setNeedsProfile] = useState(() => !runtimeConfig.getProfileId());
-  const { theme, toggleTheme } = useTheme();
+  const { theme, setTheme } = useTheme();
   const { open: paletteOpen, setOpen: setPaletteOpen } = useCommandPalette();
 
   if (needsSetup) {
@@ -83,7 +83,7 @@ export function App() {
           </button>
 
           <div className="flex items-center gap-3">
-            <ThemeToggle theme={theme} onToggle={toggleTheme} />
+            <ThemeToggle theme={theme} onChange={setTheme} />
             <InstallButton />
           </div>
         </div>

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -141,7 +141,7 @@ export function CommandPalette({ open, onClose }: { open: boolean; onClose: () =
       <div
         ref={dialogRef}
         tabIndex={-1}
-        className="relative w-full max-w-lg overflow-hidden rounded-2xl shadow-feature"
+        className="glass-surface relative w-full max-w-lg overflow-hidden rounded-2xl shadow-feature"
         style={{ background: "var(--bg-0)", border: "1px solid var(--border-strong)" }}
         onClick={(e) => e.stopPropagation()}
       >

--- a/apps/web/src/components/MediaDetailPanel.tsx
+++ b/apps/web/src/components/MediaDetailPanel.tsx
@@ -212,7 +212,8 @@ export function DetailPanel({
           aria-label={item.name}
           tabIndex={-1}
           onClick={(e) => e.stopPropagation()}
-          className="relative flex h-full w-full max-h-screen flex-col overflow-hidden bg-cream-50 shadow-feature sm:h-auto sm:max-h-[85vh] sm:max-w-4xl sm:flex-row sm:rounded-3xl sm:border sm:border-ink-100 lg:max-w-5xl"
+          className="relative flex h-full w-full max-h-screen flex-col overflow-hidden shadow-feature sm:h-auto sm:max-h-[85vh] sm:max-w-4xl sm:flex-row sm:rounded-3xl sm:border lg:max-w-5xl"
+          style={{ background: "var(--bg-0)", borderColor: "var(--border)" }}
         >
           {/* Close */}
           <button
@@ -245,9 +246,12 @@ export function DetailPanel({
                 {item.type === "movie" ? <Film className="h-3 w-3" /> : <Tv className="h-3 w-3" />}
                 {item.type === "movie" ? "Movie" : "Series"}
               </span>
-              {item.year && <span className="text-sm text-ink-500">{item.year}</span>}
+              {item.year && <span className="text-sm" style={{ color: "var(--text-mute)" }}>{item.year}</span>}
               {item.certification && (
-                <span className="rounded-md border border-ink-200 px-2 py-0.5 text-xs font-semibold text-ink-600">
+                <span
+                  className="rounded-md border px-2 py-0.5 text-xs font-semibold"
+                  style={{ borderColor: "var(--border-strong)", color: "var(--text-dim)" }}
+                >
                   {item.certification}
                 </span>
               )}
@@ -257,7 +261,7 @@ export function DetailPanel({
                 </span>
               )}
             </div>
-            <h2 className="mt-3 text-2xl font-bold text-ink-900">{item.name}</h2>
+            <h2 className="mt-3 text-2xl font-bold" style={{ color: "var(--text)" }}>{item.name}</h2>
 
             {/* Meta row: rating, runtime, network, genres */}
             <div className="mt-2 flex flex-wrap items-center gap-2">
@@ -267,17 +271,29 @@ export function DetailPanel({
                 </span>
               )}
               {item.runtime != null && item.runtime > 0 && (
-                <span className="inline-flex items-center gap-1 rounded-full bg-ink-100 px-2.5 py-1 text-xs text-ink-600">
+                <span
+                  className="inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs"
+                  style={{ background: "var(--surface-strong)", color: "var(--text-dim)" }}
+                >
                   <Clock className="h-3 w-3" />{formatRuntime(item.runtime)}
                 </span>
               )}
               {item.network && (
-                <span className="inline-flex items-center gap-1 rounded-full bg-ink-100 px-2.5 py-1 text-xs text-ink-600">
+                <span
+                  className="inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs"
+                  style={{ background: "var(--surface-strong)", color: "var(--text-dim)" }}
+                >
                   <TvMinimalPlay className="h-3 w-3" />{item.network}
                 </span>
               )}
               {item.genres.slice(0, 3).map((g) => (
-                <span key={g} className="rounded-full bg-ink-100 px-2.5 py-1 text-xs text-ink-600">{g}</span>
+                <span
+                  key={g}
+                  className="rounded-full px-2.5 py-1 text-xs"
+                  style={{ background: "var(--surface-strong)", color: "var(--text-dim)" }}
+                >
+                  {g}
+                </span>
               ))}
             </div>
           </div>
@@ -312,8 +328,8 @@ export function DetailPanel({
           {/* Description */}
           {item.description && (
             <div>
-              <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-ink-500">Overview</h3>
-              <p className="text-sm leading-relaxed text-ink-700">{item.description}</p>
+              <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--text-mute)" }}>Overview</h3>
+              <p className="text-sm leading-relaxed" style={{ color: "var(--text-dim)" }}>{item.description}</p>
             </div>
           )}
 

--- a/apps/web/src/components/ThemeToggle.tsx
+++ b/apps/web/src/components/ThemeToggle.tsx
@@ -86,9 +86,9 @@ export function ThemeToggle({ theme, onChange }: { theme: Theme; onChange: (next
               key={t.id}
               ref={(el) => { itemRefs.current[i] = el; }}
               type="button"
-              role="menuitem"
+              role="menuitemradio"
               tabIndex={activeIndex === i ? 0 : -1}
-              aria-current={theme === t.id ? "true" : undefined}
+              aria-checked={theme === t.id}
               onClick={() => {
                 onChange(t.id);
                 closeAndFocusButton();

--- a/apps/web/src/components/ThemeToggle.tsx
+++ b/apps/web/src/components/ThemeToggle.tsx
@@ -4,7 +4,10 @@ import { Theme, THEMES } from "../hooks/useTheme";
 
 export function ThemeToggle({ theme, onChange }: { theme: Theme; onChange: (next: Theme) => void }) {
   const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(0);
   const ref = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const itemRefs = useRef<(HTMLButtonElement | null)[]>([]);
 
   useEffect(() => {
     if (!open) return;
@@ -15,14 +18,55 @@ export function ThemeToggle({ theme, onChange }: { theme: Theme; onChange: (next
     return () => document.removeEventListener("mousedown", handler);
   }, [open]);
 
+  useEffect(() => {
+    if (open) setActiveIndex(Math.max(0, THEMES.findIndex((t) => t.id === theme)));
+  }, [open, theme]);
+
+  useEffect(() => {
+    if (open) itemRefs.current[activeIndex]?.focus();
+  }, [open, activeIndex]);
+
+  const closeAndFocusButton = () => {
+    setOpen(false);
+    buttonRef.current?.focus();
+  };
+
+  const handleMenuKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setActiveIndex((i) => (i + 1) % THEMES.length);
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setActiveIndex((i) => (i - 1 + THEMES.length) % THEMES.length);
+    } else if (e.key === "Home") {
+      e.preventDefault();
+      setActiveIndex(0);
+    } else if (e.key === "End") {
+      e.preventDefault();
+      setActiveIndex(THEMES.length - 1);
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      closeAndFocusButton();
+    } else if (e.key === "Tab") {
+      setOpen(false);
+    }
+  };
+
   return (
     <div ref={ref} className="relative">
       <button
+        ref={buttonRef}
         type="button"
-        aria-haspopup="listbox"
+        aria-haspopup="menu"
         aria-expanded={open}
         aria-label="Choose theme"
         onClick={() => setOpen((v) => !v)}
+        onKeyDown={(e) => {
+          if (e.key === "ArrowDown" || e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            setOpen(true);
+          }
+        }}
         className="flex h-9 w-9 flex-none items-center justify-center rounded-full transition-colors active:scale-95"
         style={{ border: "1px solid var(--border-strong)", background: "var(--surface)", color: "var(--text)" }}
       >
@@ -31,21 +75,25 @@ export function ThemeToggle({ theme, onChange }: { theme: Theme; onChange: (next
 
       {open && (
         <div
-          role="listbox"
+          role="menu"
+          aria-label="Theme"
           className="absolute right-0 top-11 z-40 w-44 overflow-hidden rounded-xl py-1 shadow-lg"
           style={{ border: "1px solid var(--border-strong)", background: "var(--bg-1)" }}
+          onKeyDown={handleMenuKeyDown}
         >
-          {THEMES.map((t) => (
+          {THEMES.map((t, i) => (
             <button
               key={t.id}
+              ref={(el) => { itemRefs.current[i] = el; }}
               type="button"
-              role="option"
-              aria-selected={theme === t.id}
+              role="menuitem"
+              tabIndex={activeIndex === i ? 0 : -1}
+              aria-current={theme === t.id ? "true" : undefined}
               onClick={() => {
                 onChange(t.id);
-                setOpen(false);
+                closeAndFocusButton();
               }}
-              className="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm transition-colors hover:bg-[var(--surface-strong)]"
+              className="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm transition-colors hover:bg-[var(--surface-strong)] focus-visible:bg-[var(--surface-strong)] focus-visible:outline-none"
               style={{ color: "var(--text)" }}
             >
               {t.label}

--- a/apps/web/src/components/ThemeToggle.tsx
+++ b/apps/web/src/components/ThemeToggle.tsx
@@ -1,59 +1,59 @@
-import { Theme } from "../hooks/useTheme";
+import { useEffect, useRef, useState } from "react";
+import { Check, Palette } from "lucide-react";
+import { Theme, THEMES } from "../hooks/useTheme";
 
-/**
- * Sun/moon slider toggle. All motion is a direct response to the state
- * change (CSS transition), never an idle/looping animation — clouds and
- * star-twinkle keyframes were deliberately dropped to match the app's
- * "fast and purposeful, never decorative" motion rule.
- */
-export function ThemeToggle({ theme, onToggle }: { theme: Theme; onToggle: () => void }) {
-  const dark = theme === "dark";
+export function ThemeToggle({ theme, onChange }: { theme: Theme; onChange: (next: Theme) => void }) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open]);
 
   return (
-    <button
-      type="button"
-      role="switch"
-      aria-checked={dark}
-      aria-label={dark ? "Switch to light mode" : "Switch to dark mode"}
-      onClick={onToggle}
-      className="relative h-9 w-16 flex-none rounded-full transition-colors duration-200 active:scale-95"
-      style={{
-        border: "1px solid var(--border-strong)",
-        background: dark ? "#1c2333" : "#bfe3ff",
-      }}
-    >
-      {/* static stars, only visible in dark mode — no twinkle loop */}
-      <span
-        className="absolute left-2.5 top-2 h-[3px] w-[3px] rounded-full bg-white transition-opacity duration-200"
-        style={{ opacity: dark ? 0.9 : 0 }}
-      />
-      <span
-        className="absolute left-4 top-4.5 h-[2px] w-[2px] rounded-full bg-white transition-opacity duration-200"
-        style={{ opacity: dark ? 0.7 : 0 }}
-      />
-      <span
-        className="absolute left-2 top-6 h-[2px] w-[2px] rounded-full bg-white transition-opacity duration-200"
-        style={{ opacity: dark ? 0.5 : 0 }}
-      />
-
-      {/* sliding sun/moon knob */}
-      <span
-        className="absolute top-1 left-1 flex h-6 w-6 items-center justify-center rounded-full shadow-sm transition-transform duration-200"
-        style={{
-          transform: dark ? "translateX(28px)" : "translateX(0)",
-          background: dark ? "#e2e8f0" : "#fbbf24",
-        }}
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-label="Choose theme"
+        onClick={() => setOpen((v) => !v)}
+        className="flex h-9 w-9 flex-none items-center justify-center rounded-full transition-colors active:scale-95"
+        style={{ border: "1px solid var(--border-strong)", background: "var(--surface)", color: "var(--text)" }}
       >
-        {/* moon craters fade in/out with the knob, no separate animation */}
-        <span
-          className="absolute h-1.5 w-1.5 rounded-full bg-slate-400 transition-opacity duration-200"
-          style={{ opacity: dark ? 0.8 : 0, top: "3px", left: "3px" }}
-        />
-        <span
-          className="absolute h-1 w-1 rounded-full bg-slate-400 transition-opacity duration-200"
-          style={{ opacity: dark ? 0.6 : 0, bottom: "4px", right: "4px" }}
-        />
-      </span>
-    </button>
+        <Palette className="h-4 w-4" />
+      </button>
+
+      {open && (
+        <div
+          role="listbox"
+          className="absolute right-0 top-11 z-40 w-44 overflow-hidden rounded-xl py-1 shadow-lg"
+          style={{ border: "1px solid var(--border-strong)", background: "var(--bg-1)" }}
+        >
+          {THEMES.map((t) => (
+            <button
+              key={t.id}
+              type="button"
+              role="option"
+              aria-selected={theme === t.id}
+              onClick={() => {
+                onChange(t.id);
+                setOpen(false);
+              }}
+              className="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm transition-colors hover:bg-[var(--surface-strong)]"
+              style={{ color: "var(--text)" }}
+            >
+              {t.label}
+              {theme === t.id && <Check className="h-3.5 w-3.5" style={{ color: "var(--accent)" }} />}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
   );
 }

--- a/apps/web/src/components/media-detail/CastSection.tsx
+++ b/apps/web/src/components/media-detail/CastSection.tsx
@@ -10,7 +10,7 @@ export function CastSection({ cast, loading }: { cast: CastMember[]; loading: bo
   if (loading) {
     return (
       <div>
-        <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-ink-500">Cast</h3>
+        <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--text-mute)" }}>Cast</h3>
         <div className="flex gap-3 overflow-hidden">
           {[1, 2, 3, 4].map((i) => (
             <div key={i} className="flex-none w-16 space-y-1">
@@ -27,7 +27,7 @@ export function CastSection({ cast, loading }: { cast: CastMember[]; loading: bo
 
   return (
     <div>
-      <h3 className="mb-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-ink-500">
+      <h3 className="mb-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--text-mute)" }}>
         <User className="h-3.5 w-3.5" /> Cast
       </h3>
       <div className="flex gap-3 overflow-x-auto pb-1 scrollbar-hide">
@@ -37,16 +37,20 @@ export function CastSection({ cast, loading }: { cast: CastMember[]; loading: bo
               <img
                 src={member.photo}
                 alt={member.name}
-                className="h-16 w-16 rounded-full object-cover ring-1 ring-ink-100 mx-auto"
+                className="h-16 w-16 rounded-full object-cover mx-auto"
+                style={{ boxShadow: "0 0 0 1px var(--border)" }}
                 loading="lazy"
               />
             ) : (
-              <div className="h-16 w-16 rounded-full bg-ink-100 flex items-center justify-center mx-auto ring-1 ring-ink-100">
-                <User className="h-6 w-6 text-ink-400" />
+              <div
+                className="h-16 w-16 rounded-full flex items-center justify-center mx-auto"
+                style={{ background: "var(--surface-strong)", boxShadow: "0 0 0 1px var(--border)" }}
+              >
+                <User className="h-6 w-6" style={{ color: "var(--text-mute)" }} />
               </div>
             )}
-            <p className="mt-1.5 text-2xs font-medium text-ink-700 leading-tight truncate">{member.name}</p>
-            <p className="text-2xs text-ink-500 truncate">{member.character}</p>
+            <p className="mt-1.5 text-2xs font-medium leading-tight truncate" style={{ color: "var(--text-dim)" }}>{member.name}</p>
+            <p className="text-2xs truncate" style={{ color: "var(--text-mute)" }}>{member.character}</p>
           </div>
         ))}
       </div>

--- a/apps/web/src/components/media-detail/CheckInBlock.tsx
+++ b/apps/web/src/components/media-detail/CheckInBlock.tsx
@@ -28,14 +28,15 @@ export function CheckInBlock({
           </span>
           <span className="text-sm font-semibold text-claw-600">Now Watching</span>
           {activeCheckin.season != null && activeCheckin.episode != null && (
-            <span className="text-xs text-ink-500">S{String(activeCheckin.season).padStart(2, "0")}:E{String(activeCheckin.episode).padStart(2, "0")}</span>
+            <span className="text-xs" style={{ color: "var(--text-mute)" }}>S{String(activeCheckin.season).padStart(2, "0")}:E{String(activeCheckin.episode).padStart(2, "0")}</span>
           )}
         </div>
         <div className="flex gap-2">
           <button
             type="button"
             onClick={() => onCheckout(false)}
-            className="flex-1 rounded-xl border border-ink-200 bg-ink-100 px-3 py-2 text-xs font-semibold text-ink-700 hover:bg-ink-200 transition-colors"
+            className="flex-1 rounded-xl border px-3 py-2 text-xs font-semibold transition-colors hover:bg-[var(--surface-strong)]"
+            style={{ borderColor: "var(--border-strong)", background: "var(--surface)", color: "var(--text-dim)" }}
           >
             Check Out
           </button>
@@ -61,7 +62,8 @@ export function CheckInBlock({
           onStartCheckin();
         }
       }}
-      className="flex w-full items-center justify-center gap-2 rounded-xl border border-ink-200 bg-cream-50 px-4 py-2.5 text-sm font-semibold text-ink-700 hover:border-claw-500/40 hover:bg-claw-500/5 hover:text-claw-600 transition-colors"
+      className="flex w-full items-center justify-center gap-2 rounded-xl border px-4 py-2.5 text-sm font-semibold transition-colors hover:border-claw-500/40 hover:bg-claw-500/5 hover:text-claw-600"
+      style={{ borderColor: "var(--border-strong)", background: "var(--surface)", color: "var(--text-dim)" }}
     >
       <Radio className="h-4 w-4" /> Check In
     </button>

--- a/apps/web/src/components/media-detail/CheckInModal.tsx
+++ b/apps/web/src/components/media-detail/CheckInModal.tsx
@@ -50,37 +50,40 @@ export function CheckInModal({
         aria-modal="true"
         aria-labelledby="checkin-modal-title"
         tabIndex={-1}
-        className="w-full max-w-sm rounded-2xl border border-ink-100 bg-cream-50 shadow-md"
+        className="w-full max-w-sm rounded-2xl border shadow-md"
+        style={{ borderColor: "var(--border)", background: "var(--bg-0)" }}
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="flex items-center justify-between border-b border-ink-100 px-5 py-4">
+        <div className="flex items-center justify-between border-b px-5 py-4" style={{ borderColor: "var(--border)" }}>
           <div className="flex items-center gap-2">
             <Radio className="h-4 w-4 text-claw-600" />
-            <h3 id="checkin-modal-title" className="text-base font-bold text-ink-900">Check In</h3>
+            <h3 id="checkin-modal-title" className="text-base font-bold" style={{ color: "var(--text)" }}>Check In</h3>
           </div>
-          <button onClick={onClose} aria-label="Close" className="rounded-lg p-1.5 text-ink-500 hover:bg-ink-100 hover:text-ink-900">
+          <button onClick={onClose} aria-label="Close" className="rounded-lg p-1.5 hover:bg-[var(--surface-strong)]" style={{ color: "var(--text-mute)" }}>
             <X className="h-4 w-4" />
           </button>
         </div>
         <div className="px-5 py-4 space-y-4">
-          <p className="text-sm text-ink-600">Which episode of <span className="font-semibold text-ink-900">{seriesName}</span> are you watching?</p>
+          <p className="text-sm" style={{ color: "var(--text-dim)" }}>Which episode of <span className="font-semibold" style={{ color: "var(--text)" }}>{seriesName}</span> are you watching?</p>
           <div className="flex gap-3">
             <div className="flex-1">
-              <label htmlFor="checkin-season" className="mb-1.5 block text-xs font-medium text-ink-500">Season</label>
+              <label htmlFor="checkin-season" className="mb-1.5 block text-xs font-medium" style={{ color: "var(--text-mute)" }}>Season</label>
               <input
                 id="checkin-season"
                 type="number" min="1" value={season}
                 onChange={(e) => setSeason(e.target.value)}
-                className="w-full rounded-xl border border-ink-200 bg-white px-3 py-2.5 text-sm text-ink-900 focus:border-claw-500 focus:outline-none focus:ring-2 focus:ring-claw-500/15"
+                className="w-full rounded-xl border px-3 py-2.5 text-sm focus:border-claw-500 focus:outline-none focus:ring-2 focus:ring-claw-500/15"
+                style={{ borderColor: "var(--border-strong)", background: "var(--surface)", color: "var(--text)" }}
               />
             </div>
             <div className="flex-1">
-              <label htmlFor="checkin-episode" className="mb-1.5 block text-xs font-medium text-ink-500">Episode</label>
+              <label htmlFor="checkin-episode" className="mb-1.5 block text-xs font-medium" style={{ color: "var(--text-mute)" }}>Episode</label>
               <input
                 id="checkin-episode"
                 type="number" min="1" value={episode}
                 onChange={(e) => setEpisode(e.target.value)}
-                className="w-full rounded-xl border border-ink-200 bg-white px-3 py-2.5 text-sm text-ink-900 focus:border-claw-500 focus:outline-none focus:ring-2 focus:ring-claw-500/15"
+                className="w-full rounded-xl border px-3 py-2.5 text-sm focus:border-claw-500 focus:outline-none focus:ring-2 focus:ring-claw-500/15"
+                style={{ borderColor: "var(--border-strong)", background: "var(--surface)", color: "var(--text)" }}
               />
             </div>
           </div>
@@ -88,7 +91,8 @@ export function CheckInModal({
           <div className="flex gap-3 pt-1">
             <button
               type="button" onClick={onClose}
-              className="flex-1 rounded-xl bg-ink-100 px-4 py-2.5 text-sm font-medium text-ink-700 hover:bg-ink-200 transition-colors"
+              className="flex-1 rounded-xl px-4 py-2.5 text-sm font-medium transition-colors hover:bg-[var(--surface-strong)]"
+              style={{ background: "var(--surface)", color: "var(--text-dim)" }}
             >
               Cancel
             </button>

--- a/apps/web/src/components/media-detail/DropShowButton.tsx
+++ b/apps/web/src/components/media-detail/DropShowButton.tsx
@@ -10,15 +10,16 @@ export function DropShowButton({
   if (loading) return null;
 
   return (
-    <div className="pt-2 border-t border-ink-100">
+    <div className="pt-2 border-t" style={{ borderColor: "var(--border)" }}>
       <button
         type="button"
         onClick={onToggle}
         className={`w-full rounded-xl px-4 py-2.5 text-sm font-semibold transition-colors ${
           isDropped
-            ? "bg-ink-100 text-ink-700 hover:bg-ink-200"
+            ? "hover:bg-[var(--surface-strong)]"
             : "bg-rose-500/10 text-rose-500 ring-1 ring-rose-500/20 hover:bg-rose-500/20"
         }`}
+        style={isDropped ? { background: "var(--surface)", color: "var(--text-dim)" } : undefined}
       >
         {isDropped ? "✓ Dropped — Click to Undrop" : "Drop Show"}
       </button>

--- a/apps/web/src/components/media-detail/ProvidersSection.tsx
+++ b/apps/web/src/components/media-detail/ProvidersSection.tsx
@@ -14,7 +14,7 @@ export function ProvidersSection({ providers, loading }: { providers: WatchProvi
 
   return (
     <div>
-      <h3 className="mb-2 flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-ink-500">
+      <h3 className="mb-2 flex items-center gap-2 text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--text-mute)" }}>
         <MonitorPlay className="h-3.5 w-3.5" /> Where to Watch
       </h3>
       <div className="flex flex-wrap gap-2">
@@ -22,12 +22,13 @@ export function ProvidersSection({ providers, loading }: { providers: WatchProvi
           <span
             key={p.id}
             title={p.name}
-            className="flex items-center gap-1.5 rounded-full bg-ink-100 px-2.5 py-1 text-xs text-ink-700"
+            className="flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs"
+            style={{ background: "var(--surface-strong)", color: "var(--text-dim)" }}
           >
             {p.logo ? (
               <img src={p.logo} alt="" className="h-4 w-4 rounded" />
             ) : (
-              <MonitorPlay className="h-3.5 w-3.5 text-ink-500" />
+              <MonitorPlay className="h-3.5 w-3.5" style={{ color: "var(--text-mute)" }} />
             )}
             {p.name}
           </span>

--- a/apps/web/src/components/media-detail/RatingsSection.tsx
+++ b/apps/web/src/components/media-detail/RatingsSection.tsx
@@ -13,13 +13,13 @@ export function ExternalRatings({
   if (imdbRating == null && rtScore == null && mcScore == null) return null;
   return (
     <div>
-      <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-ink-500">Ratings</h3>
+      <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--text-mute)" }}>Ratings</h3>
       <div className="flex flex-wrap items-center gap-4">
         {imdbRating != null && (
           <div className="flex items-center gap-1.5">
             <ImdbLogo />
-            <span className="text-sm font-semibold text-ink-900">{imdbRating.toFixed(1)}</span>
-            <span className="text-xs text-ink-500">/10</span>
+            <span className="text-sm font-semibold" style={{ color: "var(--text)" }}>{imdbRating.toFixed(1)}</span>
+            <span className="text-xs" style={{ color: "var(--text-mute)" }}>/10</span>
           </div>
         )}
         {rtScore != null && (
@@ -31,8 +31,8 @@ export function ExternalRatings({
         {mcScore != null && (
           <div className="flex items-center gap-1.5">
             <McIcon score={mcScore} />
-            <span className="text-sm font-semibold text-ink-900">{mcScore}</span>
-            <span className="text-xs text-ink-500">/100</span>
+            <span className="text-sm font-semibold" style={{ color: "var(--text)" }}>{mcScore}</span>
+            <span className="text-xs" style={{ color: "var(--text-mute)" }}>/100</span>
           </div>
         )}
       </div>
@@ -108,7 +108,7 @@ export function StarRating({
   const displayRating = hoverRating ?? userRating ?? 0;
   return (
     <div>
-      <h3 className="mb-2 flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-ink-500">
+      <h3 className="mb-2 flex items-center gap-2 text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--text-mute)" }}>
         <Star className="h-3.5 w-3.5" /> Your Rating
       </h3>
       <div className="flex items-center gap-1">
@@ -128,7 +128,8 @@ export function StarRating({
             >
               <span className="relative grid h-5 w-5 place-items-center">
                 <Star
-                  className={`absolute h-5 w-5 transition-colors duration-300 ${isPreview ? "text-amber-400" : "text-ink-300"}`}
+                  className={`absolute h-5 w-5 transition-colors duration-300 ${isPreview ? "text-amber-400" : ""}`}
+                  style={isPreview ? undefined : { color: "var(--text-mute)" }}
                 />
                 <Star
                   className={`star-shake-target absolute h-5 w-5 fill-amber-400 text-amber-400 transition-opacity duration-300 ${isFilled ? "star-pop opacity-100" : "opacity-0"}`}

--- a/apps/web/src/components/media-detail/SeasonsSection.tsx
+++ b/apps/web/src/components/media-detail/SeasonsSection.tsx
@@ -12,7 +12,7 @@ export function SeasonsSection({ seasons, loading }: { seasons: SeasonInfo[]; lo
   if (loading) {
     return (
       <div>
-        <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-ink-500">Seasons</h3>
+        <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--text-mute)" }}>Seasons</h3>
         <div className="grid grid-cols-2 gap-2">
           {[1, 2, 3, 4].map((i) => <div key={i} className="skeleton h-10 rounded-xl" />)}
         </div>
@@ -24,18 +24,25 @@ export function SeasonsSection({ seasons, loading }: { seasons: SeasonInfo[]; lo
 
   return (
     <div>
-      <h3 className="mb-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-ink-500">
+      <h3 className="mb-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--text-mute)" }}>
         <Tv className="h-3.5 w-3.5" /> Seasons
       </h3>
       <div className="grid grid-cols-2 gap-2">
         {seasons.map((s) => (
-          <div key={s.seasonNumber} className="flex items-center gap-2.5 rounded-xl bg-cream-50 border border-ink-100 px-3 py-2.5">
-            <div className="flex h-8 w-8 flex-none items-center justify-center rounded-lg bg-ink-100 text-xs font-bold text-ink-700">
+          <div
+            key={s.seasonNumber}
+            className="flex items-center gap-2.5 rounded-xl border px-3 py-2.5"
+            style={{ background: "var(--surface)", borderColor: "var(--border)" }}
+          >
+            <div
+              className="flex h-8 w-8 flex-none items-center justify-center rounded-lg text-xs font-bold"
+              style={{ background: "var(--surface-strong)", color: "var(--text-dim)" }}
+            >
               {s.seasonNumber}
             </div>
             <div className="min-w-0">
-              <p className="text-xs font-medium text-ink-900 truncate">{s.name}</p>
-              <p className="text-2xs text-ink-500">{s.episodeCount} eps{s.airYear ? ` · ${s.airYear}` : ""}</p>
+              <p className="text-xs font-medium truncate" style={{ color: "var(--text)" }}>{s.name}</p>
+              <p className="text-2xs" style={{ color: "var(--text-mute)" }}>{s.episodeCount} eps{s.airYear ? ` · ${s.airYear}` : ""}</p>
             </div>
           </div>
         ))}

--- a/apps/web/src/components/media-detail/WatchDateModal.tsx
+++ b/apps/web/src/components/media-detail/WatchDateModal.tsx
@@ -48,12 +48,13 @@ export function WatchDateModal({
         aria-modal="true"
         aria-labelledby="watch-date-modal-title"
         tabIndex={-1}
-        className="w-full max-w-sm rounded-2xl border border-ink-100 bg-cream-50 p-6 shadow-md"
+        className="w-full max-w-sm rounded-2xl border p-6 shadow-md"
+        style={{ borderColor: "var(--border)", background: "var(--bg-0)" }}
         onClick={(e) => e.stopPropagation()}
       >
         <div className="mb-5 flex items-center justify-between">
-          <h3 id="watch-date-modal-title" className="text-base font-semibold text-ink-900">When did you watch this?</h3>
-          <button type="button" onClick={onClose} aria-label="Close" className="rounded-lg p-1 text-ink-500 hover:text-ink-900">
+          <h3 id="watch-date-modal-title" className="text-base font-semibold" style={{ color: "var(--text)" }}>When did you watch this?</h3>
+          <button type="button" onClick={onClose} aria-label="Close" className="rounded-lg p-1 hover:opacity-80" style={{ color: "var(--text-mute)" }}>
             <X className="h-4 w-4" />
           </button>
         </div>
@@ -62,25 +63,27 @@ export function WatchDateModal({
         {target.kind === "episode" && (
           <div className="mb-4 flex gap-3">
             <div className="flex-1">
-              <label htmlFor="watch-date-season" className="mb-1 block text-xs text-ink-500">Season</label>
+              <label htmlFor="watch-date-season" className="mb-1 block text-xs" style={{ color: "var(--text-mute)" }}>Season</label>
               <input
                 id="watch-date-season"
                 type="number"
                 min={1}
                 value={season}
                 onChange={(e) => setSeason(Math.max(1, parseInt(e.target.value) || 1))}
-                className="w-full rounded-lg border border-ink-200 bg-white px-3 py-2 text-sm text-ink-900 focus:outline-none focus:ring-2 focus:ring-claw-500/30"
+                className="w-full rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-claw-500/30"
+                style={{ borderColor: "var(--border-strong)", background: "var(--surface)", color: "var(--text)" }}
               />
             </div>
             <div className="flex-1">
-              <label htmlFor="watch-date-episode" className="mb-1 block text-xs text-ink-500">Episode</label>
+              <label htmlFor="watch-date-episode" className="mb-1 block text-xs" style={{ color: "var(--text-mute)" }}>Episode</label>
               <input
                 id="watch-date-episode"
                 type="number"
                 min={1}
                 value={episode}
                 onChange={(e) => setEpisode(Math.max(1, parseInt(e.target.value) || 1))}
-                className="w-full rounded-lg border border-ink-200 bg-white px-3 py-2 text-sm text-ink-900 focus:outline-none focus:ring-2 focus:ring-claw-500/30"
+                className="w-full rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-claw-500/30"
+                style={{ borderColor: "var(--border-strong)", background: "var(--surface)", color: "var(--text)" }}
               />
             </div>
           </div>
@@ -104,7 +107,8 @@ export function WatchDateModal({
                   const [y, m, d] = releaseDate.split("-").map(Number);
                   void submit(new Date(Date.UTC(y, m - 1, d, 12)).toISOString());
                 }}
-                className="rounded-xl bg-ink-100 px-4 py-3 text-sm font-semibold text-ink-900 hover:bg-ink-200 disabled:opacity-50 transition-colors"
+                className="rounded-xl px-4 py-3 text-sm font-semibold transition-colors hover:bg-[var(--surface-strong)] disabled:opacity-50"
+                style={{ background: "var(--surface)", color: "var(--text)" }}
               >
                 Release date
               </button>
@@ -113,14 +117,16 @@ export function WatchDateModal({
               type="button"
               disabled={saving}
               onClick={() => void submit(new Date("2000-01-01T12:00:00.000Z").toISOString())}
-              className="rounded-xl bg-ink-100 px-4 py-3 text-sm font-semibold text-ink-900 hover:bg-ink-200 disabled:opacity-50 transition-colors"
+              className="rounded-xl px-4 py-3 text-sm font-semibold transition-colors hover:bg-[var(--surface-strong)] disabled:opacity-50"
+              style={{ background: "var(--surface)", color: "var(--text)" }}
             >
               Unknown date
             </button>
             <button
               type="button"
               onClick={() => setMode("custom")}
-              className="rounded-xl bg-ink-100 px-4 py-3 text-sm font-semibold text-ink-900 hover:bg-ink-200 transition-colors"
+              className="rounded-xl px-4 py-3 text-sm font-semibold transition-colors hover:bg-[var(--surface-strong)]"
+              style={{ background: "var(--surface)", color: "var(--text)" }}
             >
               Other date
             </button>
@@ -132,13 +138,15 @@ export function WatchDateModal({
               value={customDate}
               max={new Date().toISOString().slice(0, 10)}
               onChange={(e) => setCustomDate(e.target.value)}
-              className="w-full rounded-xl border border-ink-200 bg-white px-4 py-3 text-sm text-ink-900 focus:outline-none focus:ring-2 focus:ring-claw-500/30"
+              className="w-full rounded-xl border px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-claw-500/30"
+              style={{ borderColor: "var(--border-strong)", background: "var(--surface)", color: "var(--text)" }}
             />
             <div className="flex gap-2">
               <button
                 type="button"
                 onClick={() => setMode("quick")}
-                className="flex-1 rounded-xl bg-ink-100 px-4 py-2.5 text-sm font-medium text-ink-700 hover:bg-ink-200 transition-colors"
+                className="flex-1 rounded-xl px-4 py-2.5 text-sm font-medium transition-colors hover:bg-[var(--surface-strong)]"
+                style={{ background: "var(--surface)", color: "var(--text-dim)" }}
               >
                 Back
               </button>

--- a/apps/web/src/components/media-detail/WatchHistorySection.tsx
+++ b/apps/web/src/components/media-detail/WatchHistorySection.tsx
@@ -15,7 +15,7 @@ export function WatchHistorySection({
   return (
     <div>
       <div className="mb-3 flex items-center justify-between">
-        <h3 className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-ink-500">
+        <h3 className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--text-mute)" }}>
           <Clock className="h-3.5 w-3.5" /> Watch History
         </h3>
         <button
@@ -30,24 +30,31 @@ export function WatchHistorySection({
       {loading ? (
         <div className="space-y-2">{[1, 2, 3].map((i) => <div key={i} className="skeleton h-11 rounded-lg" />)}</div>
       ) : history.length === 0 ? (
-        <p className="rounded-xl bg-cream-50 border border-ink-100 py-5 text-center text-sm text-ink-500">
+        <p
+          className="rounded-xl border py-5 text-center text-sm"
+          style={{ background: "var(--surface)", borderColor: "var(--border)", color: "var(--text-mute)" }}
+        >
           No watch history yet
         </p>
       ) : (
         <div className="space-y-1.5">
           {history.map((event) => (
-            <div key={event.id} className="group flex items-center gap-3 rounded-lg bg-cream-50 border border-ink-100 px-3 py-2.5">
-              <ChevronRight className="h-3.5 w-3.5 shrink-0 text-ink-400" />
+            <div
+              key={event.id}
+              className="group flex items-center gap-3 rounded-lg border px-3 py-2.5"
+              style={{ background: "var(--surface)", borderColor: "var(--border)" }}
+            >
+              <ChevronRight className="h-3.5 w-3.5 shrink-0" style={{ color: "var(--text-mute)" }} />
               <div className="min-w-0 flex-1">
                 {event.season != null && event.episode != null ? (
-                  <span className="text-sm text-ink-900">
+                  <span className="text-sm" style={{ color: "var(--text)" }}>
                     S{String(event.season).padStart(2, "0")}:E{String(event.episode).padStart(2, "0")}
                   </span>
                 ) : (
-                  <span className="text-sm text-ink-900">Watched</span>
+                  <span className="text-sm" style={{ color: "var(--text)" }}>Watched</span>
                 )}
               </div>
-              <time className="shrink-0 text-2xs text-ink-500">
+              <time className="shrink-0 text-2xs" style={{ color: "var(--text-mute)" }}>
                 {new Date(event.watchedAt).toISOString().slice(0, 10) === "2000-01-01"
                   ? "Unknown date"
                   : new Date(event.watchedAt).toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" })}
@@ -55,7 +62,8 @@ export function WatchHistorySection({
               <button
                 type="button"
                 onClick={() => onDeleteEvent(event.id)}
-                className="shrink-0 rounded p-1 text-ink-400 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 hover:bg-rose-500/10 hover:text-rose-500 transition-all"
+                className="shrink-0 rounded p-1 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 hover:bg-rose-500/10 hover:text-rose-500 transition-all"
+                style={{ color: "var(--text-mute)" }}
                 aria-label="Remove watch event"
               >
                 <Trash2 className="h-3.5 w-3.5" />

--- a/apps/web/src/components/media-detail/WatchHistorySection.tsx
+++ b/apps/web/src/components/media-detail/WatchHistorySection.tsx
@@ -62,8 +62,7 @@ export function WatchHistorySection({
               <button
                 type="button"
                 onClick={() => onDeleteEvent(event.id)}
-                className="shrink-0 rounded p-1 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 hover:bg-rose-500/10 hover:text-rose-500 transition-all"
-                style={{ color: "var(--text-mute)" }}
+                className="shrink-0 rounded p-1 text-[var(--text-mute)] opacity-0 group-hover:opacity-100 focus-visible:opacity-100 hover:bg-rose-500/10 hover:text-rose-500 transition-all"
                 aria-label="Remove watch event"
               >
                 <Trash2 className="h-3.5 w-3.5" />

--- a/apps/web/src/components/media-detail/detailPanelUtils.ts
+++ b/apps/web/src/components/media-detail/detailPanelUtils.ts
@@ -10,7 +10,7 @@ export function statusColor(status: string): string {
   if (s.includes("return") || s.includes("ongoing")) return "text-green-400 bg-green-500/10 ring-green-500/20";
   if (s.includes("ended") || s.includes("cancel")) return "text-rose-400 bg-rose-500/10 ring-rose-500/20";
   if (s.includes("production") || s.includes("planned")) return "text-amber-400 bg-amber-500/10 ring-amber-500/20";
-  return "text-ink-600 bg-ink-100 ring-ink-200";
+  return "text-slate-400 bg-slate-500/10 ring-slate-500/20";
 }
 
 export type WatchLogTarget =

--- a/apps/web/src/hooks/useTheme.ts
+++ b/apps/web/src/hooks/useTheme.ts
@@ -1,19 +1,30 @@
 import { useCallback, useEffect, useState } from "react";
 
-export type Theme = "light" | "dark";
+export type Theme = "light" | "dark" | "glass" | "midnight" | "letterboxd";
+
+export const THEMES: { id: Theme; label: string }[] = [
+  { id: "light", label: "Light" },
+  { id: "dark", label: "Dark" },
+  { id: "glass", label: "Glass" },
+  { id: "midnight", label: "Midnight Cinema" },
+  { id: "letterboxd", label: "Letterboxd" },
+];
 
 const STORAGE_KEY = "cataloggy:theme";
+
+function isTheme(value: string | null): value is Theme {
+  return THEMES.some((t) => t.id === value);
+}
 
 function getInitialTheme(): Theme {
   if (typeof window === "undefined") return "light";
   const stored = window.localStorage.getItem(STORAGE_KEY);
-  if (stored === "light" || stored === "dark") return stored;
-  return "light";
+  return isTheme(stored) ? stored : "light";
 }
 
 function applyTheme(theme: Theme) {
   document.documentElement.setAttribute("data-theme", theme);
-  document.documentElement.style.colorScheme = theme;
+  document.documentElement.style.colorScheme = theme === "light" ? "light" : "dark";
 }
 
 export function useTheme() {
@@ -25,9 +36,6 @@ export function useTheme() {
   }, [theme]);
 
   const setTheme = useCallback((next: Theme) => setThemeState(next), []);
-  const toggleTheme = useCallback(() => {
-    setThemeState((prev) => (prev === "light" ? "dark" : "light"));
-  }, []);
 
-  return { theme, setTheme, toggleTheme };
+  return { theme, setTheme };
 }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -43,12 +43,90 @@
   --accent-3: #34d399;
 }
 
+[data-theme="glass"] {
+  color-scheme: dark;
+  --poster-ratio: 2 / 3;
+
+  /* Apple TV-inspired frosted glass over a deep ambient backdrop */
+  --bg-0: #0b0d12;
+  --bg-1: #11141b;
+  --bg-2: #f5f6f8;
+  --surface: rgba(255,255,255,0.06);
+  --surface-strong: rgba(255,255,255,0.10);
+  --border: rgba(255,255,255,0.10);
+  --border-strong: rgba(255,255,255,0.20);
+  --text: #f5f6f8;
+  --text-dim: #b7bcc6;
+  --text-mute: #80869a;
+  --accent: #0a84ff;
+  --accent-2: #5e9eff;
+  --accent-3: #30d158;
+  --glass-blur: 24px;
+}
+
+[data-theme="midnight"] {
+  color-scheme: dark;
+  --poster-ratio: 2 / 3;
+
+  /* Midnight Cinema — near-black navy with a marquee-red accent */
+  --bg-0: #07080d;
+  --bg-1: #0e1018;
+  --bg-2: #f4f1ea;
+  --surface: rgba(244,241,234,0.04);
+  --surface-strong: rgba(244,241,234,0.08);
+  --border: rgba(244,241,234,0.08);
+  --border-strong: rgba(244,241,234,0.16);
+  --text: #f4f1ea;
+  --text-dim: #a3a6b8;
+  --text-mute: #6f7286;
+  --accent: #e02f44;
+  --accent-2: #ff5a6e;
+  --accent-3: #f0c419;
+}
+
+[data-theme="letterboxd"] {
+  color-scheme: dark;
+  --poster-ratio: 2 / 3;
+
+  /* Letterboxd-ish — charcoal canvas, signature orange/green/blue accents */
+  --bg-0: #14181c;
+  --bg-1: #1c2228;
+  --bg-2: #ffffff;
+  --surface: rgba(255,255,255,0.04);
+  --surface-strong: rgba(255,255,255,0.08);
+  --border: rgba(255,255,255,0.08);
+  --border-strong: rgba(255,255,255,0.16);
+  --text: #ffffff;
+  --text-dim: #9ab;
+  --text-mute: #678;
+  --accent: #ff8000;
+  --accent-2: #00e054;
+  --accent-3: #40bcf4;
+}
+
 body {
   @apply m-0 min-h-screen;
   background-color: var(--bg-0);
   color: var(--text);
   font-family: 'Outfit', Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   line-height: 1.5;
+}
+
+/* Ambient glow behind frosted surfaces — gives backdrop-filter: blur()
+   something colorful to actually blur, like tvOS's focus-light effect. */
+[data-theme="glass"] body {
+  background-image:
+    radial-gradient(60vw 60vh at 12% -5%, rgba(10,132,255,0.20), transparent 60%),
+    radial-gradient(50vw 50vh at 100% 20%, rgba(48,209,88,0.14), transparent 60%),
+    radial-gradient(45vw 45vh at 30% 110%, rgba(94,158,255,0.12), transparent 60%);
+  background-attachment: fixed;
+}
+
+[data-theme="glass"] .glass-surface,
+[data-theme="glass"] header {
+  background: rgba(17,20,27,0.55) !important;
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
 }
 
 @layer base {


### PR DESCRIPTION
Extends the theme system from a light/dark toggle to a 5-option picker,
adding an Apple TV-inspired frosted glass theme (with ambient blur
backdrop), a navy/marquee-red Midnight Cinema theme, and a charcoal
Letterboxd-style theme.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0145sq1Nc2qRpUF3e2iYk56k

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added theme selector dropdown with additional appearance options: glass, midnight, and letterboxd.
  * Introduced frosted-glass visuals for the glass theme and new theme-scoped color tokens.

* **Style**
  * Updated multiple media detail components, modals, and panels to use consistent theme-aware CSS variables for backgrounds, borders, text, and pills.
  * Refined the command palette panel styling.

* **Bug Fixes**
  * Improved theme initialization/restoration on load by validating stored themes and applying correct light/dark color-scheme handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->