### PR TITLE
Increase AI config max_tokens floor to prevent truncation

### DIFF
--- a/apps/api/src/lib/ai.ts
+++ b/apps/api/src/lib/ai.ts
@@ -122,15 +122,23 @@ export const buildTasteProfile = async (profileId?: string) => {
   return { topGenres, topRated, recentTitles, watchedImdbIds, avgRating };
 };
 
-const callAiProvider = async (config: AiProviderConfig, prompt: string): Promise<string> => {
+const callAiProvider = async (
+  config: AiProviderConfig,
+  prompt: string,
+  minTokens = 0
+): Promise<string> => {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), 60_000);
 
+  const configuredMaxTokens = (config.payload.max_tokens as number | undefined) ?? 4096;
   const payload = {
     ...config.payload,
     messages: [{ role: "user", content: prompt }],
     stream: false,
-    max_tokens: (config.payload.max_tokens as number | undefined) ?? 4096,
+    // Never go below what the requested recommendation count needs, even if the
+    // user's saved config specifies a smaller value — a low max_tokens silently
+    // truncates the JSON array mid-response, which surfaces as a parse failure.
+    max_tokens: Math.max(configuredMaxTokens, minTokens),
   };
 
   let response: Response;
@@ -171,7 +179,17 @@ const parseRecsFromContent = (content: string): AiRecItem[] => {
   // Use bracket-matching to extract the first JSON array, avoiding greedy regex
   // overshoot when the AI appends trailing text containing "]"
   const start = content.indexOf("[");
-  if (start === -1) throw new Error("No JSON array in AI response");
+  if (start === -1) {
+    // An unterminated <think> block means generation was cut off by max_tokens
+    // while still reasoning, before it ever got to the JSON — the fix is more
+    // headroom, not better parsing.
+    if (/<think>/i.test(content)) {
+      throw new Error(
+        "AI response was truncated mid-reasoning before producing any output — increase max_tokens"
+      );
+    }
+    throw new Error("No JSON array in AI response");
+  }
 
   let depth = 0;
   let end = -1;
@@ -186,7 +204,11 @@ const parseRecsFromContent = (content: string): AiRecItem[] => {
     }
   }
 
-  if (end === -1) throw new Error("No JSON array in AI response");
+  if (end === -1) {
+    throw new Error(
+      "AI response was truncated before the JSON array closed — increase max_tokens or lower the recommendation limit"
+    );
+  }
 
   try {
     return JSON.parse(content.slice(start, end + 1)) as AiRecItem[];
@@ -233,7 +255,11 @@ Return ONLY a JSON array, no other text, no markdown:
   }
 ]`;
 
-    const content = await callAiProvider(config, prompt);
+    // Each recommendation is ~100-150 tokens once title/year/type/reason and JSON
+    // punctuation are accounted for; without this floor a low configured
+    // max_tokens truncates the array well before `limit` items are reached.
+    const minTokens = 400 + limit * 150;
+    const content = await callAiProvider(config, prompt, minTokens);
     const recs = parseRecsFromContent(content);
 
     const tmdb = await getTmdb();

--- a/apps/api/src/lib/ai.ts
+++ b/apps/api/src/lib/ai.ts
@@ -10,6 +10,11 @@ import type { AiProviderConfig, StremioMetaPreview } from "./types.js";
 export const AI_CONFIG_KEY = "ai:config";
 export const AI_LAST_RECS_GENERATED_AT_KEY = "ai:lastRecsGeneratedAt";
 export const AI_RECS_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+// Floor for a *saved* config's max_tokens. The per-request generation path
+// already computes a higher floor scaled to the requested limit, but this
+// keeps the persisted value itself from being set low enough to guarantee
+// truncation (e.g. the old UI default of 1024).
+export const MIN_AI_CONFIG_MAX_TOKENS = 2048;
 
 export const getAiConfig = async (): Promise<AiProviderConfig | null> => {
   const row = await prisma.kV.findUnique({ where: { key: AI_CONFIG_KEY } });
@@ -34,6 +39,16 @@ export const redactAiConfig = (config: AiProviderConfig): AiProviderConfig => ({
       k.toLowerCase() === "authorization" ? "Bearer ****" : v,
     ])
   ),
+  payload: {
+    ...config.payload,
+    // Configs saved before MIN_AI_CONFIG_MAX_TOKENS existed may still have a
+    // truncation-prone value on disk; reflect the effective (clamped) value
+    // here so the settings UI doesn't show a stale number.
+    max_tokens:
+      typeof config.payload.max_tokens === "number"
+        ? Math.max(config.payload.max_tokens, MIN_AI_CONFIG_MAX_TOKENS)
+        : config.payload.max_tokens,
+  },
 });
 
 export const shouldRefreshAiRecs = async (): Promise<boolean> => {

--- a/apps/api/src/lib/ai.ts
+++ b/apps/api/src/lib/ai.ts
@@ -15,6 +15,10 @@ export const AI_RECS_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 // keeps the persisted value itself from being set low enough to guarantee
 // truncation (e.g. the old UI default of 1024).
 export const MIN_AI_CONFIG_MAX_TOKENS = 2048;
+// Heuristic for the per-request token floor: a base allowance plus a
+// per-recommendation cost (title/year/type/reason text + JSON punctuation).
+const BASE_TOKENS = 400;
+const TOKENS_PER_RECOMMENDATION = 150;
 
 export const getAiConfig = async (): Promise<AiProviderConfig | null> => {
   const row = await prisma.kV.findUnique({ where: { key: AI_CONFIG_KEY } });
@@ -145,7 +149,10 @@ const callAiProvider = async (
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), 60_000);
 
-  const configuredMaxTokens = (config.payload.max_tokens as number | undefined) ?? 4096;
+  const configuredMaxTokens = Math.max(
+    (config.payload.max_tokens as number | undefined) ?? 4096,
+    MIN_AI_CONFIG_MAX_TOKENS
+  );
   const payload = {
     ...config.payload,
     messages: [{ role: "user", content: prompt }],
@@ -270,10 +277,9 @@ Return ONLY a JSON array, no other text, no markdown:
   }
 ]`;
 
