### PR TITLE
Add AniList integration, year-in-review stats, and collection list

### DIFF
--- a/apps/api/prisma/migrations/20260626130000_collection_singleton_constraint/migration.sql
+++ b/apps/api/prisma/migrations/20260626130000_collection_singleton_constraint/migration.sql
@@ -2,4 +2,4 @@ ALTER TYPE "ListKind" ADD VALUE 'collection';
 
 -- Enforce at most one default collection (kind = 'collection') at the database level,
 -- mirroring the watchlist singleton constraint above.
-CREATE UNIQUE INDEX "List_collection_singleton_key" ON "List"("kind") WHERE "kind" = 'collection';
+CREATE UNIQUE INDEX "List_collection_singleton_key" ON "List"("profileId", "kind") WHERE "kind" = 'collection';

--- a/apps/api/prisma/migrations/20260626130000_collection_singleton_constraint/migration.sql
+++ b/apps/api/prisma/migrations/20260626130000_collection_singleton_constraint/migration.sql
@@ -1,0 +1,5 @@
+ALTER TYPE "ListKind" ADD VALUE 'collection';
+
+-- Enforce at most one default collection (kind = 'collection') at the database level,
+-- mirroring the watchlist singleton constraint above.
+CREATE UNIQUE INDEX "List_collection_singleton_key" ON "List"("kind") WHERE "kind" = 'collection';

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -16,6 +16,7 @@ enum ItemType {
 enum ListKind {
   watchlist
   custom
+  collection
 }
 
 enum ListItemType {
@@ -71,10 +72,11 @@ model Item {
   @@unique([type, imdbId])
 }
 
-// A partial unique index on kind = 'watchlist' (migration 20260617120000) enforces
-// that at most one default watchlist exists. Prisma's schema DSL has no syntax for
-// partial unique indexes, so it isn't declared here — don't let `prisma migrate dev`
-// generate a migration that drops it.
+// Partial unique indexes on kind = 'watchlist' (migration 20260617120000) and
+// kind = 'collection' (migration 20260626130000) enforce that at most one default
+// watchlist and one default collection exist. Prisma's schema DSL has no syntax for
+// partial unique indexes, so they aren't declared here — don't let `prisma migrate dev`
+// generate a migration that drops them.
 model List {
   id        String     @id @default(uuid()) @db.Uuid
   name      String

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -8,6 +8,7 @@ import { getAiRecommendations, isAiConfigured } from "./lib/ai.js";
 import { trendingCacheDeletePrefix } from "./lib/cache.js";
 import { pollTraktHistory, syncTraktWatchlist } from "./lib/trakt-client.js";
 import { ensureDefaultWatchlist } from "./lib/watchlist.js";
+import { ensureDefaultCollection } from "./lib/collection.js";
 import { getDefaultProfileId } from "./lib/profile.js";
 import { checkUpcomingEpisodesAndNotify } from "./lib/notify-episodes.js";
 import { cleanupStaleSessions, SCROBBLE_CLEANUP_INTERVAL_MS } from "./routes/scrobble.js";
@@ -130,6 +131,7 @@ const start = async () => {
   }
 
   await ensureDefaultWatchlist();
+  await ensureDefaultCollection();
 
   if (TRAKT_POLL_INTERVAL_SEC > 0) {
     setInterval(() => {

--- a/apps/api/src/lib/anilist-client.test.ts
+++ b/apps/api/src/lib/anilist-client.test.ts
@@ -130,5 +130,14 @@ describe("anilist-client", () => {
       expect(numbering.totalEpisodes).toBe(0);
       expect(numbering.absoluteEpisode(7)).toBe(7);
     });
+
+    it("clamps to 1 even when total episodes is unknown", async () => {
+      const { toAbsoluteEpisodeNumbering } = await import("./anilist-client.js");
+      const numbering = toAbsoluteEpisodeNumbering({
+        id: 1, title: "Test", episodes: null, coverImage: null, format: "TV",
+      });
+      expect(numbering.absoluteEpisode(0)).toBe(1);
+      expect(numbering.absoluteEpisode(-5)).toBe(1);
+    });
   });
 });

--- a/apps/api/src/lib/anilist-client.test.ts
+++ b/apps/api/src/lib/anilist-client.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockFetchOnce = (body: unknown, ok = true, status = 200) => {
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+    ok,
+    status,
+    json: async () => body,
+  }));
+};
+
+describe("anilist-client", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe("searchAnime", () => {
+    it("returns an empty array for a blank query without calling fetch", async () => {
+      const fetchSpy = vi.fn();
+      vi.stubGlobal("fetch", fetchSpy);
+      const { searchAnime } = await import("./anilist-client.js");
+      expect(await searchAnime("   ")).toEqual([]);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it("maps AniList media into simplified search results", async () => {
+      mockFetchOnce({
+        data: {
+          Page: {
+            media: [
+              {
+                id: 1,
+                episodes: 24,
+                coverImage: { large: "https://example.com/cover.jpg" },
+                title: { english: "Cowboy Bebop", romaji: "Cowboy Bebop", native: null },
+              },
+            ],
+          },
+        },
+      });
+
+      const { searchAnime } = await import("./anilist-client.js");
+      const results = await searchAnime("cowboy bebop");
+      expect(results).toEqual([
+        { id: 1, title: "Cowboy Bebop", episodes: 24, coverImage: "https://example.com/cover.jpg" },
+      ]);
+    });
+
+    it("falls back to romaji or native title when english is missing", async () => {
+      mockFetchOnce({
+        data: {
+          Page: {
+            media: [
+              { id: 2, episodes: null, coverImage: { large: null }, title: { english: null, romaji: "Shingeki", native: null } },
+            ],
+          },
+        },
+      });
+
+      const { searchAnime } = await import("./anilist-client.js");
+      const results = await searchAnime("attack on titan");
+      expect(results[0].title).toBe("Shingeki");
+    });
+
+    it("throws when AniList returns a non-OK response", async () => {
+      mockFetchOnce({}, false, 500);
+      const { searchAnime } = await import("./anilist-client.js");
+      await expect(searchAnime("test")).rejects.toThrow("AniList request failed with status 500");
+    });
+
+    it("throws when AniList returns GraphQL errors", async () => {
+      mockFetchOnce({ errors: [{ message: "Invalid request" }] });
+      const { searchAnime } = await import("./anilist-client.js");
+      await expect(searchAnime("test")).rejects.toThrow("Invalid request");
+    });
+  });
+
+  describe("getAnimeById", () => {
+    it("maps a single media entry into anime details", async () => {
+      mockFetchOnce({
+        data: {
+          Media: {
+            id: 5,
+            episodes: 12,
+            format: "TV",
+            coverImage: { large: "https://example.com/x.jpg" },
+            title: { english: "Test Anime", romaji: "Tesuto Anime", native: null },
+          },
+        },
+      });
+
+      const { getAnimeById } = await import("./anilist-client.js");
+      const result = await getAnimeById(5);
+      expect(result).toEqual({
+        id: 5,
+        title: "Test Anime",
+        episodes: 12,
+        coverImage: "https://example.com/x.jpg",
+        format: "TV",
+      });
+    });
+
+    it("returns null when AniList has no matching media", async () => {
+      mockFetchOnce({ data: { Media: null } });
+      const { getAnimeById } = await import("./anilist-client.js");
+      expect(await getAnimeById(999)).toBeNull();
+    });
+  });
+
+  describe("toAbsoluteEpisodeNumbering", () => {
+    it("clamps episode numbers within the anime's total episode count", async () => {
+      const { toAbsoluteEpisodeNumbering } = await import("./anilist-client.js");
+      const numbering = toAbsoluteEpisodeNumbering({
+        id: 1, title: "Test", episodes: 12, coverImage: null, format: "TV",
+      });
+      expect(numbering.totalEpisodes).toBe(12);
+      expect(numbering.absoluteEpisode(5)).toBe(5);
+      expect(numbering.absoluteEpisode(15)).toBe(12);
+      expect(numbering.absoluteEpisode(0)).toBe(1);
+    });
+
+    it("passes through the requested episode when total episodes is unknown", async () => {
+      const { toAbsoluteEpisodeNumbering } = await import("./anilist-client.js");
+      const numbering = toAbsoluteEpisodeNumbering({
+        id: 1, title: "Test", episodes: null, coverImage: null, format: "TV",
+      });
+      expect(numbering.totalEpisodes).toBe(0);
+      expect(numbering.absoluteEpisode(7)).toBe(7);
+    });
+  });
+});

--- a/apps/api/src/lib/anilist-client.ts
+++ b/apps/api/src/lib/anilist-client.ts
@@ -1,0 +1,130 @@
+import { LRUCache } from "lru-cache";
+
+const ANILIST_API_URL = "https://graphql.anilist.co";
+const ANILIST_CACHE_TTL_MS = 60 * 60 * 1000;
+
+export type AniListSearchResult = {
+  id: number;
+  title: string;
+  episodes: number | null;
+  coverImage: string | null;
+};
+
+export type AniListAnimeDetails = {
+  id: number;
+  title: string;
+  episodes: number | null;
+  coverImage: string | null;
+  format: string | null;
+};
+
+const NOT_FOUND = Symbol("anilist-not-found");
+
+const searchCache = new LRUCache<string, AniListSearchResult[]>({ max: 200, ttl: ANILIST_CACHE_TTL_MS });
+const byIdCache = new LRUCache<number, AniListAnimeDetails | typeof NOT_FOUND>({ max: 500, ttl: ANILIST_CACHE_TTL_MS });
+
+const titleOf = (title: { english: string | null; romaji: string | null; native: string | null }): string =>
+  title.english ?? title.romaji ?? title.native ?? "Unknown";
+
+const query = async <T>(graphqlQuery: string, variables: Record<string, unknown>): Promise<T> => {
+  const res = await fetch(ANILIST_API_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ query: graphqlQuery, variables }),
+    signal: AbortSignal.timeout(8000),
+  });
+
+  if (!res.ok) {
+    throw new Error(`AniList request failed with status ${res.status}`);
+  }
+
+  const json = await res.json() as { data?: T; errors?: Array<{ message: string }> };
+  if (json.errors?.length) {
+    throw new Error(`AniList request failed: ${json.errors.map((e) => e.message).join(", ")}`);
+  }
+  if (!json.data) {
+    throw new Error("AniList request returned no data");
+  }
+  return json.data;
+};
+
+export const searchAnime = async (search: string): Promise<AniListSearchResult[]> => {
+  const trimmed = search.trim();
+  if (!trimmed) return [];
+
+  const cached = searchCache.get(trimmed);
+  if (cached) return cached;
+
+  const data = await query<{
+    Page: { media: Array<{ id: number; episodes: number | null; coverImage: { large: string | null }; title: { english: string | null; romaji: string | null; native: string | null } }> };
+  }>(
+    `query ($search: String) {
+      Page(perPage: 10) {
+        media(search: $search, type: ANIME) {
+          id
+          episodes
+          coverImage { large }
+          title { english romaji native }
+        }
+      }
+    }`,
+    { search: trimmed }
+  );
+
+  const results = data.Page.media.map((m) => ({
+    id: m.id,
+    title: titleOf(m.title),
+    episodes: m.episodes,
+    coverImage: m.coverImage.large,
+  }));
+
+  searchCache.set(trimmed, results);
+  return results;
+};
+
+export const getAnimeById = async (id: number): Promise<AniListAnimeDetails | null> => {
+  const cached = byIdCache.get(id);
+  if (cached !== undefined) return cached === NOT_FOUND ? null : cached;
+
+  const data = await query<{
+    Media: { id: number; episodes: number | null; format: string | null; coverImage: { large: string | null }; title: { english: string | null; romaji: string | null; native: string | null } } | null;
+  }>(
+    `query ($id: Int) {
+      Media(id: $id, type: ANIME) {
+        id
+        episodes
+        format
+        coverImage { large }
+        title { english romaji native }
+      }
+    }`,
+    { id }
+  );
+
+  const result = data.Media
+    ? {
+        id: data.Media.id,
+        title: titleOf(data.Media.title),
+        episodes: data.Media.episodes,
+        coverImage: data.Media.coverImage.large,
+        format: data.Media.format,
+      }
+    : null;
+
+  byIdCache.set(id, result ?? NOT_FOUND);
+  return result;
+};
+
+/**
+ * Maps an AniList anime's total episode count into a flat absolute-episode
+ * numbering scheme (1..episodes), independent of TMDB's season/episode split.
+ */
+export const toAbsoluteEpisodeNumbering = (
+  anime: AniListAnimeDetails
+): { totalEpisodes: number; absoluteEpisode: (n: number) => number } => {
+  const totalEpisodes = anime.episodes ?? 0;
+  return {
+    totalEpisodes,
+    absoluteEpisode: (n: number) => Math.min(Math.max(n, 1), totalEpisodes || n),
+  };
+};

