### PR TITLE
Add Google Gemini as an AI provider option

### DIFF
--- a/apps/web/src/components/settings/AiSettings.tsx
+++ b/apps/web/src/components/settings/AiSettings.tsx
@@ -31,7 +31,7 @@ const PROVIDERS: {
     id: "gemini",
     label: "Google Gemini",
     url: "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions",
-    model: "gemini-2.0-flash",
+    model: "gemini-2.5-flash",
     helpUrl: "https://aistudio.google.com/app/apikey",
   },
   {

--- a/apps/web/src/components/settings/AiSettings.tsx
+++ b/apps/web/src/components/settings/AiSettings.tsx
@@ -6,6 +6,7 @@ import { StatusBadge } from "./StatusBadge";
 
 type Provider =
   | "openai"
+  | "gemini"
   | "groq"
   | "nvidia"
   | "ollama"
@@ -25,6 +26,13 @@ const PROVIDERS: {
     url: "https://api.openai.com/v1/chat/completions",
     model: "gpt-4o-mini",
     helpUrl: "https://platform.openai.com/api-keys",
+  },
+  {
+    id: "gemini",
+    label: "Google Gemini",
+    url: "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions",
+    model: "gemini-2.0-flash",
+    helpUrl: "https://aistudio.google.com/app/apikey",
   },
   {
     id: "groq",


### PR DESCRIPTION
## Summary
This PR adds support for Google Gemini as an AI provider in the settings, allowing users to configure and use Gemini models alongside existing providers like OpenAI, Groq, Nvidia, and Ollama.

## Key Changes
- Added "gemini" to the `Provider` type union
- Registered Google Gemini as a new provider in the `PROVIDERS` configuration with:
  - Provider ID: `gemini`
  - Display label: `Google Gemini`
  - API endpoint: `https://generativelanguage.googleapis.com/v1beta/openai/chat/completions`
  - Default model: `gemini-2.0-flash`
  - Help/setup URL: `https://aistudio.google.com/app/apikey`

## Implementation Details
The Gemini provider is configured to use the OpenAI-compatible chat completions endpoint, enabling seamless integration with the existing AI settings infrastructure without requiring additional adapter code.

https://claude.ai/code/session_01LArcfiZ9C6VM44MpZN7H6D

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Gemini AI provider in settings.
  * Provider selection now includes Gemini, with its endpoint, default model, and help link for API key setup.
  * Existing automatic URL/model filling and provider detection now work with Gemini.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->