### PR TITLE
Bump Docker base images from node:20-alpine to node:26-alpine

### DIFF
--- a/apps/addon/Dockerfile
+++ b/apps/addon/Dockerfile
@@ -1,7 +1,7 @@
-FROM node:20-alpine
+FROM node:26-alpine
 
 WORKDIR /app
-RUN corepack enable
+RUN npm install -g corepack@latest && corepack enable
 RUN apk add --no-cache wget
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json eslint.config.mjs .npmrc ./

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,7 +1,7 @@
-FROM node:20-alpine AS build
+FROM node:26-alpine AS build
 
 WORKDIR /app
-RUN corepack enable
+RUN npm install -g corepack@latest && corepack enable
 RUN apk add --no-cache openssl
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json eslint.config.mjs .npmrc ./
@@ -21,10 +21,10 @@ RUN pnpm --filter @cataloggy/api build
 
 RUN pnpm prune --prod
 
-FROM node:20-alpine AS runtime
+FROM node:26-alpine AS runtime
 
 WORKDIR /app
-RUN corepack enable
+RUN npm install -g corepack@latest && corepack enable
 RUN apk add --no-cache wget openssl
 
 COPY --from=build /app/node_modules ./node_modules

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,7 +1,7 @@
-FROM node:20-alpine AS build
+FROM node:26-alpine AS build
 
 WORKDIR /app
-RUN corepack enable
+RUN npm install -g corepack@latest && corepack enable
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json eslint.config.mjs .npmrc ./
 COPY apps/web/package.json ./apps/web/package.json
@@ -14,7 +14,7 @@ COPY apps/web ./apps/web
 
 RUN pnpm --filter @cataloggy/web build
 
-FROM node:20-alpine AS runtime
+FROM node:26-alpine AS runtime
 
 WORKDIR /app
 RUN apk add --no-cache wget && npm install -g serve@14


### PR DESCRIPTION
## Summary
Applies the Node base image bump proposed by Dependabot in #276, #277, and #278 (apps/addon, apps/web, apps/api respectively), reapplied fresh on top of `main` since those branches had gone stale relative to the recent dependency migration (#308).

## Key fix
Node.js removed Corepack from its distributed tarballs/images starting in v25 (`build: stop distributing Corepack`, confirmed in the official v25.0.0 and v26.0.0 release notes). All three Dockerfiles ran `RUN corepack enable` immediately after `FROM node:20-alpine`, which would fail outright on `node:26-alpine` since the `corepack` binary no longer exists there.

Fixed by installing Corepack via npm first, in every build stage that needs pnpm:
```dockerfile
RUN npm install -g corepack@latest && corepack enable
```

## Changes
- `apps/api/Dockerfile`: bump both `build` and `runtime` stages to `node:26-alpine`, fix corepack in both.
- `apps/web/Dockerfile`: bump both `build` and `runtime` stages to `node:26-alpine`, fix corepack in the `build` stage (the `runtime` stage doesn't use pnpm).
- `apps/addon/Dockerfile`: bump the single stage to `node:26-alpine`, fix corepack.

## Caveat
Docker registry pulls weren't available in the environment this was prepared in, so the Docker build couldn't be run end-to-end to verify. The fix is based on Node.js's own authoritative release notes rather than an executed build — worth confirming via real CI/manual build before merging.

## Test plan
- [ ] CI passes (`lint-typecheck-test-build`)
- [ ] `docker build -f apps/api/Dockerfile .` succeeds
- [ ] `docker build -f apps/web/Dockerfile .` succeeds
- [ ] `docker build -f apps/addon/Dockerfile .` succeeds
- [ ] Manually verify each container starts and passes its healthcheck
