### PR TITLE
Improve modal and toast UX with scroll lock and escape key handling

### DIFF
--- a/apps/web/src/components/MediaDetailPanel.tsx
+++ b/apps/web/src/components/MediaDetailPanel.tsx
@@ -14,6 +14,8 @@ import { WatchHistorySection } from "./media-detail/WatchHistorySection";
 import { DropShowButton } from "./media-detail/DropShowButton";
 import { formatRuntime, statusColor, WatchLogTarget } from "./media-detail/detailPanelUtils";
 import { useFocusTrap } from "../hooks/useFocusTrap";
+import { useScrollLock } from "../hooks/useScrollLock";
+import { useEscapeKey } from "../hooks/useEscapeKey";
 
 export { StarRating };
 
@@ -39,18 +41,8 @@ export function DetailPanel({
   const listNames = item.lists.map((id) => listMap.get(id)?.name).filter(Boolean) as string[];
   const dialogRef = useFocusTrap<HTMLDivElement>();
 
-  // Lock background scroll while the panel is open
-  useEffect(() => {
-    const previousOverflow = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
-    return () => { document.body.style.overflow = previousOverflow; };
-  }, []);
-
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
-    document.addEventListener("keydown", handler);
-    return () => document.removeEventListener("keydown", handler);
-  }, [onClose]);
+  useScrollLock();
+  useEscapeKey(onClose);
 
   // Cast
   const [cast, setCast] = useState<CastMember[]>([]);