--- a/apps/api/src/lib/anilist-client.ts
+++ b/apps/api/src/lib/anilist-client.ts
@@ -125,6 +125,9 @@ export const toAbsoluteEpisodeNumbering = (
   const totalEpisodes = anime.episodes ?? 0;
   return {
     totalEpisodes,
-    absoluteEpisode: (n: number) => Math.min(Math.max(n, 1), totalEpisodes || n),
+    absoluteEpisode: (n: number) => {
+      const normalized = Math.max(n, 1);
+      return totalEpisodes > 0 ? Math.min(normalized, totalEpisodes) : normalized;
+    },
   };
 };

--- a/apps/api/src/lib/collection.ts
+++ b/apps/api/src/lib/collection.ts
@@ -5,7 +5,7 @@ import { getDefaultProfileId } from "./profile.js";
 export const ensureDefaultCollection = async () => {
   const profileId = await getDefaultProfileId();
   const existing = await prisma.list.findFirst({
-    where: { kind: ListKind.collection, name: "Collection", profileId },
+    where: { kind: ListKind.collection, profileId },
   });
   if (existing) return;
 
@@ -24,13 +24,24 @@ export const getDefaultCollection = async (profileId?: string) => {
   const resolvedProfileId = profileId ?? (await getDefaultProfileId());
 
   const collection = await prisma.list.findFirst({
-    where: { kind: ListKind.collection, name: "Collection", profileId: resolvedProfileId },
+    where: { kind: ListKind.collection, profileId: resolvedProfileId },
     orderBy: { createdAt: "asc" },
   });
 
   if (collection) return collection;
 
-  return prisma.list.create({
-    data: { kind: ListKind.collection, name: "Collection", profileId: resolvedProfileId },
-  });
+  try {
+    return await prisma.list.create({
+      data: { kind: ListKind.collection, name: "Collection", profileId: resolvedProfileId },
+    });
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
+      const retry = await prisma.list.findFirst({
+        where: { kind: ListKind.collection, profileId: resolvedProfileId },
+        orderBy: { createdAt: "asc" },
+      });
+      if (retry) return retry;
+    }
+    throw error;
+  }
 };

