### PR TITLE
Improve UX with install prompt snooze, error handling, and font updates

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -11,9 +11,6 @@
     <link rel="icon" href="/favicon.ico" sizes="32x32" />
     <link rel="icon" type="image/png" href="/icons/icon-192.png" sizes="192x192" />
     <link rel="apple-touch-icon" href="/icons/icon-192.png" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
     <title>Cataloggy</title>
     <script src="/config.js"></script>
     <script>

--- a/apps/web/src/components/ErrorBoundary.tsx
+++ b/apps/web/src/components/ErrorBoundary.tsx
@@ -1,31 +1,65 @@
 import { Component, type ReactNode } from "react";
+import { AlertTriangle } from "lucide-react";
 
 type ErrorBoundaryProps = { children: ReactNode };
-type ErrorBoundaryState = { hasError: boolean };
+type ErrorBoundaryState = { hasError: boolean; error: Error | null };
 
 export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
-  state: ErrorBoundaryState = { hasError: false };
+  state: ErrorBoundaryState = { hasError: false, error: null };
 
-  static getDerivedStateFromError() {
-    return { hasError: true };
+  static getDerivedStateFromError(error: Error) {
+    return { hasError: true, error };
   }
 
   componentDidCatch(error: unknown) {
     console.error(error);
   }
 
+  resetErrorBoundary = () => {
+    this.setState({ hasError: false, error: null });
+  };
+
   render() {
     if (this.state.hasError) {
       return (
         <div className="flex min-h-screen w-full flex-col items-center justify-center gap-4 px-6 text-center">
-          <p style={{ color: "var(--text-mute)" }}>Something went wrong.</p>
-          <button
-            type="button"
-            onClick={() => window.location.reload()}
-            className="mt-4 rounded-lg bg-claw-500 px-4 py-2 text-white"
+          <div
+            className="flex h-14 w-14 items-center justify-center rounded-full bg-red-500/10 text-red-500"
+            aria-hidden="true"
           >
-            Reload
-          </button>
+            <AlertTriangle className="h-7 w-7" />
+          </div>
+          <div className="space-y-1">
+            <h1 className="text-lg font-semibold" style={{ color: "var(--text)" }}>
+              Something went wrong
+            </h1>
+            <p style={{ color: "var(--text-mute)" }}>An unexpected error occurred. Try again, or reload the page.</p>
+          </div>
+          <div className="flex gap-3">
+            <button
+              type="button"
+              onClick={this.resetErrorBoundary}
+              className="rounded-lg border border-claw-500 px-4 py-2 text-claw-500"
+            >
+              Try Again
+            </button>
+            <button
+              type="button"
+              onClick={() => window.location.reload()}
+              className="rounded-lg bg-claw-500 px-4 py-2 text-white"
+            >
+              Reload
+            </button>
+          </div>
+          {import.meta.env.DEV && this.state.error && (
+            <pre
+              className="mt-4 max-w-xl overflow-auto rounded-lg bg-black/5 p-4 text-left text-xs"
+              style={{ color: "var(--text-mute)" }}
+            >
+              {this.state.error.message}
+              {this.state.error.stack ? `\n\n${this.state.error.stack}` : ""}
+            </pre>
+          )}
         </div>
       );
     }

--- a/apps/web/src/components/InstallButton.tsx
+++ b/apps/web/src/components/InstallButton.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Download } from "lucide-react";
+import { Download, X } from "lucide-react";
 
 type BeforeInstallPromptEvent = Event & {
   prompt: () => Promise<void>;
@@ -11,9 +11,18 @@ const isStandalone =
   window.matchMedia("(display-mode: standalone)").matches ||
   ("standalone" in window.navigator && Boolean((window.navigator as Navigator & { standalone?: boolean }).standalone));
 
+const SNOOZE_KEY = "cataloggy:install-snooze-until";
+const SNOOZE_DAYS = 14;
+
+function isSnoozed() {
+  const until = Number(localStorage.getItem(SNOOZE_KEY) ?? 0);
+  return Date.now() < until;
+}
+
 export function InstallButton() {
   const [deferredPrompt, setDeferredPrompt] = useState<BeforeInstallPromptEvent | null>(null);
   const [showManualHint, setShowManualHint] = useState(false);
+  const [snoozed, setSnoozed] = useState(isSnoozed);
 
   useEffect(() => {
     const onBeforeInstallPrompt = (event: Event) => {
@@ -26,7 +35,13 @@ export function InstallButton() {
     return () => window.removeEventListener("beforeinstallprompt", onBeforeInstallPrompt);
   }, []);
 
-  if (isStandalone) {
+  useEffect(() => {
+    if (!showManualHint) return;
+    const timer = window.setTimeout(() => setShowManualHint(false), 5000);
+    return () => window.clearTimeout(timer);
+  }, [showManualHint]);
+
+  if (isStandalone || snoozed || (!deferredPrompt && !isIOS)) {
     return null;
   }
 
@@ -41,19 +56,36 @@ export function InstallButton() {
     setShowManualHint(true);
   };
 
+  const onDismiss = () => {
+    localStorage.setItem(SNOOZE_KEY, String(Date.now() + SNOOZE_DAYS * 24 * 60 * 60 * 1000));
+    setSnoozed(true);
+  };
+
+  const label = isIOS && !deferredPrompt ? "Add to Home Screen" : "Install";
+
   return (
     <div className="flex flex-col items-end gap-2">
-      <button
-        type="button"
-        onClick={() => {
-          void onInstall();
-        }}
-        aria-label="Install Cataloggy"
-        className="flex items-center gap-1.5 rounded-full border border-ink-200 bg-white px-3.5 py-2 text-xs font-medium text-ink-600 hover:bg-ink-100 hover:text-ink-900 transition-all"
-      >
-        <Download className="h-3.5 w-3.5" />
-        <span className="hidden sm:inline" aria-hidden="true">Install</span>
-      </button>
+      <div className="flex items-center gap-1">
+        <button
+          type="button"
+          onClick={() => {
+            void onInstall();
+          }}
+          aria-label={label === "Install" ? "Install Cataloggy" : label}
+          className="flex items-center gap-1.5 rounded-full border border-ink-200 bg-white px-3.5 py-2 text-xs font-medium text-ink-600 hover:bg-ink-100 hover:text-ink-900 transition-all"
+        >
+          <Download className="h-3.5 w-3.5" />
+          <span className="hidden sm:inline" aria-hidden="true">{label}</span>
+        </button>
+        <button
+          type="button"
+          onClick={onDismiss}
+          aria-label="Dismiss install prompt"
+          className="flex items-center justify-center rounded-full border border-ink-200 bg-white p-2 text-ink-400 hover:bg-ink-100 hover:text-ink-700 transition-all"
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+      </div>
       {showManualHint && (
         <p className="max-w-xs text-right text-xs text-ink-500">
           {isIOS

--- a/apps/web/src/components/InstallButton.tsx
+++ b/apps/web/src/components/InstallButton.tsx
@@ -15,8 +15,20 @@ const SNOOZE_KEY = "cataloggy:install-snooze-until";
 const SNOOZE_DAYS = 14;
 
 function isSnoozed() {
-  const until = Number(localStorage.getItem(SNOOZE_KEY) ?? 0);
-  return Date.now() < until;
+  try {
+    const until = Number(localStorage.getItem(SNOOZE_KEY) ?? 0);
+    return Date.now() < until;
+  } catch {
+    return false;
+  }
+}
+
+function snoozeInstallPrompt() {
+  try {
+    localStorage.setItem(SNOOZE_KEY, String(Date.now() + SNOOZE_DAYS * 24 * 60 * 60 * 1000));
+  } catch {
+    // ignore storage errors (e.g. private browsing)
+  }
 }
 
 export function InstallButton() {
@@ -47,9 +59,14 @@ export function InstallButton() {
 
   const onInstall = async () => {
     if (deferredPrompt) {
-      await deferredPrompt.prompt();
-      await deferredPrompt.userChoice;
-      setDeferredPrompt(null);
+      try {
+        await deferredPrompt.prompt();
+        await deferredPrompt.userChoice;
+      } catch (err) {
+        console.error(err);
+      } finally {
+        setDeferredPrompt(null);
+      }
       return;
     }
 
@@ -57,7 +74,7 @@ export function InstallButton() {
   };
 
   const onDismiss = () => {
-    localStorage.setItem(SNOOZE_KEY, String(Date.now() + SNOOZE_DAYS * 24 * 60 * 60 * 1000));
+    snoozeInstallPrompt();
     setSnoozed(true);
   };
 

--- a/apps/web/src/components/settings/Section.tsx
+++ b/apps/web/src/components/settings/Section.tsx
@@ -33,6 +33,10 @@ export function Section({
   const panelId = `${id}-panel`;
 
   useEffect(() => {
+    if (contentRef.current) contentRef.current.inert = !open;
+  }, [open]);
+
+  useEffect(() => {
     if (!contentRef.current) return;
     if (open) {
       setHeight(contentRef.current.scrollHeight);

--- a/apps/web/src/components/settings/Section.tsx
+++ b/apps/web/src/components/settings/Section.tsx
@@ -1,10 +1,33 @@
 import { ReactNode, useEffect, useId, useRef, useState } from "react";
 import { ChevronDown } from "lucide-react";
 
-export function Section({ title, icon, defaultOpen, children }: { title: string; icon: ReactNode; defaultOpen?: boolean; children: ReactNode }) {
-  const [open, setOpen] = useState(defaultOpen ?? false);
+const STORAGE_PREFIX = "cataloggy:settings-section:";
+
+function readStoredOpen(storageKey: string, fallback: boolean): boolean {
+  try {
+    const stored = localStorage.getItem(STORAGE_PREFIX + storageKey);
+    return stored === null ? fallback : stored === "1";
+  } catch {
+    return fallback;
+  }
+}
+
+export function Section({
+  title,
+  icon,
+  defaultOpen,
+  storageKey,
+  children,
+}: {
+  title: string;
+  icon: ReactNode;
+  defaultOpen?: boolean;
+  storageKey: string;
+  children: ReactNode;
+}) {
+  const [open, setOpen] = useState(() => readStoredOpen(storageKey, defaultOpen ?? true));
   const contentRef = useRef<HTMLDivElement>(null);
-  const [height, setHeight] = useState<number | undefined>(defaultOpen ? undefined : 0);
+  const [height, setHeight] = useState<number | undefined>(open ? undefined : 0);
   const id = useId();
   const buttonId = `${id}-toggle`;
   const panelId = `${id}-panel`;
@@ -21,6 +44,18 @@ export function Section({ title, icon, defaultOpen, children }: { title: string;
     }
   }, [open]);
 
+  const toggle = () => {
+    setOpen((prev) => {
+      const next = !prev;
+      try {
+        localStorage.setItem(STORAGE_PREFIX + storageKey, next ? "1" : "0");
+      } catch {
+        // ignore storage errors (e.g. private browsing)
+      }
+      return next;
+    });
+  };
+
   return (
     <div className="rounded-2xl border border-ink-100 bg-cream-50 shadow-sm overflow-hidden">
       <button
@@ -28,7 +63,7 @@ export function Section({ title, icon, defaultOpen, children }: { title: string;
         type="button"
         aria-expanded={open}
         aria-controls={panelId}
-        onClick={() => setOpen((prev) => !prev)}
+        onClick={toggle}
         className="flex w-full items-center gap-3 px-5 py-[1.125rem] text-left transition-colors hover:bg-ink-100/40"
       >
         <span className="flex h-9 w-9 items-center justify-center rounded-lg bg-ink-100 text-ink-500">{icon}</span>

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -108,7 +108,7 @@ body {
   @apply m-0 min-h-screen;
   background-color: var(--bg-0);
   color: var(--text);
-  font-family: 'Outfit', Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-family: "Plus Jakarta Sans Variable", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   line-height: 1.5;
 }
 

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter } from "react-router-dom";
 import { registerSW } from "virtual:pwa-register";
 import { App } from "./App";
 import { ErrorBoundary } from "./components/ErrorBoundary";
+import "@fontsource-variable/plus-jakarta-sans";
 import "./index.css";
 
 registerSW({ immediate: true });

--- a/apps/web/src/pages/SearchPage.tsx
+++ b/apps/web/src/pages/SearchPage.tsx
@@ -83,6 +83,7 @@ export function SearchPage() {
   const dropdownRef = useRef<HTMLDivElement>(null);
   const lastSearchRef = useRef<{ filter: FilterType; query: string }>({ filter: "all", query: "" });
   const requestIdRef = useRef(0);
+  const abortRef = useRef<AbortController | null>(null);
 
   // Load lists + providers on mount
   useEffect(() => {
@@ -117,6 +118,11 @@ export function SearchPage() {
   const doSearch = useCallback(
     async (searchFilter: FilterType, searchQuery: string) => {
       if (!searchQuery.trim()) return;
+
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
+
       const requestId = ++requestIdRef.current;
       setIsSearching(true);
       lastSearchRef.current = { filter: searchFilter, query: searchQuery };
@@ -124,8 +130,8 @@ export function SearchPage() {
       try {
         if (searchFilter === "all") {
           const [movies, series] = await Promise.all([
-            api.search("movie", searchQuery),
-            api.search("series", searchQuery),
+            api.search("movie", searchQuery, controller.signal),
+            api.search("series", searchQuery, controller.signal),
           ]);
           if (requestIdRef.current !== requestId) return;
           const merged: SearchResult[] = [];
@@ -136,12 +142,13 @@ export function SearchPage() {
           }
           setRawResults(merged);
         } else {
-          const response = await api.search(searchFilter, searchQuery);
+          const response = await api.search(searchFilter, searchQuery, controller.signal);
           if (requestIdRef.current !== requestId) return;
           setRawResults(response);
         }
       } catch (err) {
         if (requestIdRef.current !== requestId) return;
+        if (err instanceof DOMException && err.name === "AbortError") return;
         setRawResults([]);
         showToast(err instanceof Error ? err.message : "Search failed", "error");
       } finally {
@@ -168,17 +175,18 @@ export function SearchPage() {
 
   // Debounced auto-search on query/filter change
   useEffect(() => {
-    // Invalidate any in-flight request so its response is discarded
-    ++requestIdRef.current;
-
     if (!filters.query.trim()) {
+      // Invalidate any in-flight request so its response is discarded
+      ++requestIdRef.current;
+      abortRef.current?.abort();
+      if (debounceRef.current) clearTimeout(debounceRef.current);
       setRawResults(null);
       setIsSearching(false);
       return;
     }
-    // Only re-search if query or media type filter changed
+    // Only re-search if query or media type filter actually changed
     const last = lastSearchRef.current;
-    if (last.query === filters.query && last.filter === filters.filter && rawResults !== null) return;
+    if (last.query === filters.query && last.filter === filters.filter) return;
 
     if (debounceRef.current) clearTimeout(debounceRef.current);
     debounceRef.current = setTimeout(() => {

--- a/apps/web/src/pages/SearchPage.tsx
+++ b/apps/web/src/pages/SearchPage.tsx
@@ -98,6 +98,11 @@ export function SearchPage() {
     })();
   }, [showToast]);
 
+  // Abort any in-flight search when the page unmounts
+  useEffect(() => {
+    return () => abortRef.current?.abort();
+  }, []);
+
   // Close dropdown on outside click
   useEffect(() => {
     const handler = (e: MouseEvent) => {
@@ -180,6 +185,7 @@ export function SearchPage() {
       ++requestIdRef.current;
       abortRef.current?.abort();
       if (debounceRef.current) clearTimeout(debounceRef.current);
+      lastSearchRef.current = { filter: filters.filter, query: "" };
       setRawResults(null);
       setIsSearching(false);
       return;

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import { Key, Link, Database, Info, Clapperboard, Image, Globe, Star, Sparkles, Bell, Users } from "lucide-react";
 import { Section } from "../components/settings/Section";
 import { ApiTokenSettings } from "../components/settings/ApiTokenSettings";
@@ -17,8 +17,21 @@ const APP_VERSION = typeof __APP_VERSION__ !== "undefined" ? __APP_VERSION__ : "
 
 type SettingsTab = "preferences" | "integrations";
 
+function isSettingsTab(value: string | null): value is SettingsTab {
+  return value === "preferences" || value === "integrations";
+}
+
 export function SettingsPage() {
-  const [tab, setTab] = useState<SettingsTab>("preferences");
+  const [searchParams, setSearchParams] = useSearchParams();
+  const tab: SettingsTab = isSettingsTab(searchParams.get("tab")) ? (searchParams.get("tab") as SettingsTab) : "preferences";
+
+  const setTab = (next: SettingsTab) => {
+    setSearchParams((prev) => {
+      const params = new URLSearchParams(prev);
+      params.set("tab", next);
+      return params;
+    });
+  };
 
   const tabs: { id: SettingsTab; label: string }[] = [
     { id: "preferences", label: "Preferences" },
@@ -48,19 +61,19 @@ export function SettingsPage() {
 
       {tab === "preferences" && (
         <div className="space-y-4">
-          <Section title="Preferences" icon={<Globe size={20} />} defaultOpen>
+          <Section title="Preferences" icon={<Globe size={20} />} storageKey="preferences">
             <PreferencesSettings />
           </Section>
 
-          <Section title="Profile" icon={<Users size={20} />}>
+          <Section title="Profile" icon={<Users size={20} />} storageKey="profile">
             <ProfileSettings />
           </Section>
 
-          <Section title="Notifications" icon={<Bell size={20} />}>
+          <Section title="Notifications" icon={<Bell size={20} />} storageKey="notifications">
             <PushSettings />
           </Section>
 
-          <Section title="About" icon={<Info size={20} />}>
+          <Section title="About" icon={<Info size={20} />} storageKey="about">
             <div className="space-y-2 text-sm text-ink-600">
               <p className="text-base font-semibold text-ink-900">Cataloggy <span className="font-mono text-claw-600">v{APP_VERSION}</span></p>
               <p className="text-sm">A personal media catalog and watchlist manager.</p>
@@ -71,31 +84,31 @@ export function SettingsPage() {
 
       {tab === "integrations" && (
         <div className="space-y-4">
-          <Section title="API Token" icon={<Key size={20} />} defaultOpen>
+          <Section title="API Token" icon={<Key size={20} />} storageKey="api-token">
             <ApiTokenSettings />
           </Section>
 
-          <Section title="Trakt Integration" icon={<Link size={20} />}>
+          <Section title="Trakt Integration" icon={<Link size={20} />} storageKey="trakt">
             <TraktSettings />
           </Section>
 
-          <Section title="Stremio Addon" icon={<Clapperboard size={20} />}>
+          <Section title="Stremio Addon" icon={<Clapperboard size={20} />} storageKey="addon">
             <AddonSettings />
           </Section>
 
-          <Section title="OMDB Ratings" icon={<Star size={20} />}>
+          <Section title="OMDB Ratings" icon={<Star size={20} />} storageKey="omdb">
             <OmdbSettings />
           </Section>
 
-          <Section title="RPDB Posters" icon={<Image size={20} />}>
+          <Section title="RPDB Posters" icon={<Image size={20} />} storageKey="rpdb">
             <RpdbSettings />
           </Section>
 
-          <Section title="AI Recommendations" icon={<Sparkles size={20} />}>
+          <Section title="AI Recommendations" icon={<Sparkles size={20} />} storageKey="ai">
             <AiSettings />
           </Section>
 
-          <Section title="Data" icon={<Database size={20} />}>
+          <Section title="Data" icon={<Database size={20} />} storageKey="data">
             <DataSettings />
           </Section>
         </div>

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -53,8 +53,8 @@ export default {
         },
       },
       fontFamily: {
-        heading: ["Outfit", '"Plus Jakarta Sans Variable"', "Inter", "system-ui", "sans-serif"],
-        sans: ["Outfit", "Inter", "system-ui", "-apple-system", "BlinkMacSystemFont", '"Segoe UI"', "sans-serif"],
+        heading: ['"Plus Jakarta Sans Variable"', "system-ui", "sans-serif"],
+        sans: ['"Plus Jakarta Sans Variable"', "system-ui", "-apple-system", "BlinkMacSystemFont", '"Segoe UI"', "sans-serif"],
       },
       fontSize: {
         "2xs": ["0.6875rem", { lineHeight: "1rem" }],


### PR DESCRIPTION
This PR enhances the user experience across several components with better state management, error handling, and visual improvements.

## Summary
Multiple improvements to the web app's UX including a snooze feature for the install prompt, enhanced error boundary with recovery options, persistent settings panel state, URL-based settings tab navigation, and font optimization.

## Key Changes

**InstallButton Component**
- Added snooze functionality allowing users to dismiss the install prompt for 14 days
- Implemented localStorage-based snooze state with `isSnoozed()` check
- Added dismiss button with X icon next to install button
- Auto-hide manual hint after 5 seconds with useEffect cleanup
- Dynamic label text based on platform (iOS vs others)
- Improved visibility logic to hide button when snoozed or not applicable

**ErrorBoundary Component**
- Enhanced error state to capture and display the actual error object
- Added visual error icon (AlertTriangle) with styled container
- Implemented "Try Again" button for error recovery without full page reload
- Added error details display in development mode for debugging
- Improved messaging and button layout with better UX

**Section Component (Settings)**
- Added `storageKey` prop for persistent panel open/closed state
- Implemented localStorage persistence with `readStoredOpen()` helper
- Graceful fallback for storage errors (e.g., private browsing mode)
- Fixed initial height calculation to use actual open state

**SettingsPage Component**
- Migrated from useState to URL-based tab navigation using `useSearchParams`
- Tab selection now persists in URL query parameters (`?tab=integrations`)
- Added `isSettingsTab()` type guard for safe tab validation
- Updated all Section components with unique `storageKey` props

**SearchPage Component**
- Added AbortController for canceling in-flight API requests
- Properly abort previous searches when new search is initiated
- Handle AbortError gracefully without showing error toast
- Improved debounce logic to avoid unnecessary re-searches
- Better cleanup of pending requests on query/filter changes

**Font Updates**
- Removed Google Fonts dependency (Outfit font)
- Switched to Plus Jakarta Sans Variable from @fontsource-variable
- Updated tailwind font configuration to use Plus Jakarta Sans as primary
- Removed preconnect links to Google Fonts in HTML

## Notable Implementation Details
- Snooze duration: 14 days (1,209,600,000 milliseconds)
- Storage keys use `cataloggy:` prefix for namespace isolation
- Error boundary recovery allows users to retry without losing app state
- Settings state now survives page refreshes and browser navigation
- Search requests are properly aborted to prevent race conditions and memory leaks

https://claude.ai/code/session_01Gi1Y9AFC8c8gp5rsV1F156

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search now better handles fast typing and changing filters without showing outdated results.
  * Settings sections can remember their open/closed state, and the active settings tab stays in the URL for easier sharing and navigation.
  * Install prompts now include a dismiss option and can be snoozed for later.

* **Bug Fixes**
  * Error screens now show clearer guidance with options to try again or reload.
  * The app’s typography and font loading have been updated for a more consistent visual appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->