### PR TITLE
Filter watched titles from cached AI recommendations

### DIFF
--- a/apps/api/src/lib/ai.ts
+++ b/apps/api/src/lib/ai.ts
@@ -1,7 +1,7 @@
 import { MetadataType } from "@prisma/client";
 import type { FastifyBaseLogger } from "fastify";
 import { prisma } from "./prisma.js";
-import { trendingCacheGet, trendingCacheSet } from "./cache.js";
+import { trendingCacheGet, trendingCacheSet, trendingCacheDelete, watchedImdbIdsCache } from "./cache.js";
 import { getTmdb } from "./tmdb-client.js";
 import { getRpdbApiKey, withRpdbPoster } from "./rpdb.js";
 import { upsertMetadata } from "./metadata.js";
@@ -71,6 +71,10 @@ export const shouldRefreshAiRecs = async (): Promise<boolean> => {
 // to exclude already-watched titles from recommendations. Recommendation exclusion
 // needs completeness; the taste-profile signals below (genres/ratings/recency) don't.
 export const getWatchedImdbIds = async (profileId?: string): Promise<Set<string>> => {
+  const cacheKey = profileId ?? "__all__";
+  const cached = watchedImdbIdsCache.get(cacheKey);
+  if (cached) return cached;
+
   const [movies, episodes] = await Promise.all([
     prisma.watchEvent.findMany({
       where: { ...(profileId ? { profileId } : undefined), type: "movie" },
@@ -83,7 +87,9 @@ export const getWatchedImdbIds = async (profileId?: string): Promise<Set<string>
       select: { seriesImdbId: true },
     }),
   ]);
-  return new Set([...movies.map((m) => m.imdbId), ...episodes.map((e) => e.seriesImdbId!)]);
+  const ids = new Set([...movies.map((m) => m.imdbId), ...episodes.map((e) => e.seriesImdbId!)]);
+  watchedImdbIdsCache.set(cacheKey, ids);
+  return ids;
 };
 
 export const buildTasteProfile = async (profileId?: string) => {
@@ -258,6 +264,11 @@ const parseRecsFromContent = (content: string): AiRecItem[] => {
   }
 };
 
+// Guards against firing a duplicate background regeneration for the same cache
+// key while one is already in flight (e.g. concurrent movie/series page-load
+// requests both finding a just-filtered-short cached list).
+const regeneratingCacheKeys = new Set<string>();
+
 export const getAiRecommendations = async (
   type: "movie" | "series",
   limit = 10,
@@ -276,6 +287,18 @@ export const getAiRecommendations = async (
     const reasons = Object.fromEntries(
       Object.entries(cached.reasons ?? {}).filter(([id]) => !watchedIds.has(id))
     );
+
+    // Filtering can leave fewer than `limit` items with nothing to top up from —
+    // regenerate in the background (an LLM round trip is too slow to do inline)
+    // so the next request gets a full list again.
+    if (metas.length < limit && metas.length < cached.data.length && !regeneratingCacheKeys.has(cacheKey)) {
+      regeneratingCacheKeys.add(cacheKey);
+      trendingCacheDelete(cacheKey);
+      void getAiRecommendations(type, limit, profileId, logger)
+        .catch((error) => logger?.debug({ error }, "Background AI recs top-up failed"))
+        .finally(() => regeneratingCacheKeys.delete(cacheKey));
+    }
+
     return { metas, reasons };
   }
 

--- a/apps/api/src/lib/ai.ts
+++ b/apps/api/src/lib/ai.ts
@@ -67,6 +67,25 @@ export const shouldRefreshAiRecs = async (): Promise<boolean> => {
   return daysSinceLastGen >= 7;
 };
 
+// Full watch history (not windowed like buildTasteProfile's last-50 events), used
+// to exclude already-watched titles from recommendations. Recommendation exclusion
+// needs completeness; the taste-profile signals below (genres/ratings/recency) don't.
+export const getWatchedImdbIds = async (profileId?: string): Promise<Set<string>> => {
+  const [movies, episodes] = await Promise.all([
+    prisma.watchEvent.findMany({
+      where: { ...(profileId ? { profileId } : undefined), type: "movie" },
+      distinct: ["imdbId"],
+      select: { imdbId: true },
+    }),
+    prisma.watchEvent.findMany({
+      where: { ...(profileId ? { profileId } : undefined), type: "episode", seriesImdbId: { not: null } },
+      distinct: ["seriesImdbId"],
+      select: { seriesImdbId: true },
+    }),
+  ]);
+  return new Set([...movies.map((m) => m.imdbId), ...episodes.map((e) => e.seriesImdbId!)]);
+};
+
 export const buildTasteProfile = async (profileId?: string) => {
   const recentEvents = await prisma.watchEvent.findMany({
     where: profileId ? { profileId } : undefined,
@@ -131,7 +150,7 @@ export const buildTasteProfile = async (profileId?: string) => {
     })
     .filter((n): n is string => !!n);
 
-  const watchedImdbIds = new Set(allIds);
+  const watchedImdbIds = await getWatchedImdbIds(profileId);
 
   const avgRating =
     ratings.length > 0
@@ -247,7 +266,18 @@ export const getAiRecommendations = async (
 ): Promise<{ metas: StremioMetaPreview[]; reasons: Record<string, string> } | null> => {
   const cacheKey = `ai-recs:${type}:${limit}${profileId ? `:${profileId}` : ""}`;
   const cached = trendingCacheGet(cacheKey);
-  if (cached) return { metas: cached.data, reasons: cached.reasons ?? {} };
+  if (cached) {
+    // The cache lives up to AI_RECS_TTL_MS and isn't purged on every watch event
+    // (regeneration is rate-limited by shouldRefreshAiRecs), so titles watched
+    // since the cache was populated must be filtered out here rather than relying
+    // on the exclusion check at generation time.
+    const watchedIds = await getWatchedImdbIds(profileId);
+    const metas = cached.data.filter((m) => !watchedIds.has(m.id));
+    const reasons = Object.fromEntries(
+      Object.entries(cached.reasons ?? {}).filter(([id]) => !watchedIds.has(id))
+    );
+    return { metas, reasons };
+  }
 
   const config = await getAiConfig();
   if (!config) return null;

--- a/apps/api/src/lib/cache.ts
+++ b/apps/api/src/lib/cache.ts
@@ -8,8 +8,17 @@ export const TRENDING_CACHE_TTL_MS = 30 * 60 * 1000;
 export const CAST_CACHE_TTL_MS = 60 * 60 * 1000;
 export const WATCH_PROVIDERS_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 export const EXTERNAL_IDS_CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+// Short-lived: this only exists to collapse the burst of watched-history lookups
+// that back-to-back requests (e.g. the movie + series AI recs calls on page load)
+// trigger, not to serve as a source of truth — kept well under a minute so a
+// just-recorded watch event is reflected almost immediately.
+export const WATCHED_IMDB_IDS_CACHE_TTL_MS = 30 * 1000;
 
 export const trendingCache = new LRUCache<string, TrendingCacheEntry>({ max: 100, ttl: TRENDING_CACHE_TTL_MS });
+export const watchedImdbIdsCache = new LRUCache<string, Set<string>>({
+  max: 200,
+  ttl: WATCHED_IMDB_IDS_CACHE_TTL_MS,
+});
 export const castCache = new LRUCache<string, CastMember[]>({ max: 500, ttl: CAST_CACHE_TTL_MS });
 export const seasonsCache = new LRUCache<string, SeasonInfo[]>({ max: 500, ttl: CAST_CACHE_TTL_MS });
 export const watchProvidersCache = new LRUCache<string, WatchProviders>({
@@ -25,6 +34,10 @@ export const trendingCacheGet = (key: string): TrendingCacheEntry | undefined =>
 
 export const trendingCacheSet = (key: string, entry: TrendingCacheEntry, ttl?: number) => {
   trendingCache.set(key, entry, ttl !== undefined ? { ttl } : undefined);
+};
+
+export const trendingCacheDelete = (key: string) => {
+  trendingCache.delete(key);
 };
 
 export const trendingCacheDeletePrefix = (prefix: string) => {


### PR DESCRIPTION
## Summary
This PR improves the AI recommendations system to properly exclude already-watched titles even when serving cached recommendations. Previously, watched titles could reappear in recommendations if they were watched after the cache was populated but before it expired.

## Key Changes
- **New `getWatchedImdbIds()` function**: Extracts a helper function that retrieves the complete watch history (both movies and TV series) for a profile. This uses the full history rather than a windowed approach, ensuring accurate exclusion of watched content.
- **Updated `buildTasteProfile()`**: Refactored to use the new `getWatchedImdbIds()` function instead of building the watched set inline, reducing code duplication.
- **Enhanced `getAiRecommendations()` caching logic**: Added filtering of cached recommendations against the current watch history. Since the cache can live up to `AI_RECS_TTL_MS` and regeneration is rate-limited, titles watched after cache population are now filtered out at serve time rather than relying solely on generation-time exclusion.

## Implementation Details
- The `getWatchedImdbIds()` function queries both `watchEvent` records for movies and series separately, using `distinct` to avoid duplicates and returning a `Set<string>` for efficient lookups.
- Cache filtering applies the same exclusion logic to both the metadata list and the reasons dictionary to keep them in sync.
- The solution maintains backward compatibility while ensuring recommendations remain fresh relative to the user's actual watch history.

https://claude.ai/code/session_01XvfzUAcxbYpV3dAjDNGbZ7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Recommendations now exclude titles you’ve already watched, even when results come from cache.
  * Watch history used for filtering is more complete, covering both movies and TV episodes/series entries.
  * Taste-based recommendations now use full watch history for exclusions, improving relevance and reducing repeat suggestions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->