@@ -400,12 +392,6 @@ export function useDetailPanel() {
   const [selectedItem, setSelectedItem] = useState<SearchResult | null>(null);
   const [panelHistory, setPanelHistory] = useState<WatchEvent[]>([]);
   const [panelHistoryLoading, setPanelHistoryLoading] = useState(false);
-
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => { if (e.key === "Escape") setSelectedItem(null); };
-    document.addEventListener("keydown", handler);
-    return () => document.removeEventListener("keydown", handler);
-  }, []);
 
   useEffect(() => {
     if (!selectedItem) return;

--- a/apps/web/src/components/media-detail/CheckInModal.tsx
+++ b/apps/web/src/components/media-detail/CheckInModal.tsx
@@ -1,6 +1,8 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Radio, X } from "lucide-react";
 import { useFocusTrap } from "../../hooks/useFocusTrap";
+import { useScrollLock } from "../../hooks/useScrollLock";
+import { useEscapeKey } from "../../hooks/useEscapeKey";
 
 export function CheckInModal({
   seriesName,
@@ -21,11 +23,8 @@ export function CheckInModal({
   const [error, setError] = useState<string | null>(null);
   const dialogRef = useFocusTrap<HTMLDivElement>();
 
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
-    document.addEventListener("keydown", handler);
-    return () => document.removeEventListener("keydown", handler);
-  }, [onClose]);
+  useScrollLock();
+  useEscapeKey(onClose);
 
   const submit = async () => {
     const s = parseInt(season, 10);

--- a/apps/web/src/components/media-detail/WatchDateModal.tsx
+++ b/apps/web/src/components/media-detail/WatchDateModal.tsx
@@ -2,6 +2,8 @@ import { useState } from "react";
 import { X } from "lucide-react";
 import { WatchLogTarget } from "./detailPanelUtils";
 import { useFocusTrap } from "../../hooks/useFocusTrap";
+import { useScrollLock } from "../../hooks/useScrollLock";
+import { useEscapeKey } from "../../hooks/useEscapeKey";
 
 export function WatchDateModal({
   target,
@@ -17,6 +19,9 @@ export function WatchDateModal({
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const dialogRef = useFocusTrap<HTMLDivElement>();
+
+  useScrollLock();
+  useEscapeKey(onClose);
 
   // For episode mode: let user pick season+episode
   const [season, setSeason] = useState(target.kind === "episode" ? target.season : 1);

--- a/apps/web/src/hooks/useEscapeKey.ts
+++ b/apps/web/src/hooks/useEscapeKey.ts
@@ -1,0 +1,34 @@
+import { useEffect, useRef } from "react";
+
+let stack: Array<() => void> = [];
+
+/**
+ * Registers `onEscape` for the Escape key, but only the most recently
+ * mounted handler (i.e. the topmost modal in a stack) actually fires.
+ * Prevents nested modals (e.g. a sub-modal opened on top of a detail panel)
+ * from all closing at once on a single Escape press.
+ */
+export function useEscapeKey(onEscape: () => void, active = true) {
+  const callbackRef = useRef(onEscape);
+  callbackRef.current = onEscape;
+
+  useEffect(() => {
+    if (!active) return;
+
+    const entry = () => callbackRef.current();
+    stack.push(entry);
+
+    return () => {
+      stack = stack.filter((e) => e !== entry);
+    };
+  }, [active]);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key !== "Escape" || stack.length === 0) return;
+      stack[stack.length - 1]();
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, []);
+}

--- a/apps/web/src/hooks/useScrollLock.ts
+++ b/apps/web/src/hooks/useScrollLock.ts
@@ -1,0 +1,38 @@
+import { useEffect } from "react";
+
+let lockCount = 0;
+let savedScrollY = 0;
+
+/**
+ * Locks background scroll while active, ref-counted so nested/stacked modals
+ * don't fight over restoring `overflow`. Uses `position: fixed` on the body
+ * (rather than just `overflow: hidden`) because iOS Safari ignores
+ * `overflow: hidden` and keeps scrolling the page behind a fixed overlay.
+ */
+export function useScrollLock(active = true) {
+  useEffect(() => {
+    if (!active) return;
+
+    if (lockCount === 0) {
+      savedScrollY = window.scrollY;
+      document.body.style.position = "fixed";
+      document.body.style.top = `-${savedScrollY}px`;
+      document.body.style.left = "0";
+      document.body.style.right = "0";
+      document.body.style.width = "100%";
+    }
+    lockCount += 1;
+
+    return () => {
+      lockCount -= 1;
+      if (lockCount === 0) {
+        document.body.style.position = "";
+        document.body.style.top = "";
+        document.body.style.left = "";
+        document.body.style.right = "";
+        document.body.style.width = "";
+        window.scrollTo(0, savedScrollY);
+      }
+    };
+  }, [active]);
+}

--- a/apps/web/src/hooks/useToast.tsx
+++ b/apps/web/src/hooks/useToast.tsx
@@ -5,26 +5,36 @@ export type Toast = { id: number; message: string; type: "success" | "error" | "
 
 let toastId = 0;
 
+const MAX_VISIBLE_TOASTS = 3;
+
 type ToastContextValue = {
   showToast: (message: string, type?: Toast["type"]) => void;
 };
 
 const ToastContext = createContext<ToastContextValue | null>(null);
 
-function ToastContainer({ toasts }: { toasts: Toast[] }) {
+function ToastContainer({ toasts, onDismiss }: { toasts: Toast[]; onDismiss: (id: number) => void }) {
+  const visible = toasts.slice(-MAX_VISIBLE_TOASTS);
+  const hiddenCount = toasts.length - visible.length;
+
   return (
     <div role="status" aria-live="polite" aria-atomic="true" className="fixed bottom-6 right-6 z-[100] flex flex-col gap-3 sm:bottom-6 max-sm:bottom-20 max-sm:right-4">
-      {toasts.map((toast) => (
+      {hiddenCount > 0 && (
+        <span className="self-end text-xs font-medium" style={{ color: "var(--text-mute)" }}>
+          +{hiddenCount} more
+        </span>
+      )}
+      {visible.map((toast) => (
         <div
           key={toast.id}
-          className={`toast-enter flex items-center gap-3 rounded-xl border bg-cream-50 px-5 py-3.5 shadow-md ${
+          className={`toast-enter flex items-center gap-3 rounded-xl border px-5 py-3.5 shadow-md ${
             toast.type === "success"
               ? "border-emerald-500/30"
               : toast.type === "error"
                 ? "border-rose-500/30"
                 : "border-claw-500/30"
           }`}
-          style={{ borderLeftWidth: "4px" }}
+          style={{ borderLeftWidth: "4px", background: "var(--bg-1)" }}
         >
           {toast.type === "success" ? (
             <Check aria-hidden="true" className="h-5 w-5 flex-none text-emerald-500" />
@@ -34,6 +44,15 @@ function ToastContainer({ toasts }: { toasts: Toast[] }) {
             <Heart aria-hidden="true" className="h-5 w-5 flex-none text-claw-600" />
           )}
           <span className="text-sm font-medium" style={{ color: "var(--text)" }}>{toast.message}</span>
+          <button
+            type="button"
+            onClick={() => onDismiss(toast.id)}
+            aria-label="Dismiss notification"
+            className="ml-1 flex-none rounded-md p-1 hover:bg-[var(--surface-strong)]"
+            style={{ color: "var(--text-mute)" }}
+          >
+            <X aria-hidden="true" className="h-3.5 w-3.5" />
+          </button>
         </div>
       ))}
     </div>
@@ -43,18 +62,20 @@ function ToastContainer({ toasts }: { toasts: Toast[] }) {
 export function ToastProvider({ children }: { children: ReactNode }) {
   const [toasts, setToasts] = useState<Toast[]>([]);
 
+  const dismissToast = useCallback((id: number) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
   const showToast = useCallback((message: string, type: Toast["type"] = "success") => {
     const id = ++toastId;
     setToasts((prev) => [...prev, { id, message, type }]);
-    setTimeout(() => {
-      setToasts((prev) => prev.filter((t) => t.id !== id));
-    }, 3000);
-  }, []);
+    setTimeout(() => dismissToast(id), 3000);
+  }, [dismissToast]);
 
   return (
     <ToastContext.Provider value={{ showToast }}>
       {children}
-      <ToastContainer toasts={toasts} />
+      <ToastContainer toasts={toasts} onDismiss={dismissToast} />
     </ToastContext.Provider>
   );
 }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -232,6 +232,30 @@ body {
   animation: toast-out 0.3s ease forwards;
 }
 
+@media (max-width: 640px) {
+  @keyframes toast-in {
+    from {
+      opacity: 0;
+      transform: translateX(50px);
+    }
+    to {
+      opacity: 1;
+      transform: translateX(0);
+    }
+  }
+
+  @keyframes toast-out {
+    from {
+      opacity: 1;
+      transform: translateX(0);
+    }
+    to {
+      opacity: 0;
+      transform: translateX(50px);
+    }
+  }
+}
+
 /* Star rating pop-in + shake animation */
 @keyframes star-pop-in {
   0% {

--- a/apps/web/src/pages/ListsPage.tsx
+++ b/apps/web/src/pages/ListsPage.tsx
@@ -4,6 +4,8 @@ import { api, CatalogList, ListItemWithMeta, MediaType, SearchResult } from "../
 import { DetailPanel, useDetailPanel } from "../components/MediaDetailPanel";
 import { useFocusTrap } from "../hooks/useFocusTrap";
 import { useToast } from "../hooks/useToast";
+import { useScrollLock } from "../hooks/useScrollLock";
+import { useEscapeKey } from "../hooks/useEscapeKey";
 
 type SortOption = "added" | "name" | "year" | "rating";
 
@@ -54,13 +56,8 @@ function AddItemModal({
     inputRef.current?.focus();
   }, []);
 
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    document.addEventListener("keydown", handler);
-    return () => document.removeEventListener("keydown", handler);
-  }, [onClose]);
+  useScrollLock();
+  useEscapeKey(onClose);
 
   const doSearch = useCallback(async (q: string, t: MediaType) => {
     if (!q.trim()) {


### PR DESCRIPTION
## Summary
This PR enhances the user experience for modals and toasts by introducing reusable utilities for managing scroll locking and escape key handling, along with improvements to the toast notification system.

## Key Changes

- **New `useScrollLock` hook**: Provides ref-counted scroll locking for modals using `position: fixed` on the body (with special handling for iOS Safari which ignores `overflow: hidden`). Supports nested/stacked modals without conflicts.

- **New `useEscapeKey` hook**: Implements a stack-based escape key handler that ensures only the topmost modal closes on Escape, preventing nested modals from all closing simultaneously.

- **Toast improvements**:
  - Added maximum visible toast limit (3 toasts) with a "+N more" indicator for hidden notifications
  - Added manual dismiss button (X icon) to each toast
  - Refactored auto-dismiss logic to use the new `dismissToast` callback
  - Updated styling to use CSS variables for better theme consistency
  - Added mobile-specific toast animations (translateX instead of default)

- **Refactored modal implementations**: Updated `DetailPanel`, `CheckInModal`, `WatchDateModal`, and `AddItemModal` to use the new `useScrollLock` and `useEscapeKey` hooks, removing duplicate scroll-locking and escape-key logic.

## Implementation Details

- The `useScrollLock` hook uses a global `lockCount` to handle nested modals gracefully, only applying/removing styles when transitioning from 0 to 1+ locks or back to 0.
- The `useEscapeKey` hook maintains a global stack of handlers, with only the most recently mounted handler executing on Escape key press.
- Toast styling now uses CSS variables (`--bg-1`, `--text`, `--text-mute`) for better theme integration.
- Mobile toast animations are defined in a media query to provide better UX on smaller screens.

https://claude.ai/code/session_01JYVXECbpoSEjFTgnxeqcVD