--- a/apps/api/src/lib/collection.ts
+++ b/apps/api/src/lib/collection.ts
@@ -1,0 +1,36 @@
+import { ListKind, Prisma } from "@prisma/client";
+import { prisma } from "./prisma.js";
+import { getDefaultProfileId } from "./profile.js";
+
+export const ensureDefaultCollection = async () => {
+  const profileId = await getDefaultProfileId();
+  const existing = await prisma.list.findFirst({
+    where: { kind: ListKind.collection, name: "Collection", profileId },
+  });
+  if (existing) return;
+
+  try {
+    await prisma.list.create({ data: { kind: ListKind.collection, name: "Collection", profileId } });
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
+      // race condition — another instance created it first
+      return;
+    }
+    throw error;
+  }
+};
+
+export const getDefaultCollection = async (profileId?: string) => {
+  const resolvedProfileId = profileId ?? (await getDefaultProfileId());
+
+  const collection = await prisma.list.findFirst({
+    where: { kind: ListKind.collection, name: "Collection", profileId: resolvedProfileId },
+    orderBy: { createdAt: "asc" },
+  });
+
+  if (collection) return collection;
+
+  return prisma.list.create({
+    data: { kind: ListKind.collection, name: "Collection", profileId: resolvedProfileId },
+  });
+};

