### PR TITLE
Add A-Z/Z-A sort options to Stremio watchlist and discovery catalogs

### DIFF
--- a/apps/addon/src/index.ts
+++ b/apps/addon/src/index.ts
@@ -246,10 +246,13 @@ const fetchEnabledCatalogs = async (): Promise<string[] | null> => {
   }
 };
 
+// Stremio's UI only renders a filter dropdown for the "genre" extra, so
+// alphabetical sorting (which Stremio has no native concept of) is exposed
+// as pseudo-genre options alongside the real content genres.
+const SORT_OPTIONS = ["A-Z", "Z-A"];
+
 const buildManifest = (lists: CataloggyList[], genres: string[], enabledCatalogs: string[] | null) => {
-  const genreExtra = genres.length > 0
-    ? [{ name: "genre", options: genres, isRequired: false }]
-    : [];
+  const genreExtra = [{ name: "genre", options: [...SORT_OPTIONS, ...genres], isRequired: false }];
 
   const listCatalogs = lists.flatMap((list) => [
     {
@@ -372,6 +375,13 @@ const applyExtraFilters = (metas: StremioMetaPreview[], extraParams: Record<stri
   if (extraParams.search) {
     const query = extraParams.search.toLowerCase();
     filtered = filtered.filter((m) => m.name.toLowerCase().includes(query));
+  }
+
+  if (extraParams.genre === "A-Z") {
+    return [...filtered].sort((a, b) => a.name.localeCompare(b.name));
+  }
+  if (extraParams.genre === "Z-A") {
+    return [...filtered].sort((a, b) => b.name.localeCompare(a.name));
   }
 
   if (extraParams.genre) {


### PR DESCRIPTION
Stremio's UI only renders a filter dropdown for the catalog's "genre"
extra, so the addon's per-list (watchlist, custom list) and discovery
catalogs had no way to sort items alphabetically — list items were
always returned in addedAt-desc order with no client-facing control.
Expose "A-Z"/"Z-A" as pseudo-genre options ahead of the real content
genres, and sort by name when one of them is selected.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LfFm9mnnHEL48uUKi5L2RV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “A-Z” and “Z-A” options to the genre dropdown in the addon manifest.
  * Users can now sort catalog results by name in ascending or descending order from the genre filter.

* **Bug Fixes**
  * Improved genre filter behavior so sorting options work consistently alongside normal genre selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->