### PR TITLE
fix(api): invoke prisma binary directly at runtime instead of pnpm exec

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -43,4 +43,4 @@ ENV NODE_ENV=production
 
 EXPOSE 7000
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s CMD wget -q --spider http://127.0.0.1:7000/health || exit 1
-CMD ["sh", "-c", "cd apps/api && pnpm exec prisma migrate deploy && node dist/index.js"]
+CMD ["sh", "-c", "cd apps/api && node_modules/.bin/prisma migrate deploy && node dist/index.js"]


### PR DESCRIPTION
The runtime image doesn't copy pnpm-workspace.yaml, so pnpm exec run from apps/api can't resolve the workspace context and fails with ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL / "Command prisma not found". All deps are already installed at that point, so call the local binary directly and skip pnpm (and corepack's pnpm download) at runtime.