### PR TITLE
Add MIT license, credit author, fix README project structure

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 TheShield2594
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ cataloggy/
   apps/
     api/        # Fastify API + Prisma
     addon/      # Stremio/Omni addon service
+    web/        # React + Vite PWA frontend
   packages/
     shared/     # shared types/utilities
   docker-compose.yml
@@ -235,3 +236,11 @@ Cataloggy is designed for self-hosting on a trusted local network (LAN), not for
   ```bash
   pnpm --filter @cataloggy/api prisma:push
   ```
+
+## Author
+
+Created and maintained by [TheShield2594](https://github.com/TheShield2594).
+
+## License
+
+Cataloggy is licensed under the [MIT License](LICENSE).

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "private": true,
   "version": "0.1.0",
   "type": "module",
+  "license": "MIT",
+  "author": "TheShield2594",
   "packageManager": "pnpm@9.12.0",
   "scripts": {
     "dev": "pnpm -r --parallel dev",


### PR DESCRIPTION
Adds a LICENSE file (MIT) and license/author metadata to package.json.
Fixes the README's project structure diagram, which was missing the
web app, and adds Author and License sections.