### PR TITLE
Compute next episode intelligently based on season episode counts

### DIFF
--- a/apps/api/src/lib/next-episode.ts
+++ b/apps/api/src/lib/next-episode.ts
@@ -1,0 +1,52 @@
+import { seasonsCache } from "./cache.js";
+import { getTmdb } from "./tmdb-client.js";
+import type { SeasonInfo } from "../tmdb.js";
+
+async function getSeasonsForImdbId(imdbId: string, tmdbId: number | null): Promise<SeasonInfo[]> {
+  const cacheKey = `seasons:${imdbId}`;
+  const cached = seasonsCache.get(cacheKey);
+  if (cached) return cached;
+
+  if (!tmdbId) return [];
+
+  try {
+    const tmdb = await getTmdb();
+    const seasons = await tmdb.getSeasons(tmdbId);
+    seasonsCache.set(cacheKey, seasons);
+    return seasons;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Given the last watched season/episode, returns the next episode to watch,
+ * rolling over to the next season's E1 once a season's episode count is
+ * exhausted. Returns null if the series appears fully watched (no further
+ * season exists past the last one with episodes).
+ */
+export async function computeNextEpisode(
+  imdbId: string,
+  tmdbId: number | null,
+  lastSeason: number,
+  lastEpisode: number
+): Promise<{ season: number; episode: number } | null> {
+  const seasons = await getSeasonsForImdbId(imdbId, tmdbId);
+  if (seasons.length === 0) {
+    // No season data available — fall back to naive increment.
+    return { season: lastSeason, episode: lastEpisode + 1 };
+  }
+
+  const currentSeason = seasons.find((s) => s.seasonNumber === lastSeason);
+  if (!currentSeason || lastEpisode < currentSeason.episodeCount) {
+    return { season: lastSeason, episode: lastEpisode + 1 };
+  }
+
+  const nextSeason = seasons
+    .filter((s) => s.seasonNumber > lastSeason)
+    .sort((a, b) => a.seasonNumber - b.seasonNumber)[0];
+
+  if (!nextSeason) return null;
+
+  return { season: nextSeason.seasonNumber, episode: 1 };
+}

--- a/apps/api/src/lib/next-episode.ts
+++ b/apps/api/src/lib/next-episode.ts
@@ -43,7 +43,7 @@ export async function computeNextEpisode(
   }
 
   const nextSeason = seasons
-    .filter((s) => s.seasonNumber > lastSeason)
+    .filter((s) => s.seasonNumber > lastSeason && s.episodeCount > 0)
     .sort((a, b) => a.seasonNumber - b.seasonNumber)[0];
 
   if (!nextSeason) return null;

--- a/apps/api/src/routes/series.ts
+++ b/apps/api/src/routes/series.ts
@@ -108,7 +108,7 @@ const seriesRoutes: FastifyPluginAsync = async (app) => {
       } catch { /* TMDB unavailable – return what we have */ }
     }
 
-    const progress = await Promise.all(
+    const progressWithNulls = await Promise.all(
       progressRows.map(async (row) => {
         const meta = metaByImdbId.get(row.seriesImdbId);
         const next = await computeNextEpisode(
@@ -117,13 +117,15 @@ const seriesRoutes: FastifyPluginAsync = async (app) => {
           row.lastSeason,
           row.lastEpisode
         );
+        // Series is fully watched (no further season exists) — drop from Continue Watching.
+        if (!next) return null;
         return {
           imdbId: row.seriesImdbId,
           seriesImdbId: row.seriesImdbId,
           lastSeason: row.lastSeason,
           lastEpisode: row.lastEpisode,
-          nextSeason: next?.season ?? null,
-          nextEpisode: next?.episode ?? null,
+          nextSeason: next.season,
+          nextEpisode: next.episode,
           lastWatchedAt: row.lastWatchedAt,
           updatedAt: row.updatedAt,
           name: meta?.name ?? row.seriesImdbId,
@@ -134,6 +136,8 @@ const seriesRoutes: FastifyPluginAsync = async (app) => {
         };
       })
     );
+
+    const progress = progressWithNulls.filter((p): p is NonNullable<typeof p> => p !== null);
 
     return { progress };
   });

--- a/apps/api/src/routes/series.ts
+++ b/apps/api/src/routes/series.ts
@@ -5,6 +5,7 @@ import { getTmdb } from "../lib/tmdb-client.js";
 import { upsertMetadata } from "../lib/metadata.js";
 import { upsertSeriesProgressIfNewer } from "../lib/series-progress.js";
 import { resolveProfile } from "../lib/profile.js";
+import { computeNextEpisode } from "../lib/next-episode.js";
 
 const DROPPED_KEY = (profileId: string, imdbId: string) => `dropped:series:${profileId}:${imdbId}`;
 
@@ -44,7 +45,7 @@ const seriesRoutes: FastifyPluginAsync = async (app) => {
     const [metadata, episodeCounts] = await Promise.all([
       prisma.metadata.findMany({
         where: { imdbId: { in: imdbIds }, type: "series" },
-        select: { imdbId: true, name: true, poster: true, totalSeasons: true, totalEpisodes: true },
+        select: { imdbId: true, name: true, poster: true, totalSeasons: true, totalEpisodes: true, tmdbId: true },
       }),
       prisma.watchEvent.groupBy({
         by: ["seriesImdbId", "season", "episode"],
@@ -89,6 +90,7 @@ const seriesRoutes: FastifyPluginAsync = async (app) => {
               poster: result.value.poster,
               totalSeasons: result.value.totalSeasons,
               totalEpisodes: result.value.totalEpisodes,
+              tmdbId: result.value.tmdbId,
             });
           }
         }
@@ -106,24 +108,32 @@ const seriesRoutes: FastifyPluginAsync = async (app) => {
       } catch { /* TMDB unavailable – return what we have */ }
     }
 
-    const progress = progressRows.map((row) => {
-      const meta = metaByImdbId.get(row.seriesImdbId);
-      return {
-        imdbId: row.seriesImdbId,
-        seriesImdbId: row.seriesImdbId,
-        lastSeason: row.lastSeason,
-        lastEpisode: row.lastEpisode,
-        nextSeason: row.lastSeason,
-        nextEpisode: row.lastEpisode + 1,
-        lastWatchedAt: row.lastWatchedAt,
-        updatedAt: row.updatedAt,
-        name: meta?.name ?? row.seriesImdbId,
-        poster: meta?.poster ?? null,
-        totalSeasons: meta?.totalSeasons ?? null,
-        totalEpisodes: meta?.totalEpisodes ?? null,
-        watchedEpisodes: watchedBySeriesId.get(row.seriesImdbId) ?? null,
-      };
-    });
+    const progress = await Promise.all(
+      progressRows.map(async (row) => {
+        const meta = metaByImdbId.get(row.seriesImdbId);
+        const next = await computeNextEpisode(
+          row.seriesImdbId,
+          meta?.tmdbId ?? null,
+          row.lastSeason,
+          row.lastEpisode
+        );
+        return {
+          imdbId: row.seriesImdbId,
+          seriesImdbId: row.seriesImdbId,
+          lastSeason: row.lastSeason,
+          lastEpisode: row.lastEpisode,
+          nextSeason: next?.season ?? null,
+          nextEpisode: next?.episode ?? null,
+          lastWatchedAt: row.lastWatchedAt,
+          updatedAt: row.updatedAt,
+          name: meta?.name ?? row.seriesImdbId,
+          poster: meta?.poster ?? null,
+          totalSeasons: meta?.totalSeasons ?? null,
+          totalEpisodes: meta?.totalEpisodes ?? null,
+          watchedEpisodes: watchedBySeriesId.get(row.seriesImdbId) ?? null,
+        };
+      })
+    );
 
     return { progress };
   });
@@ -175,8 +185,16 @@ const seriesRoutes: FastifyPluginAsync = async (app) => {
       });
       if (!row) return reply.code(404).send({ error: "No progress found for this series" });
 
