### PR TITLE
Default watchlist and list catalogs to A-Z sorting

### DIFF
--- a/apps/addon/src/index.ts
+++ b/apps/addon/src/index.ts
@@ -369,6 +369,9 @@ const parseExtra = (extra: string): Record<string, string> => {
   return params;
 };
 
+const compareNames = (a: StremioMetaPreview, b: StremioMetaPreview): number =>
+  a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
+
 const applyExtraFilters = (metas: StremioMetaPreview[], extraParams: Record<string, string>): StremioMetaPreview[] => {
   let filtered = metas;
 
@@ -378,10 +381,10 @@ const applyExtraFilters = (metas: StremioMetaPreview[], extraParams: Record<stri
   }
 
   if (extraParams.genre === "A-Z") {
-    return [...filtered].sort((a, b) => a.name.localeCompare(b.name));
+    return [...filtered].sort(compareNames);
   }
   if (extraParams.genre === "Z-A") {
-    return [...filtered].sort((a, b) => b.name.localeCompare(a.name));
+    return [...filtered].sort((a, b) => compareNames(b, a));
   }
 
   if (extraParams.genre) {
@@ -412,7 +415,7 @@ const handleCatalog = async (type: string, id: string, extra?: string) => {
 
   const [items, rpdb] = await Promise.all([fetchListItems(parsed.listId), fetchRpdbConfig()]);
   // Default to alphabetical order; Z-A/genre extras (if selected) override below.
-  let metas = itemsToMetas(items, type).sort((a, b) => a.name.localeCompare(b.name));
+  let metas = itemsToMetas(items, type).sort(compareNames);
   if (extra) {
     metas = applyExtraFilters(metas, parseExtra(extra));
   }

--- a/apps/addon/src/index.ts
+++ b/apps/addon/src/index.ts
@@ -411,7 +411,8 @@ const handleCatalog = async (type: string, id: string, extra?: string) => {
   if (!parsed || type !== parsed.catalogType) return { metas: [] };
 
   const [items, rpdb] = await Promise.all([fetchListItems(parsed.listId), fetchRpdbConfig()]);
-  let metas = itemsToMetas(items, type);
+  // Default to alphabetical order; Z-A/genre extras (if selected) override below.
+  let metas = itemsToMetas(items, type).sort((a, b) => a.name.localeCompare(b.name));
   if (extra) {
     metas = applyExtraFilters(metas, parseExtra(extra));
   }

--- a/apps/api/src/lib/stremio-helpers.ts
+++ b/apps/api/src/lib/stremio-helpers.ts
@@ -43,21 +43,23 @@ export const buildMetasFromIds = async (
   });
 };
 
+const sortMetasByName = <T extends { name: string }>(metas: T[]): T[] =>
+  [...metas].sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: "base" }));
+
 export const getWatchlistMetas = async (type: StremioMetaType, limit: number, profileId: string) => {
   const watchlist = await getDefaultWatchlist(profileId);
   const listItemType = type === "movie" ? ListItemType.movie : ListItemType.series;
 
   const watchlistItems = await prisma.listItem.findMany({
     where: { listId: watchlist.id, type: listItemType },
-    orderBy: { addedAt: "desc" },
-    take: limit,
     select: { imdbId: true },
   });
 
-  return buildMetasFromIds(
+  const metas = await buildMetasFromIds(
     watchlistItems.map((item) => item.imdbId),
     type
   );
+  return sortMetasByName(metas).slice(0, limit);
 };
 
 export const getRecentMetas = async (type: StremioMetaType, limit: number, profileId: string) => {
@@ -129,13 +131,12 @@ export const getCustomListMetas = async (
   const listItemType = type === "movie" ? ListItemType.movie : ListItemType.series;
   const listItems = await prisma.listItem.findMany({
     where: { listId, type: listItemType },
-    orderBy: { addedAt: "desc" },
-    take: limit,
     select: { imdbId: true },
   });
 
-  return buildMetasFromIds(
+  const metas = await buildMetasFromIds(
     listItems.map((item) => item.imdbId),
     type
   );
+  return sortMetasByName(metas).slice(0, limit);
 };

--- a/apps/web/src/pages/ListsPage.tsx
+++ b/apps/web/src/pages/ListsPage.tsx
@@ -206,7 +206,7 @@ export function ListsPage() {
   const [deletingListId, setDeletingListId] = useState<string | null>(null);
   const [renamingListId, setRenamingListId] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState("");
-  const [sortBy, setSortBy] = useState<SortOption>("added");
+  const [sortBy, setSortBy] = useState<SortOption>("name");
   const [filterQuery, setFilterQuery] = useState("");
   const { showToast } = useToast();
   const { selectedItem, setSelectedItem, panelHistory, setPanelHistory, panelHistoryLoading } = useDetailPanel();


### PR DESCRIPTION
The web Lists page defaulted its sort to "Date Added" instead of name.
More importantly, the previous fix for Stremio sorting (PR #264) only
touched apps/addon, a legacy service the Settings page never links to —
the actual installed manifest URL is served by apps/api/routes/stremio.ts,
which had no sort control at all and always returned items by addedAt
desc. Sort watchlist/list metas by name there so installs are A-Z by
default, and apply the same default ordering in apps/addon for parity.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XVqnNHmQR4atXZY65uCG8S

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Lists and watchlist items now default to alphabetical sorting by name.
  * The Lists page now opens with name-based sorting selected.
* **Bug Fixes**
  * Improved consistency in item ordering across catalog views and saved lists.
  * Sorting now applies more predictably before additional filters are used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->