### PR TITLE
Add calendar page with agenda and month views

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,6 +1,6 @@
 import { lazy, Suspense, useEffect, useState } from "react";
 import { Link, Route, Routes, useLocation } from "react-router-dom";
-import { BarChart3, Clapperboard, History, Loader2, Search, List, Settings, User } from "lucide-react";
+import { BarChart3, CalendarDays, Clapperboard, History, Loader2, Search, List, Settings, User } from "lucide-react";
 import { api, Profile, runtimeConfig } from "./api";
 import { CommandPalette, useCommandPalette } from "./components/CommandPalette";
 import { InstallButton } from "./components/InstallButton";
@@ -13,6 +13,7 @@ import { DashboardPage } from "./pages/DashboardPage";
 import { ProfileSwitcher } from "./pages/ProfileSwitcher";
 import { SetupWizard } from "./pages/SetupWizard";
 
+const CalendarPage = lazy(() => import("./pages/CalendarPage").then((m) => ({ default: m.CalendarPage })));
 const HistoryPage = lazy(() => import("./pages/HistoryPage").then((m) => ({ default: m.HistoryPage })));
 const ListsPage = lazy(() => import("./pages/ListsPage").then((m) => ({ default: m.ListsPage })));
 const NotFoundPage = lazy(() => import("./pages/NotFoundPage").then((m) => ({ default: m.NotFoundPage })));
@@ -24,6 +25,7 @@ const mobileNavItems = [
   { to: "/", label: "Dashboard", icon: Clapperboard, end: true },
   { to: "/search", label: "Search", icon: Search, end: false },
   { to: "/lists", label: "Lists", icon: List, end: false },
+  { to: "/calendar", label: "Calendar", icon: CalendarDays, end: false },
   { to: "/history", label: "History", icon: History, end: false },
   { to: "/stats", label: "Stats", icon: BarChart3, end: false },
 ] as const;