-      const nextEpisode = row.lastEpisode + 1;
-      const nextSeason = row.lastSeason;
+      const meta = await prisma.metadata.findUnique({
+        where: { imdbId_type: { imdbId, type: "series" } },
+        select: { tmdbId: true },
+      });
+
+      const next = await computeNextEpisode(imdbId, meta?.tmdbId ?? null, row.lastSeason, row.lastEpisode);
+      if (!next) return reply.code(409).send({ error: "Series already fully watched" });
+
+      const nextSeason = next.season;
+      const nextEpisode = next.episode;
       const watchedAt = new Date();
 
       await prisma.watchEvent.create({

--- a/apps/web/src/components/MediaDetailPanel.tsx
+++ b/apps/web/src/components/MediaDetailPanel.tsx
@@ -195,11 +195,15 @@ export function DetailPanel({
         const currentSeason = seasons.find((s) => s.seasonNumber === lastEvent.season);
         if (currentSeason && (lastEvent.episode ?? 0) >= currentSeason.episodeCount) {
           const upcoming = seasons
-            .filter((s) => s.seasonNumber > (lastEvent.season ?? 0))
+            .filter((s) => s.seasonNumber > (lastEvent.season ?? 0) && s.episodeCount > 0)
             .sort((a, b) => a.seasonNumber - b.seasonNumber)[0];
           if (upcoming) {
             nextSeason = upcoming.seasonNumber;
             nextEpisode = 1;
+          } else {
+            // Fully watched, no further season — don't suggest a nonexistent episode.
+            nextSeason = currentSeason.seasonNumber;
+            nextEpisode = currentSeason.episodeCount;
           }
         }
       }

--- a/apps/web/src/components/MediaDetailPanel.tsx
+++ b/apps/web/src/components/MediaDetailPanel.tsx
@@ -189,8 +189,20 @@ export function DetailPanel({
     } else {
       // Default to next episode after last watched, or S01E01
       const lastEvent = history.find((e) => e.season != null && e.episode != null);
-      const nextSeason = lastEvent?.season ?? 1;
-      const nextEpisode = lastEvent ? (lastEvent.episode ?? 0) + 1 : 1;
+      let nextSeason = lastEvent?.season ?? 1;
+      let nextEpisode = lastEvent ? (lastEvent.episode ?? 0) + 1 : 1;
+      if (lastEvent) {
+        const currentSeason = seasons.find((s) => s.seasonNumber === lastEvent.season);
+        if (currentSeason && (lastEvent.episode ?? 0) >= currentSeason.episodeCount) {
+          const upcoming = seasons
+            .filter((s) => s.seasonNumber > (lastEvent.season ?? 0))
+            .sort((a, b) => a.seasonNumber - b.seasonNumber)[0];
+          if (upcoming) {
+            nextSeason = upcoming.seasonNumber;
+            nextEpisode = 1;
+          }
+        }
+      }
       setWatchTarget({ kind: "episode", seriesImdbId: item.imdbId, season: nextSeason, episode: nextEpisode });
     }
   };


### PR DESCRIPTION
## Summary
This PR improves the "next episode" calculation for series by intelligently rolling over to the next season when the current season's episode count is exhausted, rather than naively incrementing the episode number indefinitely.

## Key Changes
- **New utility function** (`computeNextEpisode`): Centralized logic to determine the next episode to watch given the last watched season/episode. It:
  - Fetches season information from TMDB (with caching)
  - Rolls over to season N+1, episode 1 when the current season's episodes are exhausted
  - Returns `null` if the series appears fully watched (no further seasons exist)
  - Falls back to naive increment if season data is unavailable

- **API route updates** (`/series` endpoints):
  - Added `tmdbId` to metadata queries to enable season lookups
  - Updated progress calculation to use `computeNextEpisode` and filter out fully-watched series from "Continue Watching"
  - Updated mark-as-watched endpoint to validate the next episode exists before creating a watch event

- **Web UI update** (`MediaDetailPanel`): Mirrored the same season rollover logic for client-side next episode calculation

## Implementation Details
- Season data is cached in-memory to avoid repeated TMDB API calls
- The API now returns HTTP 409 if attempting to mark an episode as watched when the series is already fully watched
- Fully watched series are automatically removed from the "Continue Watching" list
- Graceful fallback to naive increment when TMDB data is unavailable

https://claude.ai/code/session_01U6VSM6s3G9ixyfjzXJCHKa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved “next episode” detection for series so progress and watch-next actions now follow season boundaries instead of always incrementing the episode number.
  * When a series has no remaining episodes, it is no longer shown as needing another episode; attempting to continue it now returns a clear “already fully watched” message.
  * Series with missing or unavailable metadata now safely fall back to the previous behavior without breaking progress tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->