### PR TITLE
Simplify Docker CMD by using working directory

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -43,4 +43,4 @@ ENV NODE_ENV=production
 
 EXPOSE 7000
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s CMD wget -q --spider http://127.0.0.1:7000/health || exit 1
-CMD ["sh", "-c", "pnpm exec prisma migrate deploy --schema=apps/api/prisma/schema.prisma && node apps/api/dist/index.js"]
+CMD ["sh", "-c", "cd apps/api && pnpm exec prisma migrate deploy && node dist/index.js"]


### PR DESCRIPTION
## Summary
Simplified the Docker CMD instruction in the API Dockerfile by leveraging the working directory context instead of specifying full paths.

## Changes
- Changed the CMD to use `cd apps/api` to set the working directory before executing commands
- Updated prisma migrate command to use relative path (`prisma migrate deploy`) instead of absolute schema path (`--schema=apps/api/prisma/schema.prisma`)
- Updated node command to use relative path (`dist/index.js`) instead of absolute path (`apps/api/dist/index.js`)

## Benefits
- Cleaner, more readable command
- Reduces path duplication and potential for path-related errors
- More maintainable if the project structure changes

https://claude.ai/code/session_01SPMhn7x3KNwxwWEMSw61xM