### PR TITLE
Fix AI test-connection response shape mismatch

### DIFF
--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -633,13 +633,13 @@ export const api = {
     return request<{ configured: boolean }>("/ai/config", { method: "DELETE" });
   },
   testAiConfig(config: Record<string, unknown>) {
-    return request<{ ok: boolean; message: string }>("/ai/test", {
+    return request<{ success: boolean; response?: string; error?: string }>("/ai/test", {
       method: "POST",
       body: JSON.stringify({ config }),
     });
   },
   refreshAiRecs() {
-    return request<{ movie: number; series: number }>("/recommendations/ai/refresh", { method: "POST", timeoutMs: 60000 });
+    return request<{ refreshed: boolean }>("/recommendations/ai/refresh", { method: "POST", timeoutMs: 60000 });
   },
   getAiRecommendations(type: MediaType, limit = 20) {
     return request<{ metas: TrendingMeta[]; reasons?: Record<string, string> }>(`/recommendations/ai?type=${type}&limit=${limit}`);

--- a/apps/web/src/components/settings/AiSettings.tsx
+++ b/apps/web/src/components/settings/AiSettings.tsx
@@ -211,7 +211,9 @@ export function AiSettings() {
       setTestStatus(res.success ? "ok" : "error");
       setTestMessage(
         res.success
-          ? `Connected. Model replied: "${res.response}"`
+          ? res.response?.trim()
+            ? `Connected. Model replied: "${res.response.trim()}"`
+            : "Connected."
           : res.error ?? "Test failed",
       );
     } catch (err) {

--- a/apps/web/src/components/settings/AiSettings.tsx
+++ b/apps/web/src/components/settings/AiSettings.tsx
@@ -208,8 +208,12 @@ export function AiSettings() {
     setTestMessage(null);
     try {
       const res = await api.testAiConfig(config);
-      setTestStatus(res.ok ? "ok" : "error");
-      setTestMessage(res.message);
+      setTestStatus(res.success ? "ok" : "error");
+      setTestMessage(
+        res.success
+          ? `Connected. Model replied: "${res.response}"`
+          : res.error ?? "Test failed",
+      );
     } catch (err) {
       setTestStatus("error");
       setTestMessage(err instanceof Error ? err.message : "Test failed");


### PR DESCRIPTION
AiSettings read res.ok/res.message but POST /ai/test always returns
{success, response, error}, so Test Connection showed an error even
when the provider responded successfully. Align the frontend type and
usage with the actual backend contract, and fix refreshAiRecs's return
type to match {refreshed} as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated AI connection testing to show clearer success and error messages.
  * Successful tests now display the model’s reply, making it easier to confirm the connection worked.
  * Recommends a simpler refresh status for AI recommendations, improving the feedback shown after a refresh action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->