--- a/apps/api/src/routes/lists.ts
+++ b/apps/api/src/routes/lists.ts
@@ -20,7 +20,7 @@ const listsRoutes: FastifyPluginAsync = async (app) => {
     }
 
     if (!Object.values(ListKind).includes(body.kind as ListKind)) {
-      return reply.code(400).send({ error: "kind must be one of: watchlist, custom" });
+      return reply.code(400).send({ error: "kind must be one of: watchlist, custom, collection" });
     }
 
     const list = await prisma.list.create({

--- a/apps/api/src/routes/metadata.ts
+++ b/apps/api/src/routes/metadata.ts
@@ -7,6 +7,7 @@ import { getRpdbApiKey, withRpdbPoster } from "../lib/rpdb.js";
 import { getMetadataType } from "../lib/types.js";
 import { castCache, seasonsCache, watchProvidersCache } from "../lib/cache.js";
 import { getRegionSetting } from "../lib/settings.js";
+import { searchAnime } from "../lib/anilist-client.js";
 
 const metadataRoutes: FastifyPluginAsync = async (app) => {
   app.get<{ Params: { type: string; imdbId: string } }>(
@@ -258,6 +259,21 @@ const metadataRoutes: FastifyPluginAsync = async (app) => {
     }
 
     return reply.send({ refreshed, total: allMetadata.length, limit });
+  });
+
+  app.get<{ Querystring: { q?: string } }>("/metadata/anime-search", async (request, reply) => {
+    const q = request.query.q?.trim();
+    if (!q) {
+      return reply.code(400).send({ error: "q is required" });
+    }
+
+    try {
+      const results = await searchAnime(q);
+      return { results };
+    } catch (error) {
+      request.log.error(error, "AniList search failed");
+      return reply.code(502).send({ error: "AniList search failed" });
+    }
   });
 
   app.get("/genres", async () => {

--- a/apps/api/src/routes/search.ts
+++ b/apps/api/src/routes/search.ts
@@ -57,15 +57,16 @@ const searchRoutes: FastifyPluginAsync = async (app) => {
       ]);
 
       const listInfoKey = (imdbId: string, mediaType: string) => `${mediaType}:${imdbId}`;
-      const listInfoByKey = new Map<string, { inWatchlist: boolean; lists: string[] }>();
+      const listInfoByKey = new Map<string, { inWatchlist: boolean; inCollection: boolean; lists: string[] }>();
       for (const item of listItems) {
         const key = listInfoKey(item.imdbId, item.type);
         let info = listInfoByKey.get(key);
         if (!info) {
-          info = { inWatchlist: false, lists: [] };
+          info = { inWatchlist: false, inCollection: false, lists: [] };
           listInfoByKey.set(key, info);
         }
         if (item.list.kind === ListKind.watchlist) info.inWatchlist = true;
+        if (item.list.kind === ListKind.collection) info.inCollection = true;
         info.lists.push(item.list.id);
       }
 
@@ -81,6 +82,7 @@ const searchRoutes: FastifyPluginAsync = async (app) => {
           genres: result.genres,
           rating: result.rating,
           inWatchlist: info?.inWatchlist ?? false,
+          inCollection: info?.inCollection ?? false,
           lists: info?.lists ?? [],
         };
       });

--- a/apps/api/src/routes/watch.ts
+++ b/apps/api/src/routes/watch.ts
@@ -354,8 +354,11 @@ const watchRoutes: FastifyPluginAsync = async (app) => {
 
   app.get<{ Params: { year: string } }>("/watch/stats/year/:year", async (request, reply) => {
     const profileId = request.profileId!;
+    if (!/^\d{4}$/.test(request.params.year)) {
+      return reply.code(400).send({ error: "year must be a valid 4-digit year" });
+    }
     const year = Number(request.params.year);
-    if (!Number.isInteger(year) || year < 1900 || year > 9999) {
+    if (year < 1900) {
       return reply.code(400).send({ error: "year must be a valid 4-digit year" });
     }
 

--- a/apps/api/src/routes/watch.ts
+++ b/apps/api/src/routes/watch.ts
@@ -351,6 +351,101 @@ const watchRoutes: FastifyPluginAsync = async (app) => {
       })),
     };
   });
