### PR TITLE
Add profile switching UI and improve accessibility

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -188,7 +188,7 @@ function AppShell({
 
       {/* Main content */}
       <main className={`mx-auto max-w-[1400px] px-6 pb-24 pt-[76px] sm:pb-10 transition-[padding] duration-200 ${sidebarPad}`}>
-        <Routes key={profile?.id ?? "default"}>
+        <Routes key={profile?.id ?? runtimeConfig.getProfileId() ?? "default"}>
           <Route path="/" element={<DashboardPage />} />
           <Route path="/search" element={<SearchPage />} />
           <Route path="/lists/*" element={<ListsPage />} />

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,13 +1,14 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Link, Route, Routes, useLocation } from "react-router-dom";
-import { BarChart3, Clapperboard, History, Search, List, Settings } from "lucide-react";
-import { runtimeConfig } from "./api";
+import { BarChart3, Clapperboard, History, Search, List, Settings, User } from "lucide-react";
+import { api, Profile, runtimeConfig } from "./api";
 import { CommandPalette, useCommandPalette } from "./components/CommandPalette";
 import { InstallButton } from "./components/InstallButton";
 import { Sidebar, PIN_KEY } from "./components/Sidebar";
 import { ThemeToggle } from "./components/ThemeToggle";
 import { useTheme } from "./hooks/useTheme";
 import { ToastProvider } from "./hooks/useToast";
+import { ProfileProvider, useProfile } from "./hooks/useProfile";
 import { DashboardPage } from "./pages/DashboardPage";
 import { HistoryPage } from "./pages/HistoryPage";
 import { ListsPage } from "./pages/ListsPage";
@@ -47,14 +48,88 @@ export function App() {
   }
 
   if (needsProfile) {
-    return <ProfileSwitcher onSelected={() => setNeedsProfile(false)} />;
+    return (
+      <ProfileSwitcher
+        onSelected={(profile) => {
+          runtimeConfig.setProfileId(profile.id);
+          setNeedsProfile(false);
+        }}
+      />
+    );
   }
 
   return (
     <ToastProvider>
+    <ProfileProvider initialProfile={null}>
+      <AppShell
+        sidebarPinned={sidebarPinned}
+        setSidebarPinned={setSidebarPinned}
+        sidebarPad={sidebarPad}
+        paletteOpen={paletteOpen}
+        setPaletteOpen={setPaletteOpen}
+        theme={theme}
+        setTheme={setTheme}
+        location={location}
+      />
+    </ProfileProvider>
+    </ToastProvider>
+  );
+}
+
+function AppShell({
+  sidebarPinned,
+  setSidebarPinned,
+  sidebarPad,
+  paletteOpen,
+  setPaletteOpen,
+  theme,
+  setTheme,
+  location,
+}: {
+  sidebarPinned: boolean;
+  setSidebarPinned: (pinned: boolean) => void;
+  sidebarPad: string;
+  paletteOpen: boolean;
+  setPaletteOpen: (open: boolean) => void;
+  theme: ReturnType<typeof useTheme>["theme"];
+  setTheme: ReturnType<typeof useTheme>["setTheme"];
+  location: ReturnType<typeof useLocation>;
+}) {
+  const { profile, setProfile, switcherOpen, openSwitcher, closeSwitcher } = useProfile();
+
+  useEffect(() => {
+    let cancelled = false;
+    const currentId = runtimeConfig.getProfileId();
+    if (!currentId) return;
+    void (async () => {
+      try {
+        const { profiles } = await api.getProfiles();
+        if (cancelled) return;
+        const current = profiles.find((p) => p.id === currentId);
+        if (current) setProfile(current);
+      } catch {
+        // best-effort; profile indicator just won't show a name
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [setProfile]);
+
+  const handleProfileSelected = (next: Profile) => {
+    setProfile(next);
+  };
+
+  return (
     <div className="min-h-screen w-full">
-      <Sidebar pinned={sidebarPinned} onPinnedChange={setSidebarPinned} />
+      <Sidebar
+        pinned={sidebarPinned}
+        onPinnedChange={setSidebarPinned}
+        profile={profile}
+        onSwitchProfile={openSwitcher}
+      />
       <CommandPalette open={paletteOpen} onClose={() => setPaletteOpen(false)} />
+      {switcherOpen && (
+        <ProfileSwitcher onSelected={handleProfileSelected} onClose={closeSwitcher} />
+      )}
 
       {/* Slim top bar */}
       <header
@@ -89,10 +164,20 @@ export function App() {
           <div className="flex items-center gap-3">
             <ThemeToggle theme={theme} onChange={setTheme} />
             <InstallButton />
+            <button
+              type="button"
+              onClick={openSwitcher}
+              aria-label={profile ? `Switch profile (currently ${profile.name})` : "Switch profile"}
+              title={profile?.name}
+              className="flex h-9 w-9 items-center justify-center rounded-full transition-colors hover:bg-[var(--surface-strong)] focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-400 focus-visible:ring-offset-2 sm:hidden"
+              style={{ color: "var(--text-mute)" }}
+            >
+              <User className="h-5 w-5" />
+            </button>
             <Link
               to="/settings"
               aria-label="Settings"
-              className={`flex h-9 w-9 items-center justify-center rounded-full transition-colors hover:bg-[var(--surface-strong)] sm:hidden ${location.pathname.startsWith("/settings") ? "text-claw-600" : ""}`}
+              className={`flex h-9 w-9 items-center justify-center rounded-full transition-colors hover:bg-[var(--surface-strong)] focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-400 focus-visible:ring-offset-2 sm:hidden ${location.pathname.startsWith("/settings") ? "text-claw-600" : ""}`}
               style={location.pathname.startsWith("/settings") ? {} : { color: "var(--text-mute)" }}
             >
               <Settings className="h-5 w-5" />
@@ -103,7 +188,7 @@ export function App() {
 
       {/* Main content */}
       <main className={`mx-auto max-w-[1400px] px-6 pb-24 pt-[76px] sm:pb-10 transition-[padding] duration-200 ${sidebarPad}`}>
-        <Routes>
+        <Routes key={profile?.id ?? "default"}>
           <Route path="/" element={<DashboardPage />} />
           <Route path="/search" element={<SearchPage />} />
           <Route path="/lists/*" element={<ListsPage />} />
@@ -128,7 +213,7 @@ export function App() {
             <Link
               key={item.to}
               to={item.to}
-              className={`relative flex flex-1 flex-col items-center gap-0.5 py-2.5 text-2xs font-medium transition-colors ${isActive ? "text-claw-600" : ""}`}
+              className={`relative flex flex-1 flex-col items-center gap-0.5 py-2.5 text-2xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-400 focus-visible:ring-offset-2 ${isActive ? "text-claw-600" : ""}`}
               style={isActive ? {} : { color: "var(--text-dim)" }}
             >
               {isActive && (
@@ -149,6 +234,5 @@ export function App() {
         Cataloggy &middot; Personal Media Tracker
       </footer>
     </div>
-    </ToastProvider>
   );
 }

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { NavLink } from "react-router-dom";
-import { BarChart3, Clapperboard, History, Pin, PinOff, Search, List, Settings } from "lucide-react";
+import { BarChart3, Clapperboard, History, Pin, PinOff, Search, List, Settings, User } from "lucide-react";
+import { Profile } from "../api";
 
 const navItems = [
   { to: "/", label: "Dashboard", icon: Clapperboard, end: true },
@@ -14,7 +15,17 @@ const navItems = [
 export const PIN_KEY = "cataloggy:sidebar-pinned";
 const HOVER_DELAY_MS = 200;
 
-export function Sidebar({ pinned, onPinnedChange }: { pinned: boolean; onPinnedChange: (pinned: boolean) => void }) {
+export function Sidebar({
+  pinned,
+  onPinnedChange,
+  profile,
+  onSwitchProfile,
+}: {
+  pinned: boolean;
+  onPinnedChange: (pinned: boolean) => void;
+  profile?: Profile | null;
+  onSwitchProfile?: () => void;
+}) {
   const [hovered, setHovered] = useState(false);
   const hoverTimerRef = useRef<ReturnType<typeof setTimeout>>();
   const expanded = pinned || hovered;
@@ -71,7 +82,7 @@ export function Sidebar({ pinned, onPinnedChange }: { pinned: boolean; onPinnedC
               to={item.to}
               end={item.end}
               className={({ isActive }) =>
-                `group relative flex items-center gap-3 rounded-lg px-2.5 py-2.5 text-sm font-medium transition-colors ${
+                `group relative flex items-center gap-3 rounded-lg px-2.5 py-2.5 text-sm font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-400 focus-visible:ring-offset-2 ${
                   isActive ? "" : "hover:bg-[var(--surface-strong)]"
                 }`
               }
@@ -93,10 +104,26 @@ export function Sidebar({ pinned, onPinnedChange }: { pinned: boolean; onPinnedC
         </nav>
 
         <div className="px-2.5">
+          {onSwitchProfile && (
+            <button
+              type="button"
+              onClick={onSwitchProfile}
+              className="flex w-full items-center gap-3 rounded-lg px-2.5 py-2.5 text-sm font-medium transition-colors hover:bg-[var(--surface-strong)] focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-400 focus-visible:ring-offset-2"
+              style={{ color: "var(--text-dim)" }}
+              aria-label={profile ? `Switch profile (currently ${profile.name})` : "Switch profile"}
+            >
+              <span className="flex h-[1.1rem] w-[1.1rem] flex-none items-center justify-center rounded-full" style={{ background: "var(--surface-strong)" }}>
+                <User className="h-3 w-3" />
+              </span>
+              <span className="truncate whitespace-nowrap" style={{ opacity: expanded ? 1 : 0 }}>
+                {profile?.name ?? "Switch profile"}
+              </span>
+            </button>
+          )}
           <button
             type="button"
             onClick={togglePin}
-            className="flex w-full items-center gap-3 rounded-lg px-2.5 py-2.5 text-sm font-medium transition-colors hover:bg-[var(--surface-strong)]"
+            className="flex w-full items-center gap-3 rounded-lg px-2.5 py-2.5 text-sm font-medium transition-colors hover:bg-[var(--surface-strong)] focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-400 focus-visible:ring-offset-2"
             style={{ color: "var(--text-dim)" }}
             aria-label={pinned ? "Unpin sidebar" : "Pin sidebar open"}
           >

--- a/apps/web/src/components/settings/ProfileSettings.tsx
+++ b/apps/web/src/components/settings/ProfileSettings.tsx
@@ -1,22 +1,20 @@
-import { runtimeConfig } from "../../api";
 import { Users } from "lucide-react";
+import { useProfile } from "../../hooks/useProfile";
 
 export function ProfileSettings() {
-  const switchProfile = () => {
-    runtimeConfig.clearProfileId();
-    window.location.reload();
-  };
+  const { profile, openSwitcher } = useProfile();
 
   return (
     <div className="space-y-4">
       <p className="text-sm leading-relaxed" style={{ color: "var(--text-dim)" }}>
+        {profile ? <>Currently watching as <strong>{profile.name}</strong>. </> : null}
         Switch to a different profile, or create a new one. Each profile has its own watch history,
         lists, and stats.
       </p>
       <button
         type="button"
-        onClick={switchProfile}
-        className="inline-flex items-center gap-2 rounded-xl border px-5 py-2.5 text-sm font-semibold transition-colors hover:bg-[var(--surface-strong)]"
+        onClick={openSwitcher}
+        className="inline-flex items-center gap-2 rounded-xl border px-5 py-2.5 text-sm font-semibold transition-colors hover:bg-[var(--surface-strong)] focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-400 focus-visible:ring-offset-2"
         style={{ background: "var(--surface)", borderColor: "var(--border-strong)", color: "var(--text-dim)" }}
       >
         <Users size={16} /> Switch Profile

--- a/apps/web/src/hooks/useProfile.tsx
+++ b/apps/web/src/hooks/useProfile.tsx
@@ -1,4 +1,4 @@
-import { createContext, ReactNode, useCallback, useContext, useState } from "react";
+import { createContext, ReactNode, useCallback, useContext, useMemo, useState } from "react";
 import { Profile, runtimeConfig } from "../api";
 
 type ProfileContextValue = {
@@ -30,11 +30,12 @@ export function ProfileProvider({
   const openSwitcher = useCallback(() => setSwitcherOpen(true), []);
   const closeSwitcher = useCallback(() => setSwitcherOpen(false), []);
 
-  return (
-    <ProfileContext.Provider value={{ profile, setProfile, switcherOpen, openSwitcher, closeSwitcher }}>
-      {children}
-    </ProfileContext.Provider>
+  const value = useMemo(
+    () => ({ profile, setProfile, switcherOpen, openSwitcher, closeSwitcher }),
+    [profile, setProfile, switcherOpen, openSwitcher, closeSwitcher]
   );
+
+  return <ProfileContext.Provider value={value}>{children}</ProfileContext.Provider>;
 }
 
 export function useProfile() {

--- a/apps/web/src/hooks/useProfile.tsx
+++ b/apps/web/src/hooks/useProfile.tsx
@@ -1,0 +1,44 @@
+import { createContext, ReactNode, useCallback, useContext, useState } from "react";
+import { Profile, runtimeConfig } from "../api";
+
+type ProfileContextValue = {
+  profile: Profile | null;
+  setProfile: (profile: Profile) => void;
+  switcherOpen: boolean;
+  openSwitcher: () => void;
+  closeSwitcher: () => void;
+};
+
+const ProfileContext = createContext<ProfileContextValue | null>(null);
+
+export function ProfileProvider({
+  initialProfile,
+  children,
+}: {
+  initialProfile: Profile | null;
+  children: ReactNode;
+}) {
+  const [profile, setProfileState] = useState<Profile | null>(initialProfile);
+  const [switcherOpen, setSwitcherOpen] = useState(false);
+
+  const setProfile = useCallback((next: Profile) => {
+    runtimeConfig.setProfileId(next.id);
+    setProfileState(next);
+    setSwitcherOpen(false);
+  }, []);
+
+  const openSwitcher = useCallback(() => setSwitcherOpen(true), []);
+  const closeSwitcher = useCallback(() => setSwitcherOpen(false), []);
+
+  return (
+    <ProfileContext.Provider value={{ profile, setProfile, switcherOpen, openSwitcher, closeSwitcher }}>
+      {children}
+    </ProfileContext.Provider>
+  );
+}
+
+export function useProfile() {
+  const ctx = useContext(ProfileContext);
+  if (!ctx) throw new Error("useProfile must be used within a ProfileProvider");
+  return ctx;
+}

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -128,7 +128,7 @@ function DiscoveryCard({ item, badge, reason, onSelect, eager }: {
     <div
       role="button"
       tabIndex={0}
-      className="flex-none group cursor-pointer"
+      className="flex-none group cursor-pointer rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-400 focus-visible:ring-offset-2"
       style={{ width: "11rem" }}
       onClick={() => onSelect?.(item)}
       onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onSelect?.(item); } }}
@@ -190,7 +190,7 @@ function ScrollArrows({
         type="button"
         onClick={() => onScroll("left")}
         disabled={!canScrollLeft}
-        className="flex h-8 w-8 items-center justify-center rounded-full transition-all disabled:opacity-30 disabled:cursor-default active:scale-95"
+        className="flex h-8 w-8 items-center justify-center rounded-full transition-all disabled:opacity-30 disabled:cursor-default active:scale-95 focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-400 focus-visible:ring-offset-2"
         style={{ border: "1px solid var(--border-strong)", background: "var(--bg-1)", color: "var(--text-dim)" }}
         aria-label="Scroll left"
       >
@@ -200,7 +200,7 @@ function ScrollArrows({
         type="button"
         onClick={() => onScroll("right")}
         disabled={!canScrollRight}
-        className="flex h-8 w-8 items-center justify-center rounded-full transition-all disabled:opacity-30 disabled:cursor-default active:scale-95"
+        className="flex h-8 w-8 items-center justify-center rounded-full transition-all disabled:opacity-30 disabled:cursor-default active:scale-95 focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-400 focus-visible:ring-offset-2"
         style={{ border: "1px solid var(--border-strong)", background: "var(--bg-1)", color: "var(--text-dim)" }}
         aria-label="Scroll right"
       >
@@ -635,7 +635,7 @@ export function DashboardPage() {
                         disabled={isMarking || isDone}
                         onClick={() => void handleMarkNext(s.imdbId)}
                         aria-label={isMarking ? "Marking" : isDone ? "Marked" : `Mark S${s.nextSeason}:E${s.nextEpisode}`}
-                        className={`mt-2 flex w-full items-center justify-center gap-1.5 rounded-lg py-2 text-xs font-semibold transition-all active:scale-[0.98] ${
+                        className={`mt-2 flex w-full items-center justify-center gap-1.5 rounded-lg py-2 text-xs font-semibold transition-all active:scale-[0.98] focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-400 focus-visible:ring-offset-2 ${
                           isMarking ? "bg-white/10 text-white/50" : isDone ? "bg-emerald-500/20 text-emerald-400" : "bg-white/15 text-white backdrop-blur-sm hover:bg-white/25"
                         }`}
                       >
@@ -807,7 +807,7 @@ export function DashboardPage() {
                 key={event.id}
                 role="button"
                 tabIndex={0}
-                className="flex-none group cursor-pointer"
+                className="flex-none group cursor-pointer rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-400 focus-visible:ring-offset-2"
                 style={{ width: "11rem" }}
                 onClick={() => setSelectedItem(toSearchResult(event.imdbId, event.type === "movie" ? "movie" : "series", event.name, { poster: event.poster }))}
                 onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); setSelectedItem(toSearchResult(event.imdbId, event.type === "movie" ? "movie" : "series", event.name, { poster: event.poster })); } }}

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -635,7 +635,7 @@ export function DashboardPage() {
                         disabled={isMarking || isDone}
                         onClick={() => void handleMarkNext(s.imdbId)}
                         aria-label={isMarking ? "Marking" : isDone ? "Marked" : `Mark S${s.nextSeason}:E${s.nextEpisode}`}
-                        className={`mt-2 flex w-full items-center justify-center gap-1.5 rounded-lg py-2 text-xs font-semibold transition-all active:scale-[0.98] focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-400 focus-visible:ring-offset-2 ${
+                        className={`mt-2 flex w-full items-center justify-center gap-1.5 rounded-lg py-2 text-xs font-semibold transition-all active:scale-[0.98] focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-claw-300 ${
                           isMarking ? "bg-white/10 text-white/50" : isDone ? "bg-emerald-500/20 text-emerald-400" : "bg-white/15 text-white backdrop-blur-sm hover:bg-white/25"
                         }`}
                       >

--- a/apps/web/src/pages/HistoryPage.tsx
+++ b/apps/web/src/pages/HistoryPage.tsx
@@ -162,7 +162,7 @@ export function HistoryPage() {
               key={opt}
               type="button"
               onClick={() => setTypeFilter(opt)}
-              className="relative rounded-full px-3 py-1.5 text-xs font-medium transition-colors"
+              className="relative rounded-full px-3 py-1.5 text-xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-400 focus-visible:ring-offset-2"
               style={
                 typeFilter === opt
                   ? { background: "var(--accent)", color: "white" }
@@ -198,7 +198,7 @@ export function HistoryPage() {
                   tabIndex={0}
                   onClick={() => setSelectedItem(toSearchResult(event))}
                   onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); setSelectedItem(toSearchResult(event)); } }}
-                  className="flex cursor-pointer items-center gap-3 rounded-xl p-3 transition-colors hover:bg-[var(--surface-strong)]"
+                  className="flex cursor-pointer items-center gap-3 rounded-xl p-3 transition-colors hover:bg-[var(--surface-strong)] focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-400 focus-visible:ring-offset-2"
                   style={{ border: "1px solid var(--border)", background: "var(--bg-1)" }}
                 >
                   <div
@@ -235,7 +235,7 @@ export function HistoryPage() {
                     type="button"
                     onClick={(e) => { e.stopPropagation(); void handleDelete(event.id); }}
                     disabled={deletingId === event.id}
-                    className="flex h-9 w-9 flex-none items-center justify-center rounded-lg transition-colors hover:bg-rose-500/10 disabled:opacity-50"
+                    className="flex h-9 w-9 flex-none items-center justify-center rounded-lg transition-colors hover:bg-rose-500/10 disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-rose-400 focus-visible:ring-offset-2"
                     aria-label="Delete watch event"
                     title="Remove from history"
                   >

--- a/apps/web/src/pages/ProfileSwitcher.tsx
+++ b/apps/web/src/pages/ProfileSwitcher.tsx
@@ -1,15 +1,30 @@
 import { FormEvent, useEffect, useState } from "react";
 import { AlertCircle, ArrowRight, Clapperboard, Loader2, Lock, Plus, User, X } from "lucide-react";
 import { api, ApiError, Profile, runtimeConfig } from "../api";
+import { useFocusTrap } from "../hooks/useFocusTrap";
 
 function Shell({ children, onClose }: { children: React.ReactNode; onClose?: () => void }) {
+  const dialogRef = useFocusTrap<HTMLDivElement>(!!onClose);
+
+  useEffect(() => {
+    if (!onClose) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [onClose]);
+
   if (onClose) {
     return (
       <div
         className="fixed inset-0 z-[200] flex items-center justify-center bg-black/50 px-6 py-12"
         onClick={onClose}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Switch profile"
       >
-        <div className="w-full max-w-md space-y-6" onClick={(e) => e.stopPropagation()}>
+        <div ref={dialogRef} tabIndex={-1} className="w-full max-w-md space-y-6" onClick={(e) => e.stopPropagation()}>
           <div className="flex items-center justify-center gap-2.5">
             <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-claw-500">
               <Clapperboard className="h-6 w-6 text-white" />

--- a/apps/web/src/pages/ProfileSwitcher.tsx
+++ b/apps/web/src/pages/ProfileSwitcher.tsx
@@ -1,8 +1,39 @@
 import { FormEvent, useEffect, useState } from "react";
-import { AlertCircle, ArrowRight, Clapperboard, Loader2, Lock, Plus, User } from "lucide-react";
+import { AlertCircle, ArrowRight, Clapperboard, Loader2, Lock, Plus, User, X } from "lucide-react";
 import { api, ApiError, Profile, runtimeConfig } from "../api";
 
-function Shell({ children }: { children: React.ReactNode }) {
+function Shell({ children, onClose }: { children: React.ReactNode; onClose?: () => void }) {
+  if (onClose) {
+    return (
+      <div
+        className="fixed inset-0 z-[200] flex items-center justify-center bg-black/50 px-6 py-12"
+        onClick={onClose}
+      >
+        <div className="w-full max-w-md space-y-6" onClick={(e) => e.stopPropagation()}>
+          <div className="flex items-center justify-center gap-2.5">
+            <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-claw-500">
+              <Clapperboard className="h-6 w-6 text-white" />
+            </div>
+            <span className="text-2xl font-bold" style={{ color: "var(--text)" }}>Cataloggy</span>
+          </div>
+
+          <div className="relative rounded-2xl border p-6 shadow-sm" style={{ borderColor: "var(--border)", background: "var(--bg-1)" }}>
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close"
+              className="absolute right-4 top-4 flex h-8 w-8 items-center justify-center rounded-full transition-colors hover:bg-[var(--surface-strong)] focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-400 focus-visible:ring-offset-2"
+              style={{ color: "var(--text-mute)" }}
+            >
+              <X className="h-4 w-4" />
+            </button>
+            {children}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="flex min-h-screen items-center justify-center px-6 py-12">
       <div className="w-full max-w-md space-y-6">
@@ -222,7 +253,7 @@ function ProfilePicker({
   );
 }
 
-export function ProfileSwitcher({ onSelected }: { onSelected: (profile: Profile) => void }) {
+export function ProfileSwitcher({ onSelected, onClose }: { onSelected: (profile: Profile) => void; onClose?: () => void }) {
   const [loading, setLoading] = useState(true);
   const [profiles, setProfiles] = useState<Profile[]>([]);
   const [error, setError] = useState<string | null>(null);
@@ -265,7 +296,7 @@ export function ProfileSwitcher({ onSelected }: { onSelected: (profile: Profile)
 
   if (loading) {
     return (
-      <Shell>
+      <Shell onClose={onClose}>
         <div className="flex items-center justify-center gap-2 py-6 text-sm" style={{ color: "var(--text-mute)" }}>
           <Loader2 size={16} className="animate-spin" /> Loading profiles...
         </div>
@@ -275,14 +306,14 @@ export function ProfileSwitcher({ onSelected }: { onSelected: (profile: Profile)
 
   if (error) {
     return (
-      <Shell>
+      <Shell onClose={onClose}>
         <p className="flex items-center gap-2 text-sm text-rose-600"><AlertCircle size={16} /> {error}</p>
       </Shell>
     );
   }
 
   return (
-    <Shell>
+    <Shell onClose={onClose}>
       {mode === "picker" && (
         <ProfilePicker profiles={profiles} onSelect={selectProfile} onCreateNew={() => setMode("create")} />
       )}

--- a/apps/web/src/pages/SearchPage.tsx
+++ b/apps/web/src/pages/SearchPage.tsx
@@ -274,7 +274,7 @@ export function SearchPage() {
             placeholder="Search movies & TV shows..."
             className="w-full rounded-full py-3.5 pl-14 pr-12 text-base placeholder:text-[var(--text-mute)] focus:border-claw-500 focus:outline-none focus:ring-2 focus:ring-claw-500/15 transition-all"
             style={{ borderWidth: 1, borderStyle: "solid", borderColor: "var(--border-strong)", background: "var(--bg-0)", color: "var(--text)" }}
-            autoFocus
+            autoFocus={typeof window !== "undefined" && !("ontouchstart" in window)}
           />
           {filters.query && (
             <button
@@ -735,33 +735,85 @@ function ResultCard({
 
 /* ─── Where to Watch Badge ────────────────────────────────── */
 
+// Module-level cache so repeated searches (and re-mounted cards) skip the network call entirely.
+const providerCache = new Map<string, WatchProvider[]>();
+
+// A single shared IntersectionObserver is far cheaper than one per card when a search
+// returns 10-20 results.
+type IntersectionCallback = (entry: IntersectionObserverEntry) => void;
+let sharedObserver: IntersectionObserver | null = null;
+const observerCallbacks = new WeakMap<Element, IntersectionCallback>();
+
+function getSharedObserver(): IntersectionObserver {
+  if (!sharedObserver) {
+    sharedObserver = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (!entry.isIntersecting) continue;
+          observerCallbacks.get(entry.target)?.(entry);
+        }
+      },
+      { rootMargin: "200px" }
+    );
+  }
+  return sharedObserver;
+}
+
+function observeOnce(node: Element, callback: IntersectionCallback) {
+  const observer = getSharedObserver();
+  observerCallbacks.set(node, (entry) => {
+    observer.unobserve(node);
+    observerCallbacks.delete(node);
+    callback(entry);
+  });
+  observer.observe(node);
+  return () => {
+    observer.unobserve(node);
+    observerCallbacks.delete(node);
+  };
+}
+
 function WhereToWatchBadge({ type, imdbId }: { type: SearchResult["type"]; imdbId: string }) {
-  const [providers, setProviders] = useState<WatchProvider[] | null>(null);
+  const cacheKey = `${type}:${imdbId}`;
+  const [providers, setProviders] = useState<WatchProvider[] | null>(providerCache.get(cacheKey) ?? null);
+  const [failed, setFailed] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
+    setFailed(false);
+    const cached = providerCache.get(cacheKey);
+    if (cached) {
+      setProviders(cached);
+      return;
+    }
+
     const node = ref.current;
     if (!node) return;
 
     let cancelled = false;
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (!entries[0]?.isIntersecting) return;
-        observer.disconnect();
-        api
-          .getWatchProviders(type, imdbId)
-          .then((r) => {
-            const merged = [...r.providers.flatrate, ...r.providers.free];
-            const deduped = merged.filter((p, i) => merged.findIndex((q) => q.id === p.id) === i);
-            if (!cancelled) setProviders(deduped);
-          })
-          .catch(() => { if (!cancelled) setProviders([]); });
-      },
-      { rootMargin: "200px" }
+    const fetchProviders = () => {
+      api
+        .getWatchProviders(type, imdbId)
+        .then((r) => {
+          const merged = [...r.providers.flatrate, ...r.providers.free];
+          const deduped = merged.filter((p, i) => merged.findIndex((q) => q.id === p.id) === i);
+          providerCache.set(cacheKey, deduped);
+          if (!cancelled) setProviders(deduped);
+        })
+        .catch(() => { if (!cancelled) setFailed(true); });
+    };
+
+    const unobserve = observeOnce(node, fetchProviders);
+    return () => { cancelled = true; unobserve(); };
+  }, [type, imdbId, cacheKey]);
+
+  if (failed) {
+    return (
+      <div ref={ref} className="mt-1.5 text-2xs" style={{ color: "var(--text-mute)" }} title="Failed to load streaming providers">
+        Providers unavailable
+      </div>
     );
-    observer.observe(node);
-    return () => { cancelled = true; observer.disconnect(); };
-  }, [type, imdbId]);
+  }
 
   if (!providers || providers.length === 0) return <div ref={ref} />;
 

--- a/apps/web/src/pages/SearchPage.tsx
+++ b/apps/web/src/pages/SearchPage.tsx
@@ -274,7 +274,7 @@ export function SearchPage() {
             placeholder="Search movies & TV shows..."
             className="w-full rounded-full py-3.5 pl-14 pr-12 text-base placeholder:text-[var(--text-mute)] focus:border-claw-500 focus:outline-none focus:ring-2 focus:ring-claw-500/15 transition-all"
             style={{ borderWidth: 1, borderStyle: "solid", borderColor: "var(--border-strong)", background: "var(--bg-0)", color: "var(--text)" }}
-            autoFocus={typeof window !== "undefined" && !("ontouchstart" in window)}
+            autoFocus={typeof window !== "undefined" && !window.matchMedia("(pointer: coarse)").matches}
           />
           {filters.query && (
             <button
@@ -791,20 +791,24 @@ function WhereToWatchBadge({ type, imdbId }: { type: SearchResult["type"]; imdbI
     if (!node) return;
 
     let cancelled = false;
+    const controller = new AbortController();
     const fetchProviders = () => {
       api
-        .getWatchProviders(type, imdbId)
+        .getWatchProviders(type, imdbId, controller.signal)
         .then((r) => {
           const merged = [...r.providers.flatrate, ...r.providers.free];
           const deduped = merged.filter((p, i) => merged.findIndex((q) => q.id === p.id) === i);
           providerCache.set(cacheKey, deduped);
           if (!cancelled) setProviders(deduped);
         })
-        .catch(() => { if (!cancelled) setFailed(true); });
+        .catch((err) => {
+          if (err instanceof DOMException && err.name === "AbortError") return;
+          if (!cancelled) setFailed(true);
+        });
     };
 
     const unobserve = observeOnce(node, fetchProviders);
-    return () => { cancelled = true; unobserve(); };
+    return () => { cancelled = true; unobserve(); controller.abort(); };
   }, [type, imdbId, cacheKey]);
 
   if (failed) {


### PR DESCRIPTION
## Summary
This PR adds a profile switcher UI that allows users to switch between profiles without reloading the page, and improves accessibility across the application by adding focus indicators to interactive elements.

## Key Changes

### Profile Management
- **New `ProfileProvider` hook** (`useProfile.tsx`): Manages profile state and switcher modal visibility globally
- **Profile switcher modal**: Integrated into the app shell, accessible from the sidebar and top navigation bar
- **Profile persistence**: Selected profile is stored in `runtimeConfig` and loaded on app startup
- **Profile display**: Shows current profile name in sidebar and top navigation
- **Seamless switching**: Routes are keyed by profile ID to ensure proper state reset when switching profiles

### UI/UX Improvements
- **Profile switcher modal**: Can now be opened/closed without page reload via `onClose` callback
- **Top navigation profile button**: Added User icon button in mobile header to access profile switcher
- **Sidebar profile button**: Added profile switcher button in sidebar with current profile name display
- **Settings page**: Updated to use the new profile context instead of page reload

### Performance Optimizations
- **Search page**: Added module-level cache for watch providers to avoid repeated API calls
- **Shared IntersectionObserver**: Replaced per-card observers with a single shared observer for watch provider badges, reducing memory overhead when displaying many search results
- **Lazy loading**: Watch provider badges only fetch data when they become visible in the viewport

### Accessibility Enhancements
- Added focus indicators (ring-2 focus-visible) to all interactive elements:
  - Navigation links in sidebar
  - Buttons in top navigation
  - Discovery cards on dashboard
  - Scroll arrows
  - Filter buttons in history page
  - Profile switcher modal close button
- **Search input**: Made `autoFocus` conditional to avoid focus on touch devices
- **Settings link**: Added focus indicators to match other buttons

## Implementation Details
- Profile switching is now non-destructive and maintains app state
- The `AppShell` component was extracted to properly use the `ProfileProvider` context
- Watch provider caching uses a `Map` to persist across component remounts
- The shared `IntersectionObserver` uses a `WeakMap` to track callbacks per element, preventing memory leaks

https://claude.ai/code/session_01MSrgb2WizPX5tDZe6qYprZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added profile switching across the app, including a dedicated switcher on desktop and mobile.
  * The current profile now appears in profile settings when available.

* **Bug Fixes**
  * Improved profile persistence so the selected profile stays active across navigation.
  * Search results now avoid unnecessary provider lookups and show a clearer message when provider data can’t be loaded.

* **Accessibility**
  * Added visible keyboard focus states to dashboards, history, sidebar, and navigation controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->