### PR TITLE
fix: drop shows out of Continue Watching once marked as dropped

### DIFF
--- a/apps/api/src/lib/dropped-shows.test.ts
+++ b/apps/api/src/lib/dropped-shows.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const prismaMock = {
+  kV: { findMany: vi.fn() },
+};
+
+vi.mock("./prisma.js", () => ({ prisma: prismaMock }));
+
+describe("getDroppedSeriesIds", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns an empty set without querying when no ids are given", async () => {
+    const { getDroppedSeriesIds } = await import("./dropped-shows.js");
+    const result = await getDroppedSeriesIds("profile-1", []);
+
+    expect(result.size).toBe(0);
+    expect(prismaMock.kV.findMany).not.toHaveBeenCalled();
+  });
+
+  it("maps dropped KV keys back to their imdb ids", async () => {
+    prismaMock.kV.findMany.mockResolvedValue([
+      { key: "dropped:series:profile-1:tt-dropped" },
+    ]);
+
+    const { getDroppedSeriesIds } = await import("./dropped-shows.js");
+    const result = await getDroppedSeriesIds("profile-1", ["tt-dropped", "tt-watching"]);
+
+    expect(result.has("tt-dropped")).toBe(true);
+    expect(result.has("tt-watching")).toBe(false);
+    expect(prismaMock.kV.findMany).toHaveBeenCalledWith({
+      where: {
+        key: {
+          in: ["dropped:series:profile-1:tt-dropped", "dropped:series:profile-1:tt-watching"],
+        },
+      },
+      select: { key: true },
+    });
+  });
+});

--- a/apps/api/src/lib/dropped-shows.ts
+++ b/apps/api/src/lib/dropped-shows.ts
@@ -1,0 +1,19 @@
+import { prisma } from "./prisma.js";
+
+export const droppedSeriesKey = (profileId: string, imdbId: string) =>
+  `dropped:series:${profileId}:${imdbId}`;
+
+export const getDroppedSeriesIds = async (
+  profileId: string,
+  imdbIds: string[]
+): Promise<Set<string>> => {
+  if (imdbIds.length === 0) return new Set();
+
+  const rows = await prisma.kV.findMany({
+    where: { key: { in: imdbIds.map((id) => droppedSeriesKey(profileId, id)) } },
+    select: { key: true },
+  });
+
+  const prefixLength = droppedSeriesKey(profileId, "").length;
+  return new Set(rows.map((row) => row.key.slice(prefixLength)));
+};

--- a/apps/api/src/lib/stremio-helpers.ts
+++ b/apps/api/src/lib/stremio-helpers.ts
@@ -2,6 +2,7 @@ import { ItemType, ListItemType } from "@prisma/client";
 import { prisma } from "./prisma.js";
 import { getRpdbApiKey, withRpdbPoster } from "./rpdb.js";
 import { getDefaultWatchlist } from "./watchlist.js";
+import { getDroppedSeriesIds } from "./dropped-shows.js";
 import type { ContinueMetaPreview, StremioMetaPreview, StremioMetaType } from "./types.js";
 
 export const buildMetasFromIds = async (
@@ -90,12 +91,14 @@ export const getRecentMetas = async (type: StremioMetaType, limit: number, profi
 };
 
 export const getContinueMetas = async (limit: number, profileId: string): Promise<ContinueMetaPreview[]> => {
-  const seriesProgress = await prisma.seriesProgress.findMany({
+  const allProgress = await prisma.seriesProgress.findMany({
     where: { profileId },
     orderBy: { lastWatchedAt: "desc" },
-    take: limit,
     select: { seriesImdbId: true, lastSeason: true, lastEpisode: true, lastWatchedAt: true },
   });
+
+  const droppedIds = await getDroppedSeriesIds(profileId, allProgress.map((p) => p.seriesImdbId));
+  const seriesProgress = allProgress.filter((p) => !droppedIds.has(p.seriesImdbId)).slice(0, limit);
 
   const metas = await buildMetasFromIds(
     seriesProgress.map((p) => p.seriesImdbId),

--- a/apps/api/src/routes/series.ts
+++ b/apps/api/src/routes/series.ts
@@ -6,8 +6,9 @@ import { upsertMetadata } from "../lib/metadata.js";
 import { upsertSeriesProgressIfNewer } from "../lib/series-progress.js";
 import { resolveProfile } from "../lib/profile.js";
 import { computeNextEpisode } from "../lib/next-episode.js";
+import { droppedSeriesKey, getDroppedSeriesIds } from "../lib/dropped-shows.js";
 
-const DROPPED_KEY = (profileId: string, imdbId: string) => `dropped:series:${profileId}:${imdbId}`;
+const DROPPED_KEY = droppedSeriesKey;
 
 const seriesRoutes: FastifyPluginAsync = async (app) => {
   app.addHook("preHandler", resolveProfile);
@@ -34,10 +35,18 @@ const seriesRoutes: FastifyPluginAsync = async (app) => {
 
   app.get("/series/progress", async (request) => {
     const profileId = request.profileId!;
-    const progressRows = await prisma.seriesProgress.findMany({
+    const allProgressRows = await prisma.seriesProgress.findMany({
       where: { profileId },
       orderBy: { lastWatchedAt: "desc" },
     });
+
+    if (allProgressRows.length === 0) return { progress: [] };
+
+    const droppedIds = await getDroppedSeriesIds(
+      profileId,
+      allProgressRows.map((p) => p.seriesImdbId)
+    );
+    const progressRows = allProgressRows.filter((p) => !droppedIds.has(p.seriesImdbId));
 
     if (progressRows.length === 0) return { progress: [] };
 

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -316,6 +316,13 @@ export function DashboardPage() {
     }
   }, []);
 
+  const refreshProgress = useCallback(async () => {
+    try {
+      const progressRes = await api.getSeriesProgress();
+      setProgress(progressRes ?? []);
+    } catch { /* keep showing the last known list */ }
+  }, []);
+
   const profileId = runtimeConfig.getProfileId();
 
   useEffect(() => {
@@ -884,7 +891,7 @@ export function DashboardPage() {
           history={panelHistory}
           historyLoading={panelHistoryLoading}
           listMap={emptyListMap}
-          onClose={() => setSelectedItem(null)}
+          onClose={() => { setSelectedItem(null); void refreshProgress(); }}
           onShowToast={showToast}
           onHistoryChange={(events) => setPanelHistory(events)}
         />


### PR DESCRIPTION
The /series/progress and Stremio continue-watching queries only read
SeriesProgress and never checked the dropped:series KV flag, so a
dropped show stayed on the Continue Watching shelf indefinitely.
Filter both queries against the dropped set, and refetch progress
when the media detail panel closes so a drop takes effect immediately.