@@ -200,6 +202,7 @@ function AppShell({
             <Route path="/" element={<DashboardPage />} />
             <Route path="/search" element={<SearchPage />} />
             <Route path="/lists/*" element={<ListsPage />} />
+            <Route path="/calendar" element={<CalendarPage />} />
             <Route path="/history" element={<HistoryPage />} />
             <Route path="/stats" element={<StatsPage />} />
             <Route path="/settings" element={<SettingsPage />} />

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { BarChart3, Clapperboard, Film, List, Search, Settings, Tv } from "lucide-react";
+import { BarChart3, CalendarDays, Clapperboard, Film, List, Search, Settings, Tv } from "lucide-react";
 import { api, SearchResult } from "../api";
 import { Poster } from "./Poster";
 import { DetailPanel, useDetailPanel } from "./MediaDetailPanel";
@@ -105,6 +105,7 @@ export function CommandPalette({ open, onClose }: { open: boolean; onClose: () =
     { id: "nav-dashboard", label: "Go to Dashboard", icon: Clapperboard, run: () => { onClose(); navigate("/"); } },
     { id: "nav-search", label: "Go to Search", icon: Search, run: () => { onClose(); navigate("/search"); } },
     { id: "nav-lists", label: "Go to Lists", icon: List, run: () => { onClose(); navigate("/lists"); } },
+    { id: "nav-calendar", label: "Go to Calendar", icon: CalendarDays, run: () => { onClose(); navigate("/calendar"); } },
     { id: "nav-stats", label: "Go to Stats", icon: BarChart3, run: () => { onClose(); navigate("/stats"); } },
     { id: "nav-settings", label: "Go to Settings", icon: Settings, run: () => { onClose(); navigate("/settings"); } },
   ];

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1,12 +1,13 @@
 import { useEffect, useRef, useState } from "react";
 import { NavLink } from "react-router-dom";
-import { BarChart3, Clapperboard, History, Pin, PinOff, Search, List, Settings, User } from "lucide-react";
+import { BarChart3, CalendarDays, Clapperboard, History, Pin, PinOff, Search, List, Settings, User } from "lucide-react";
 import { Profile } from "../api";
 
 const navItems = [
   { to: "/", label: "Dashboard", icon: Clapperboard, end: true },
   { to: "/search", label: "Search", icon: Search, end: false },
   { to: "/lists", label: "Lists", icon: List, end: false },
+  { to: "/calendar", label: "Calendar", icon: CalendarDays, end: false },
   { to: "/history", label: "History", icon: History, end: false },
   { to: "/stats", label: "Stats", icon: BarChart3, end: false },
   { to: "/settings", label: "Settings", icon: Settings, end: false },

--- a/apps/web/src/components/media-detail/DropShowButton.tsx
+++ b/apps/web/src/components/media-detail/DropShowButton.tsx
@@ -22,20 +22,17 @@ export function DropShowButton({
   };
 
   return (
-    <div className="pt-2 border-t" style={{ borderColor: "var(--border)" }}>
+    <div className="flex justify-end pt-1">
       <button
         type="button"
         onClick={handleClick}
         aria-pressed={isDropped}
         title={isDropped ? "Undrop this show" : "Mark this show as dropped"}
-        className={`w-full flex items-center justify-center gap-2 rounded-xl px-4 py-2.5 text-sm font-semibold transition-colors ${
-          isDropped
-            ? "hover:bg-[var(--surface-strong)]"
-            : "bg-rose-500/10 text-rose-500 ring-1 ring-rose-500/20 hover:bg-rose-500/20"
+        className={`inline-flex items-center gap-1.5 rounded-lg px-2 py-1 text-xs font-medium transition-colors ${
+          isDropped ? "text-[var(--text-dim)] hover:text-rose-500" : "text-[var(--text-mute)] hover:text-rose-500"
         }`}
-        style={isDropped ? { background: "var(--surface)", color: "var(--text-dim)" } : undefined}
       >
-        {isDropped ? <Check className="h-4 w-4" aria-hidden="true" /> : <X className="h-4 w-4" aria-hidden="true" />}
+        {isDropped ? <Check className="h-3.5 w-3.5" aria-hidden="true" /> : <X className="h-3.5 w-3.5" aria-hidden="true" />}
         {isDropped ? "Dropped" : "Drop Show"}
       </button>
     </div>

--- a/apps/web/src/pages/CalendarPage.tsx
+++ b/apps/web/src/pages/CalendarPage.tsx
@@ -1,0 +1,375 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { CalendarDays, ChevronLeft, ChevronRight, List, LayoutGrid } from "lucide-react";
+import { api, CalendarEntry, SearchResult } from "../api";
+import { DetailPanel, useDetailPanel } from "../components/MediaDetailPanel";
+import { Poster } from "../components/Poster";
+import { useToast } from "../hooks/useToast";
+
+type ViewMode = "agenda" | "month";
+const AGENDA_RANGES = [14, 30, 60, 90] as const;
+const MAX_CALENDAR_DAYS = 90;
+
+function toSearchResult(entry: CalendarEntry): SearchResult {
+  return {
+    imdbId: entry.seriesImdbId,
+    type: "series",
+    name: entry.seriesName,
+    year: null,
+    poster: entry.poster,
+    description: entry.overview,
+    genres: [],
+    rating: null,
+    inWatchlist: false,
+    inCollection: false,
+    lists: [],
+  };
+}
+
+function parseAirDate(airDate: string): Date {
+  const [y, m, d] = airDate.split("-").map(Number);
+  return new Date(y, m - 1, d);
+}
+
+function startOfDay(d: Date): Date {
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate());
+}
+
+function startOfMonth(d: Date): Date {
+  return new Date(d.getFullYear(), d.getMonth(), 1);
+}
+
+function addMonths(d: Date, n: number): Date {
+  return new Date(d.getFullYear(), d.getMonth() + n, 1);
+}
+
+function dateKey(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+function dateLabelFor(airDate: Date, today: Date): string {
+  const diffDays = Math.round((startOfDay(airDate).getTime() - startOfDay(today).getTime()) / 86_400_000);
+  if (diffDays === 0) return "Today";
+  if (diffDays === 1) return "Tomorrow";
+  return airDate.toLocaleDateString(undefined, { weekday: "long", month: "long", day: "numeric" });
+}
+
+const WEEKDAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+export function CalendarPage() {
+  const [view, setView] = useState<ViewMode>("agenda");
+  const [agendaDays, setAgendaDays] = useState<(typeof AGENDA_RANGES)[number]>(30);
+  const [monthCursor, setMonthCursor] = useState(() => startOfMonth(new Date()));
+  const [entries, setEntries] = useState<CalendarEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const { showToast } = useToast();
+  const { selectedItem, setSelectedItem, panelHistory, setPanelHistory, panelHistoryLoading } = useDetailPanel();
+
+  const today = useMemo(() => startOfDay(new Date()), []);
+
+  // How many days ahead to request from the API depends on the active view:
+  // agenda uses the selected range directly, month view needs enough days to
+  // cover the last day of the displayed month (capped at what the API allows).
+  const daysNeeded = useMemo(() => {
+    if (view === "agenda") return agendaDays;
+    const monthEnd = new Date(monthCursor.getFullYear(), monthCursor.getMonth() + 1, 0);
+    const diff = Math.round((startOfDay(monthEnd).getTime() - today.getTime()) / 86_400_000);
+    return Math.min(Math.max(diff, 1), MAX_CALENDAR_DAYS);
+  }, [view, agendaDays, monthCursor, today]);
+
+  // The displayed month is entirely beyond what the API can return.
+  const monthOutOfRange = useMemo(() => {
+    if (view !== "month") return false;
+    const monthStart = startOfMonth(monthCursor);
+    const diff = Math.round((monthStart.getTime() - today.getTime()) / 86_400_000);
+    return diff > MAX_CALENDAR_DAYS;
+  }, [view, monthCursor, today]);
+
+  const load = useCallback(async (days: number) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await api.getCalendar(days);
+      setEntries(res.calendar);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load calendar");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (monthOutOfRange) {
+      setEntries([]);
+      setLoading(false);
+      return;
+    }
+    void load(daysNeeded);
+  }, [daysNeeded, monthOutOfRange, load]);
+
+  const entriesByDate = useMemo(() => {
+    const map = new Map<string, CalendarEntry[]>();
+    for (const entry of entries) {
+      const key = dateKey(parseAirDate(entry.airDate));
+      const list = map.get(key);
+      if (list) list.push(entry);
+      else map.set(key, [entry]);
+    }
+    return map;
+  }, [entries]);
+
+  const agendaGroups = useMemo(() => {
+    const sorted = [...entries].sort((a, b) => a.airDate.localeCompare(b.airDate));
+    const groups: { label: string; date: Date; entries: CalendarEntry[] }[] = [];
+    for (const entry of sorted) {
+      const airDate = parseAirDate(entry.airDate);
+      const label = dateLabelFor(airDate, today);
+      const last = groups[groups.length - 1];
+      if (last && last.label === label) last.entries.push(entry);
+      else groups.push({ label, date: airDate, entries: [entry] });
+    }
+    return groups;
+  }, [entries, today]);
+
+  const monthWeeks = useMemo(() => {
+    const first = monthCursor;
+    const gridStart = new Date(first);
+    gridStart.setDate(gridStart.getDate() - gridStart.getDay());
+    const lastDayOfMonth = new Date(first.getFullYear(), first.getMonth() + 1, 0);
+    const gridEnd = new Date(lastDayOfMonth);
+    gridEnd.setDate(gridEnd.getDate() + (6 - gridEnd.getDay()));
+
+    const weeks: Date[][] = [];
+    const cursor = new Date(gridStart);
+    while (cursor <= gridEnd) {
+      const week: Date[] = [];
+      for (let d = 0; d < 7; d++) {
+        week.push(new Date(cursor));
+        cursor.setDate(cursor.getDate() + 1);
+      }
+      weeks.push(week);
+    }
+    return weeks;
+  }, [monthCursor]);
+
+  const handleSelect = (entry: CalendarEntry) => setSelectedItem(toSearchResult(entry));
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-2.5">
+          <CalendarDays className="h-6 w-6" style={{ color: "var(--text-dim)" }} />
+          <h2 className="text-2xl font-bold" style={{ color: "var(--text)" }}>Calendar</h2>
+        </div>
+
+        <div className="relative inline-flex rounded-full p-0.5" style={{ background: "var(--surface-strong)", border: "1px solid var(--border)" }}>
+          {([
+            { key: "agenda" as const, label: "Agenda", icon: List },
+            { key: "month" as const, label: "Month", icon: LayoutGrid },
+          ]).map((opt) => (
+            <button
+              key={opt.key}
+              type="button"
+              onClick={() => setView(opt.key)}
+              className="relative flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-400 focus-visible:ring-offset-2"
+              style={view === opt.key ? { background: "var(--accent)", color: "white" } : { color: "var(--text-dim)" }}
+            >
+              <opt.icon className="h-3.5 w-3.5" />
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {error && (
+        <p className="rounded-xl bg-rose-500/5 border border-rose-500/20 px-4 py-3 text-rose-600 text-sm">{error}</p>
+      )}
+
+      {view === "agenda" ? (
+        <>
+          <div className="flex items-center gap-1.5">
+            {AGENDA_RANGES.map((d) => (
+              <button
+                key={d}
+                type="button"
+                onClick={() => setAgendaDays(d)}
+                className={`rounded-full px-3 py-1.5 text-xs font-medium transition-all ${
+                  agendaDays === d ? "bg-claw-500 text-white" : "hover:text-[var(--text)]"
+                }`}
+                style={agendaDays === d ? undefined : { color: "var(--text-mute)", border: "1px solid var(--border)" }}
+              >
+                {d} Days
+              </button>
+            ))}
+          </div>
+
+          {loading ? (
+            <div className="space-y-2">
+              {Array.from({ length: 5 }).map((_, i) => (
+                <div key={i} className="skeleton h-20 rounded-xl" />
+              ))}
+            </div>
+          ) : agendaGroups.length === 0 ? (
+            <div className="rounded-2xl p-8 text-center" style={{ border: "1px solid var(--border)", background: "var(--bg-1)" }}>
+              <CalendarDays className="mx-auto h-10 w-10" style={{ color: "var(--text-mute)" }} />
+              <p className="mt-3 text-sm" style={{ color: "var(--text-dim)" }}>
+                No upcoming episodes in the next {agendaDays} days for your in-progress series.
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-6">
+              {agendaGroups.map((group) => (
+                <div key={group.label} className="space-y-2">
+                  <h3 className="text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--text-mute)" }}>
+                    {group.label}
+                  </h3>
+                  {group.entries.map((entry) => (
+                    <button
+                      key={`${entry.seriesImdbId}-s${entry.season}e${entry.episode}`}
+                      type="button"
+                      onClick={() => handleSelect(entry)}
+                      className="flex w-full items-center gap-3 rounded-xl p-3 text-left transition-colors hover:bg-[var(--surface-strong)] focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-400 focus-visible:ring-offset-2"
+                      style={{ border: "1px solid var(--border)", background: "var(--bg-1)" }}
+                    >
+                      <div className="h-16 w-11 flex-none overflow-hidden rounded-lg" style={{ boxShadow: "0 0 0 1px var(--border)" }}>
+                        <Poster src={entry.poster ?? undefined} alt={entry.seriesName} className="h-full w-full" sizes="44px" />
+                      </div>
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate text-sm font-semibold" style={{ color: "var(--text)" }}>{entry.seriesName}</p>
+                        <p className="mt-0.5 truncate text-xs" style={{ color: "var(--text-dim)" }}>
+                          S{entry.season}:E{entry.episode}{entry.episodeName ? ` — ${entry.episodeName}` : ""}
+                        </p>
+                        {entry.overview && (
+                          <p className="mt-1 line-clamp-2 text-xs" style={{ color: "var(--text-mute)" }}>{entry.overview}</p>
+                        )}
+                      </div>
+                    </button>
+                  ))}
+                </div>
+              ))}
+            </div>
+          )}
+        </>
+      ) : (
+        <>
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-1.5">
+              <button
+                type="button"
+                onClick={() => setMonthCursor((prev) => addMonths(prev, -1))}
+                aria-label="Previous month"
+                className="flex h-8 w-8 items-center justify-center rounded-lg transition-colors hover:bg-[var(--surface-strong)]"
+                style={{ border: "1px solid var(--border)", color: "var(--text-dim)" }}
+              >
+                <ChevronLeft className="h-4 w-4" />
+              </button>
+              <button
+                type="button"
+                onClick={() => setMonthCursor((prev) => addMonths(prev, 1))}
+                aria-label="Next month"
+                className="flex h-8 w-8 items-center justify-center rounded-lg transition-colors hover:bg-[var(--surface-strong)]"
+                style={{ border: "1px solid var(--border)", color: "var(--text-dim)" }}
+              >
+                <ChevronRight className="h-4 w-4" />
+              </button>
+              <button
+                type="button"
+                onClick={() => setMonthCursor(startOfMonth(new Date()))}
+                className="ml-1 rounded-lg px-3 py-1.5 text-xs font-medium transition-colors hover:bg-[var(--surface-strong)]"
+                style={{ border: "1px solid var(--border)", color: "var(--text-dim)" }}
+              >
+                Today
+              </button>
+            </div>
+            <p className="text-lg font-bold" style={{ color: "var(--text)" }}>
+              {monthCursor.toLocaleDateString(undefined, { month: "long", year: "numeric" })}
+            </p>
+          </div>
+
+          {monthOutOfRange ? (
+            <div className="rounded-2xl p-8 text-center" style={{ border: "1px solid var(--border)", background: "var(--bg-1)" }}>
+              <CalendarDays className="mx-auto h-10 w-10" style={{ color: "var(--text-mute)" }} />
+              <p className="mt-3 text-sm" style={{ color: "var(--text-dim)" }}>
+                This month is too far out — the calendar only looks {MAX_CALENDAR_DAYS} days ahead.
+              </p>
+            </div>
+          ) : (
+            <div className="overflow-hidden rounded-2xl" style={{ border: "1px solid var(--border)" }}>
+              <div className="grid grid-cols-7" style={{ borderBottom: "1px solid var(--border)" }}>
+                {WEEKDAY_LABELS.map((label) => (
+                  <div key={label} className="px-2 py-2 text-center text-2xs font-semibold uppercase tracking-wider" style={{ color: "var(--text-mute)" }}>
+                    {label}
+                  </div>
+                ))}
+              </div>
+              {loading ? (
+                <div className="p-4">
+                  <div className="skeleton h-64 rounded-lg" />
+                </div>
+              ) : (
+                <div>
+                  {monthWeeks.map((week, wi) => (
+                    <div key={wi} className="grid grid-cols-7" style={{ borderTop: wi > 0 ? "1px solid var(--border)" : undefined }}>
+                      {week.map((day) => {
+                        const inMonth = day.getMonth() === monthCursor.getMonth();
+                        const isToday = startOfDay(day).getTime() === today.getTime();
+                        const dayEntries = entriesByDate.get(dateKey(day)) ?? [];
+                        return (
+                          <div
+                            key={day.toISOString()}
+                            className="min-h-[6.5rem] p-1.5"
+                            style={{
+                              borderLeft: "1px solid var(--border)",
+                              background: inMonth ? undefined : "var(--surface)",
+                              opacity: inMonth ? 1 : 0.5,
+                            }}
+                          >
+                            <span
+                              className={`inline-flex h-5 min-w-5 items-center justify-center rounded-full px-1 text-2xs font-semibold ${isToday ? "bg-claw-500 text-white" : ""}`}
+                              style={isToday ? undefined : { color: "var(--text-mute)" }}
+                            >
+                              {day.getDate()}
+                            </span>
+                            <div className="mt-1 space-y-1">
+                              {dayEntries.slice(0, 2).map((entry) => (
+                                <button
+                                  key={`${entry.seriesImdbId}-s${entry.season}e${entry.episode}`}
+                                  type="button"
+                                  onClick={() => handleSelect(entry)}
+                                  title={`${entry.seriesName} S${entry.season}:E${entry.episode}`}
+                                  className="block w-full truncate rounded px-1 py-0.5 text-left text-2xs font-medium transition-colors hover:opacity-80"
+                                  style={{ background: "color-mix(in srgb, var(--accent) 15%, transparent)", color: "var(--accent)" }}
+                                >
+                                  {entry.seriesName}
+                                </button>
+                              ))}
+                              {dayEntries.length > 2 && (
+                                <p className="px-1 text-2xs" style={{ color: "var(--text-mute)" }}>+{dayEntries.length - 2} more</p>
+                              )}
+                            </div>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+        </>
+      )}
+
+      {selectedItem && (
+        <DetailPanel
+          item={selectedItem}
+          history={panelHistory}
+          historyLoading={panelHistoryLoading}
+          onClose={() => setSelectedItem(null)}
+          onShowToast={showToast}
+          onHistoryChange={(events) => setPanelHistory(events)}
+        />
+      )}
+
+    </div>
+  );
+}

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -679,6 +679,14 @@ export function DashboardPage() {
   const monthly = detailedStats?.monthly ?? [];
   const hasUpcoming = calendarLoading || calendarEntries.length > 0;
 
+  // The check-in hero and the Continue Watching hero can end up showing the same series
+  // (e.g. actively checked into the episode that's also furthest along in progress).
+  // When that happens, skip the redundant Continue hero and fold that series into the row instead.
+  const checkinSeriesId = activeCheckin ? (activeCheckin.type === "episode" ? activeCheckin.seriesImdbId : activeCheckin.imdbId) : null;
+  const checkinMatchesTopProgress = checkinSeriesId != null && progress[0]?.imdbId === checkinSeriesId;
+  const continueHeroItem = checkinMatchesTopProgress ? undefined : progress[0];
+  const continueRowItems = checkinMatchesTopProgress ? progress : progress.slice(1);
+
   return (
     <div className="space-y-8">
       {/* ── Greeting strip ── */}
@@ -821,16 +829,18 @@ export function DashboardPage() {
           </div>
         ) : (
           <>
-            <ContinueWatchingHero
-              s={progress[0]}
-              isMarking={markingNext.has(progress[0].imdbId)}
-              isDone={markedDone.has(progress[0].imdbId)}
-              onMarkNext={() => void handleMarkNext(progress[0].imdbId)}
-              onSelect={() => setSelectedItem(toSearchResult(progress[0].imdbId, "series", progress[0].name, { poster: progress[0].poster }))}
-            />
-            {progress.length > 1 && (
+            {continueHeroItem && (
+              <ContinueWatchingHero
+                s={continueHeroItem}
+                isMarking={markingNext.has(continueHeroItem.imdbId)}
+                isDone={markedDone.has(continueHeroItem.imdbId)}
+                onMarkNext={() => void handleMarkNext(continueHeroItem.imdbId)}
+                onSelect={() => setSelectedItem(toSearchResult(continueHeroItem.imdbId, "series", continueHeroItem.name, { poster: continueHeroItem.poster }))}
+              />
+            )}
+            {continueRowItems.length > 0 && (
               <div ref={continueScroll.ref} className="flex gap-4 overflow-x-auto pb-2 scroll-smooth scrollbar-hide">
-                {progress.slice(1).map((s, index) => (
+                {continueRowItems.map((s, index) => (
                   <ContinueWatchingCard
                     key={s.imdbId}
                     s={s}

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -895,7 +895,11 @@ export function DashboardPage() {
 
         {hasUpcoming && (
           <section>
-            <SectionHeader title="Upcoming" count={calendarEntries.length} />
+            <SectionHeader title="Upcoming" count={calendarEntries.length}>
+              <Link to="/calendar" className="text-sm font-medium text-claw-400 hover:text-claw-300 transition-colors">
+                Full calendar &rarr;
+              </Link>
+            </SectionHeader>
             {calendarLoading ? (
               <div className="space-y-2">
                 {Array.from({ length: 3 }).map((_, i) => (

--- a/apps/web/src/pages/HistoryPage.tsx
+++ b/apps/web/src/pages/HistoryPage.tsx
@@ -199,7 +199,7 @@ export function HistoryPage() {
                   tabIndex={0}
                   onClick={() => setSelectedItem(toSearchResult(event))}
                   onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); setSelectedItem(toSearchResult(event)); } }}
-                  className="flex cursor-pointer items-center gap-3 rounded-xl p-3 transition-colors hover:bg-[var(--surface-strong)] focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-400 focus-visible:ring-offset-2"
+                  className="group flex cursor-pointer items-center gap-3 rounded-xl p-3 transition-colors hover:bg-[var(--surface-strong)] focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-400 focus-visible:ring-offset-2"
                   style={{ border: "1px solid var(--border)", background: "var(--bg-1)" }}
                 >
                   <div
@@ -236,7 +236,7 @@ export function HistoryPage() {
                     type="button"
                     onClick={(e) => { e.stopPropagation(); void handleDelete(event.id); }}
                     disabled={deletingId === event.id}
-                    className="flex h-9 w-9 flex-none items-center justify-center rounded-lg transition-colors hover:bg-rose-500/10 disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-rose-400 focus-visible:ring-offset-2"
+                    className="flex h-9 w-9 flex-none items-center justify-center rounded-lg opacity-100 transition-all sm:opacity-0 sm:group-hover:opacity-100 hover:bg-rose-500/10 disabled:opacity-50 focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-rose-400 focus-visible:ring-offset-2"
                     aria-label="Delete watch event"
                     title="Remove from history"
                   >

--- a/apps/web/src/pages/ListsPage.tsx
+++ b/apps/web/src/pages/ListsPage.tsx
@@ -417,7 +417,7 @@ export function ListsPage() {
           />
           <button
             type="submit"
-            className="rounded-xl bg-emerald-600 px-4 py-2.5 text-sm font-semibold text-white hover:bg-emerald-500 transition-colors"
+            className="rounded-xl bg-claw-500 px-4 py-2.5 text-sm font-semibold text-white hover:bg-claw-600 transition-colors"
           >
             Create
           </button>
@@ -502,17 +502,27 @@ export function ListsPage() {
                     style={{ borderColor: "var(--border)", color: "var(--text)", background: "var(--bg-1)" }}
                   />
                 </div>
-                <select
-                  value={sortBy}
-                  onChange={(e) => setSortBy(e.target.value as SortOption)}
+                <div
+                  role="group"
                   aria-label="Sort items"
-                  className="rounded-full border px-3.5 py-2 text-sm focus:border-claw-500 focus:outline-none focus:ring-2 focus:ring-claw-500/15"
-                  style={{ borderColor: "var(--border)", color: "var(--text-dim)", background: "var(--bg-1)" }}
+                  className="flex flex-none items-center gap-1 rounded-full border p-1"
+                  style={{ borderColor: "var(--border)", background: "var(--bg-1)" }}
                 >
-                  {Object.entries(SORT_LABELS).map(([value, label]) => (
-                    <option key={value} value={value}>Sort: {label}</option>
+                  {(Object.entries(SORT_LABELS) as [SortOption, string][]).map(([value, label]) => (
+                    <button
+                      key={value}
+                      type="button"
+                      onClick={() => setSortBy(value)}
+                      aria-pressed={sortBy === value}
+                      className={`rounded-full px-3 py-1.5 text-xs font-medium transition-all ${
+                        sortBy === value ? "bg-claw-500 text-white" : "hover:text-[var(--text)]"
+                      }`}
+                      style={sortBy === value ? undefined : { color: "var(--text-mute)" }}
+                    >
+                      {label}
+                    </button>
                   ))}
-                </select>
+                </div>
               </div>
             )}
 


### PR DESCRIPTION
## Summary
This PR adds a new Calendar page that displays upcoming TV episodes for series in the user's collection. The calendar supports two view modes (agenda and month) and integrates with the existing detail panel system.

## Key Changes

- **New CalendarPage component** (`apps/web/src/pages/CalendarPage.tsx`):
  - Agenda view: Shows upcoming episodes grouped by date with configurable lookahead (14, 30, 60, or 90 days)
  - Month view: Calendar grid display with navigation between months
  - Handles API constraints (max 90 days lookahead) with appropriate messaging
  - Integrates with detail panel for episode/series information
  - Responsive UI with skeleton loaders and empty states

- **Navigation updates**:
  - Added Calendar icon and route to main navigation (App.tsx, Sidebar.tsx, CommandPalette.tsx)
  - Added "Full calendar" link from Dashboard's Upcoming section

- **Dashboard improvements**:
  - Deduplication logic: When the active check-in series matches the top progress item, the Continue Watching hero is hidden to avoid redundancy
  - The matching series is folded into the Continue Watching row instead

- **UI refinements**:
  - ListsPage: Converted sort dropdown to button group for consistency
  - DropShowButton: Simplified styling and layout (smaller, right-aligned)
  - SectionHeader: Now accepts children for additional actions

## Implementation Details

- Calendar data is fetched based on the active view's requirements (agenda range or month end date)
- Entries are grouped by date in agenda view and mapped by date key for month view
- Month navigation prevents viewing beyond the 90-day API limit with user-friendly messaging
- Uses existing design tokens and component patterns (Poster, DetailPanel, useToast)
- Proper date handling with timezone-safe date key generation

https://claude.ai/code/session_01LU9Bp6ddEkV8TfEtFMQGpB