+
+  app.get<{ Params: { year: string } }>("/watch/stats/year/:year", async (request, reply) => {
+    const profileId = request.profileId!;
+    const year = Number(request.params.year);
+    if (!Number.isInteger(year) || year < 1900 || year > 9999) {
+      return reply.code(400).send({ error: "year must be a valid 4-digit year" });
+    }
+
+    const yearStart = new Date(Date.UTC(year, 0, 1));
+    const yearEnd = new Date(Date.UTC(year + 1, 0, 1));
+
+    const [events, topRatings] = await Promise.all([
+      prisma.watchEvent.findMany({
+        where: { profileId, watchedAt: { gte: yearStart, lt: yearEnd } },
+        select: { type: true, imdbId: true, seriesImdbId: true, watchedAt: true, plays: true },
+      }),
+      prisma.rating.findMany({
+        where: { profileId, ratedAt: { gte: yearStart, lt: yearEnd }, type: { in: ["movie", "series"] } },
+        orderBy: { rating: "desc" },
+        take: 10,
+        select: { imdbId: true, type: true, rating: true },
+      }),
+    ]);
+
+    const totalMovies = events.filter((e) => e.type === "movie").reduce((sum, e) => sum + e.plays, 0);
+    const totalEpisodes = events.filter((e) => e.type === "episode").reduce((sum, e) => sum + e.plays, 0);
+
+    const movieImdbIds = events.filter((e) => e.type === "movie").map((e) => e.imdbId);
+    const seriesImdbIds = events
+      .filter((e) => e.type === "episode" && e.seriesImdbId)
+      .map((e) => e.seriesImdbId!);
+    const ratingImdbIds = topRatings.map((r) => r.imdbId);
+    const allMetadataIds = [...new Set([...movieImdbIds, ...seriesImdbIds, ...ratingImdbIds])];
+
+    const metadata =
+      allMetadataIds.length > 0
+        ? await prisma.metadata.findMany({
+            where: { imdbId: { in: allMetadataIds } },
+            select: { imdbId: true, name: true, type: true, poster: true, genres: true, runtime: true },
+          })
+        : [];
+    const metadataByImdbId = new Map(metadata.map((m) => [m.imdbId, m]));
+
+    let totalRuntimeMinutes = 0;
+    const genreCounts = new Map<string, number>();
+    for (const event of events) {
+      const lookupId = event.type === "episode" && event.seriesImdbId ? event.seriesImdbId : event.imdbId;
+      const meta = metadataByImdbId.get(lookupId);
+      if (!meta) continue;
+      if (meta.runtime) totalRuntimeMinutes += meta.runtime * event.plays;
+      for (const genre of meta.genres) {
+        genreCounts.set(genre, (genreCounts.get(genre) ?? 0) + event.plays);
+      }
+    }
+    const topGenres = [...genreCounts.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 5)
+      .map(([genre, count]) => ({ genre, count }));
+
+    const monthCounts = new Map<number, number>();
+    for (const event of events) {
+      const month = event.watchedAt.getUTCMonth();
+      monthCounts.set(month, (monthCounts.get(month) ?? 0) + event.plays);
+    }
+    let busiestMonth: number | null = null;
+    let busiestMonthCount = 0;
+    for (const [month, count] of monthCounts.entries()) {
+      if (count > busiestMonthCount) {
+        busiestMonth = month;
+        busiestMonthCount = count;
+      }
+    }
+
+    const topRated = topRatings.map((r) => {
+      const meta = metadataByImdbId.get(r.imdbId);
+      return {
+        imdbId: r.imdbId,
+        type: r.type,
+        name: meta?.name ?? null,
+        poster: meta?.poster ?? null,
+        rating: r.rating,
+      };
+    });
+
+    return {
+      year,
+      totalMovies,
+      totalEpisodes,
+      totalRuntimeMinutes,
+      topGenres,
+      topRated,
+      busiestMonth,
+      busiestMonthCount,
+    };
+  });
 };
 
 export default watchRoutes;

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -78,6 +78,7 @@ export type SearchResult = {
   genres: string[];
   rating: number | null;
   inWatchlist: boolean;
+  inCollection: boolean;
   lists: string[];
   // OMDB ratings — undefined = not yet fetched, null = fetched but unavailable
   imdbRating?: number | null;
@@ -105,7 +106,7 @@ export type ListItemWithMeta = ListItem & {
 export type CatalogList = {
   id: string;
   name: string;
-  kind: "watchlist" | "custom";
+  kind: "watchlist" | "custom" | "collection";
   itemCount: number;
 };
 
@@ -156,6 +157,17 @@ export type DetailedWatchStats = {
   currentStreak: number;
   longestStreak: number;
   topRated: { imdbId: string; name: string; type: string; rating: number | null; poster: string | null }[];
+};
+
+export type YearInReviewStats = {
+  year: number;
+  totalMovies: number;
+  totalEpisodes: number;
+  totalRuntimeMinutes: number;
+  topGenres: { genre: string; count: number }[];
+  topRated: { imdbId: string; name: string | null; type: string; rating: number; poster: string | null }[];
+  busiestMonth: number | null;
+  busiestMonthCount: number;
 };
 
 export type AddonConfig = {
@@ -257,7 +269,7 @@ export type ExportPayload = {
   profile: { name: string };
   lists: Array<{
     name: string;
-    kind: "watchlist" | "custom";
+    kind: "watchlist" | "custom" | "collection";
     items: Array<{ type: "movie" | "series"; imdbId: string; addedAt: string }>;
   }>;
   watchEvents: Array<{
@@ -459,6 +471,9 @@ export const api = {
   },
   getDetailedStats() {
     return request<DetailedWatchStats>("/watch/stats/detailed");
+  },
+  getYearInReview(year: number) {
+    return request<YearInReviewStats>(`/watch/stats/year/${year}`);
   },
   getAddonConfig() {
     return request<{ config: AddonConfig; availableCatalogs: string[]; availableLists: { id: string; name: string }[] }>("/addon/config");

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -287,6 +287,7 @@ export function DashboardPage() {
     genres: opts?.genres ?? [],
     rating: opts?.rating ?? null,
     inWatchlist: false,
+    inCollection: false,
     lists: [],
   }), []);
 

--- a/apps/web/src/pages/HistoryPage.tsx
+++ b/apps/web/src/pages/HistoryPage.tsx
@@ -30,6 +30,7 @@ function toSearchResult(event: WatchEvent): SearchResult {
     genres: [],
     rating: null,
     inWatchlist: false,
+    inCollection: false,
     lists: [],
   };
 }

--- a/apps/web/src/pages/ListsPage.tsx
+++ b/apps/web/src/pages/ListsPage.tsx
@@ -16,7 +16,7 @@ const SORT_LABELS: Record<SortOption, string> = {
   rating: "Rating",
 };
 
-function toSearchResult(item: ListItemWithMeta): SearchResult {
+function toSearchResult(item: ListItemWithMeta, list?: CatalogList): SearchResult {
   return {
     imdbId: item.imdbId,
     type: item.type,
@@ -26,9 +26,9 @@ function toSearchResult(item: ListItemWithMeta): SearchResult {
     description: null,
     genres: item.metadata?.genres ?? [],
     rating: item.metadata?.rating ?? null,
-    inWatchlist: false,
-    inCollection: false,
-    lists: [],
+    inWatchlist: list?.kind === "watchlist",
+    inCollection: list?.kind === "collection",
+    lists: list ? [list.id] : [],
   };
 }
 
@@ -553,7 +553,7 @@ export function ListsPage() {
                       {/* Poster */}
                       <button
                         type="button"
-                        onClick={() => setSelectedItem(toSearchResult(item))}
+                        onClick={() => setSelectedItem(toSearchResult(item, selectedList))}
                         className="card-lift relative block w-full overflow-hidden rounded-xl text-left ring-1"
                         style={{ aspectRatio: "2/3", backgroundColor: "var(--surface)", "--tw-ring-color": "var(--border)" } as React.CSSProperties}
                         aria-label={`Open details for ${name}`}

--- a/apps/web/src/pages/ListsPage.tsx
+++ b/apps/web/src/pages/ListsPage.tsx
@@ -27,6 +27,7 @@ function toSearchResult(item: ListItemWithMeta): SearchResult {
     genres: item.metadata?.genres ?? [],
     rating: item.metadata?.rating ?? null,
     inWatchlist: false,
+    inCollection: false,
     lists: [],
   };
 }

--- a/apps/web/src/pages/StatsPage.tsx
+++ b/apps/web/src/pages/StatsPage.tsx
@@ -66,6 +66,7 @@ export function StatsPage() {
   useEffect(() => {
     let cancelled = false;
     setYearError(null);
+    setYearReview(null);
     api.getYearInReview(year)
       .then((data) => { if (!cancelled) setYearReview(data); })
       .catch((err) => { if (!cancelled) setYearError(err instanceof Error ? err.message : "Failed to load year in review"); });

--- a/apps/web/src/pages/StatsPage.tsx
+++ b/apps/web/src/pages/StatsPage.tsx
@@ -1,7 +1,12 @@
 import { useCallback, useEffect, useState } from "react";
-import { AlertCircle, Award, BarChart3, Film, Flame, Minus, Star, Trophy, TrendingDown, TrendingUp } from "lucide-react";
-import { api, DetailedWatchStats, WatchStats } from "../api";
+import { AlertCircle, Award, BarChart3, Calendar, Clock, Film, Flame, Minus, Star, Trophy, TrendingDown, TrendingUp } from "lucide-react";
+import { api, DetailedWatchStats, WatchStats, YearInReviewStats } from "../api";
 import { TicketTile } from "../components/TicketTile";
+
+const MONTH_NAMES = [
+  "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December",
+];
 
 type Milestone = { label: string; threshold: number; icon: typeof Film };
 
@@ -37,6 +42,9 @@ export function StatsPage() {
   const [stats, setStats] = useState<WatchStats | null>(null);
   const [detailed, setDetailed] = useState<DetailedWatchStats | null>(null);
   const [hoveredMonth, setHoveredMonth] = useState<string | null>(null);
+  const [year, setYear] = useState(() => new Date().getFullYear() - 1);
+  const [yearReview, setYearReview] = useState<YearInReviewStats | null>(null);
+  const [yearError, setYearError] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     try {
@@ -54,6 +62,15 @@ export function StatsPage() {
   }, []);
 
   useEffect(() => { void load(); }, [load]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setYearError(null);
+    api.getYearInReview(year)
+      .then((data) => { if (!cancelled) setYearReview(data); })
+      .catch((err) => { if (!cancelled) setYearError(err instanceof Error ? err.message : "Failed to load year in review"); });
+    return () => { cancelled = true; };
+  }, [year]);
 
   if (error) {
     return (
@@ -283,6 +300,84 @@ export function StatsPage() {
           </div>
         </section>
       )}
+
+      {/* Year in Review */}
+      <section className="rounded-2xl p-5" style={{ border: "1px solid var(--border)", background: "var(--bg-1)" }}>
+        <div className="mb-4 flex items-center justify-between gap-3">
+          <h3 className="text-lg font-semibold" style={{ color: "var(--text)" }}>Year in Review</h3>
+          <select
+            value={year}
+            onChange={(e) => setYear(Number(e.target.value))}
+            className="rounded-lg px-3 py-1.5 text-sm"
+            style={{ border: "1px solid var(--border)", background: "var(--surface-strong)", color: "var(--text)" }}
+          >
+            {Array.from({ length: 6 }, (_, i) => new Date().getFullYear() - i).map((y) => (
+              <option key={y} value={y}>{y}</option>
+            ))}
+          </select>
+        </div>
+
+        {yearError && <p className="text-sm text-rose-500">{yearError}</p>}
+
+        {!yearError && yearReview && (
+          <div className="space-y-5">
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+              <TicketTile icon={Film} label="Movies Watched" value={yearReview.totalMovies} />
+              <TicketTile icon={BarChart3} label="Episodes Watched" value={yearReview.totalEpisodes} />
+              <TicketTile icon={Clock} label="Hours Watched" value={Math.round(yearReview.totalRuntimeMinutes / 60)} />
+              <TicketTile icon={Calendar} label="Busiest Month" value={yearReview.busiestMonth !== null ? MONTH_NAMES[yearReview.busiestMonth] : "—"} />
+            </div>
+
+            {yearReview.topGenres.length > 0 && (
+              <div>
+                <h4 className="mb-2 text-sm font-semibold" style={{ color: "var(--text-dim)" }}>Top Genres</h4>
+                <div className="flex flex-wrap gap-2">
+                  {yearReview.topGenres.map((g) => (
+                    <span
+                      key={g.genre}
+                      className="rounded-full px-3 py-1 text-xs"
+                      style={{ border: "1px solid var(--border)", background: "var(--surface-strong)", color: "var(--text-dim)" }}
+                    >
+                      {g.genre} <span style={{ color: "var(--text-mute)" }}>{g.count}</span>
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {yearReview.topRated.length > 0 && (
+              <div>
+                <h4 className="mb-2 flex items-center gap-2 text-sm font-semibold" style={{ color: "var(--text-dim)" }}>
+                  <Star className="h-4 w-4 text-amber-400" /> Top Rated Picks
+                </h4>
+                <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-5">
+                  {yearReview.topRated.map((item) => (
+                    <div key={item.imdbId} className="group">
+                      <div
+                        className="relative overflow-hidden rounded-xl transition-transform duration-300 group-hover:scale-[1.03]"
+                        style={{ aspectRatio: "2/3", boxShadow: "inset 0 0 0 1px var(--border)" }}
+                      >
+                        {item.poster ? (
+                          <img src={item.poster} alt={item.name ?? ""} className="h-full w-full object-cover" loading="lazy" />
+                        ) : (
+                          <div className="flex h-full w-full items-center justify-center" style={{ background: "var(--surface-strong)" }}>
+                            <Film className="h-8 w-8" style={{ color: "var(--text-mute)" }} />
+                          </div>
+                        )}
+                        <div className="absolute top-2 left-2 flex h-7 w-7 items-center justify-center rounded-full bg-black/70 backdrop-blur-sm" style={{ boxShadow: "0 0 0 1.5px rgba(245,158,11,0.7)" }}>
+                          <span className="text-2xs font-bold tabular-nums text-amber-400">{item.rating.toFixed(1)}</span>
+                        </div>
+                      </div>
+                      <p className="mt-1.5 truncate text-sm font-medium" style={{ color: "var(--text)" }}>{item.name ?? item.imdbId}</p>
+                      <p className="text-2xs capitalize" style={{ color: "var(--text-mute)" }}>{item.type}</p>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
This PR adds three major features: AniList anime search integration, a "Year in Review" statistics view, and a new "Collection" list type for organizing watched content.

## Key Changes

### AniList Integration
- Added `anilist-client.ts` with GraphQL queries to search anime and fetch anime details by ID
- Implements LRU caching (1-hour TTL) for both search results and anime metadata
- Includes `toAbsoluteEpisodeNumbering()` utility to map anime episode counts to flat numbering
- Added comprehensive test suite covering search, detail fetching, error handling, and episode numbering
- Exposed `/metadata/anime-search` endpoint for frontend anime search queries

### Year in Review Statistics
- Added new `/watch/stats/year/:year` endpoint that aggregates watch data for a specific year
- Calculates total movies watched, episodes watched, runtime, top genres, and busiest month
- Returns top 10 highest-rated items watched that year with metadata
- Updated `StatsPage.tsx` to display year-in-review data with year selector (last 6 years)
- Added `YearInReviewStats` type to API client

### Collection List Type
- Added `collection` as a new `ListKind` enum value in Prisma schema
- Created database migration enforcing at most one default collection per profile (partial unique index)
- Added `ensureDefaultCollection()` and `getDefaultCollection()` utilities in `collection.ts`
- Updated search results to track `inCollection` status alongside `inWatchlist`
- Updated list routes to accept and validate the new collection kind

### Supporting Changes
- Updated `SearchResult` type to include `inCollection` boolean field
- Updated `CatalogList` type to include "collection" as a valid kind
- Updated export payload types to support collection lists
- Initialized default collection on app startup via `ensureDefaultCollection()`
- Updated all search result constructors across pages to include `inCollection: false`

## Implementation Details
- AniList client uses 8-second request timeout and proper error handling for GraphQL errors
- Year-in-review aggregation efficiently batches metadata lookups and calculates statistics in a single pass
- Collection singleton constraint mirrors existing watchlist constraint at the database level
- UI displays year-in-review with genre tags, top-rated items with poster images and ratings, and monthly activity

https://claude.ai/code/session_01UzSBiJRgmHWHAwoK8E5Wvr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Year in Review” view with selectable years, showing watch totals, top genres, and top-rated picks.
  * Added anime search to metadata, with results returned directly in the app.
  * Collections are now recognized as a first-class list type, with default collection setup and collection-aware search results.
  * Search and export data now include collection status where relevant.

* **Bug Fixes**
  * Improved handling for missing or invalid anime search input and upstream search failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->