-    // Each recommendation is ~100-150 tokens once title/year/type/reason and JSON
-    // punctuation are accounted for; without this floor a low configured
-    // max_tokens truncates the array well before `limit` items are reached.
-    const minTokens = 400 + limit * 150;
+    // Without this floor a low configured max_tokens truncates the array well
+    // before `limit` items are reached.
+    const minTokens = BASE_TOKENS + limit * TOKENS_PER_RECOMMENDATION;
     const content = await callAiProvider(config, prompt, minTokens);
     const recs = parseRecsFromContent(content);
 

--- a/apps/api/src/routes/ai.ts
+++ b/apps/api/src/routes/ai.ts
@@ -8,6 +8,7 @@ import { trendingCacheDeletePrefix, trendingCacheGet, trendingCacheSet } from ".
 import {
   AI_CONFIG_KEY,
   AI_LAST_RECS_GENERATED_AT_KEY,
+  MIN_AI_CONFIG_MAX_TOKENS,
   getAiConfig,
   isAiConfigured,
   redactAiConfig,
@@ -371,6 +372,18 @@ const aiRoutes: FastifyPluginAsync = async (app) => {
       return reply.code(400).send({
         error: "config.payload.model must be a non-empty string",
       });
+    }
+
+    if (payload.max_tokens !== undefined) {
+      const maxTokens = Number(payload.max_tokens);
+      if (!Number.isFinite(maxTokens) || maxTokens <= 0) {
+        return reply.code(400).send({
+          error: "config.payload.max_tokens must be a positive number",
+        });
+      }
+      // Clamp low values up rather than rejecting them — a value under this
+      // floor reliably truncates recommendation responses mid-JSON.
+      payload.max_tokens = Math.max(maxTokens, MIN_AI_CONFIG_MAX_TOKENS);
     }
 
     const validConfig = {

--- a/apps/web/src/components/settings/AiSettings.tsx
+++ b/apps/web/src/components/settings/AiSettings.tsx
@@ -145,7 +145,7 @@ export function AiSettings() {
           const auth = cfg.headers?.Authorization ?? "";
           setApiKey(auth.replace(/^Bearer\s+/i, ""));
           setModel(cfg.payload?.model ?? "");
-          setMaxTokens(cfg.payload?.max_tokens ?? 1024);
+          setMaxTokens(cfg.payload?.max_tokens ?? 4096);
           setAdvancedJson(JSON.stringify(res.config, null, 2));
         }
       } catch (err) {

--- a/apps/web/src/components/settings/AiSettings.tsx
+++ b/apps/web/src/components/settings/AiSettings.tsx
@@ -65,6 +65,12 @@ const PROVIDERS: {
   { id: "custom", label: "Custom", url: "", model: "", helpUrl: "" },
 ];
 
+// Mirrors MIN_AI_CONFIG_MAX_TOKENS in apps/api/src/lib/ai.ts — the server
+// clamps up to this floor regardless, so keep the input from suggesting a
+// lower value will actually be used.
+const MIN_MAX_TOKENS = 2048;
+const DEFAULT_MAX_TOKENS = 4096;
+
 const PLACEHOLDER_KEY_PATTERNS = [
   /your_key/i,
   /your-api-key/i,
@@ -107,7 +113,7 @@ export function AiSettings() {
   const [url, setUrl] = useState(PROVIDERS[0].url);
   const [apiKey, setApiKey] = useState("");
   const [model, setModel] = useState(PROVIDERS[0].model);
-  const [maxTokens, setMaxTokens] = useState(4096);
+  const [maxTokens, setMaxTokens] = useState(DEFAULT_MAX_TOKENS);
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [advancedJson, setAdvancedJson] = useState("");
   const [advancedJsonError, setAdvancedJsonError] = useState<string | null>(
@@ -145,7 +151,7 @@ export function AiSettings() {
           const auth = cfg.headers?.Authorization ?? "";
           setApiKey(auth.replace(/^Bearer\s+/i, ""));
           setModel(cfg.payload?.model ?? "");
-          setMaxTokens(cfg.payload?.max_tokens ?? 4096);
+          setMaxTokens(cfg.payload?.max_tokens ?? DEFAULT_MAX_TOKENS);
           setAdvancedJson(JSON.stringify(res.config, null, 2));
         }
       } catch (err) {
@@ -258,7 +264,7 @@ export function AiSettings() {
       setUrl(PROVIDERS[0].url);
       setApiKey("");
       setModel(PROVIDERS[0].model);
-      setMaxTokens(4096);
+      setMaxTokens(DEFAULT_MAX_TOKENS);
       setAdvancedJson("");
       setLastGeneratedAt(null);
       setTestStatus(null);
@@ -451,10 +457,12 @@ export function AiSettings() {
               <input
                 id="ai-max-tokens"
                 type="number"
-                min={1}
+                min={MIN_MAX_TOKENS}
                 value={maxTokens}
                 onChange={(e) => {
-                  setMaxTokens(Math.max(1, parseInt(e.target.value) || 4096));
+                  setMaxTokens(
+                    Math.max(MIN_MAX_TOKENS, parseInt(e.target.value) || DEFAULT_MAX_TOKENS)
+                  );
                   setSaved(false);
                   setTestStatus(null);
                 }}
@@ -468,7 +476,7 @@ export function AiSettings() {
                 className="mt-1 text-xs"
                 style={{ color: "var(--text-mute)" }}
               >
-                Too low truncates recommendations
+                Minimum {MIN_MAX_TOKENS} — lower values are truncated and raised automatically
               </p>
             </div>
           </div>

--- a/apps/web/src/components/settings/AiSettings.tsx
+++ b/apps/web/src/components/settings/AiSettings.tsx
@@ -107,7 +107,7 @@ export function AiSettings() {
   const [url, setUrl] = useState(PROVIDERS[0].url);
   const [apiKey, setApiKey] = useState("");
   const [model, setModel] = useState(PROVIDERS[0].model);
-  const [maxTokens, setMaxTokens] = useState(1024);
+  const [maxTokens, setMaxTokens] = useState(4096);
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [advancedJson, setAdvancedJson] = useState("");
   const [advancedJsonError, setAdvancedJsonError] = useState<string | null>(
@@ -258,7 +258,7 @@ export function AiSettings() {
       setUrl(PROVIDERS[0].url);
       setApiKey("");
       setModel(PROVIDERS[0].model);
-      setMaxTokens(1024);
+      setMaxTokens(4096);
       setAdvancedJson("");
       setLastGeneratedAt(null);
       setTestStatus(null);
@@ -454,7 +454,7 @@ export function AiSettings() {
                 min={1}
                 value={maxTokens}
                 onChange={(e) => {
-                  setMaxTokens(Math.max(1, parseInt(e.target.value) || 1024));
+                  setMaxTokens(Math.max(1, parseInt(e.target.value) || 4096));
                   setSaved(false);
                   setTestStatus(null);
                 }}
@@ -464,6 +464,12 @@ export function AiSettings() {
                   color: "var(--text)",
                 }}
               />
+              <p
+                className="mt-1 text-xs"
+                style={{ color: "var(--text-mute)" }}
+              >
+                Too low truncates recommendations
+              </p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
This PR increases the minimum `max_tokens` value for AI configurations from 1024 to 4096 to prevent recommendation responses from being silently truncated mid-JSON, which causes parse failures.

## Key Changes

- **Added `MIN_AI_CONFIG_MAX_TOKENS` constant** (2048) to enforce a floor on persisted AI configurations, preventing truncation-prone values from being saved
- **Updated `redactAiConfig()`** to clamp the returned `max_tokens` value to the minimum, ensuring the settings UI displays the effective value even for legacy configs
- **Enhanced `callAiProvider()`** to accept a `minTokens` parameter and compute dynamic token requirements based on recommendation count (400 + limit × 150 tokens per item)
- **Improved error messages** in `parseRecsFromContent()` to distinguish between truncation during reasoning (unterminated `<think>` blocks) and truncation of the JSON array itself
- **Updated API validation** in `ai.ts` routes to clamp user-provided `max_tokens` values to the minimum floor rather than rejecting them
- **Changed UI defaults** in `AiSettings.tsx` from 1024 to 4096 tokens, with a helper text warning that low values truncate recommendations
- **Added validation** for `max_tokens` to ensure it's a positive number

## Implementation Details

The fix uses a multi-layered approach:
1. **Persisted floor**: Prevents new/updated configs from storing values below 2048
2. **Dynamic per-request floor**: Calculates minimum tokens needed based on recommendation count to avoid truncation
3. **Graceful clamping**: Server-side validation clamps rather than rejects low values, improving UX
4. **Better diagnostics**: Enhanced error messages help users understand when truncation occurs and how to fix it

https://claude.ai/code/session_01Vf9SHfM7gF9zVdFgSmCjYN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved AI settings by raising the default token limit and adding a helper note about low values causing truncated recommendations.
  * Better handling of recommendation output so results are less likely to cut off early.

* **Bug Fixes**
  * Prevented saved AI token settings from dropping below a safe minimum.
  * Added clearer errors when AI responses appear truncated mid-output or before a complete array is returned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->