### PR TITLE
Drop fully watched shows from Continue Watching

### DIFF
--- a/apps/api/src/routes/series.test.ts
+++ b/apps/api/src/routes/series.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import Fastify, { type FastifyInstance } from "fastify";
+
+const PROFILE_ID = "11111111-1111-4111-8111-111111111111";
+
+const prismaMock = {
+  kV: { findUnique: vi.fn(), findMany: vi.fn(), upsert: vi.fn(), deleteMany: vi.fn() },
+  seriesProgress: { findMany: vi.fn(), findUnique: vi.fn(), upsert: vi.fn(), deleteMany: vi.fn() },
+  metadata: { findMany: vi.fn(), findUnique: vi.fn() },
+  watchEvent: { groupBy: vi.fn(), findMany: vi.fn(), create: vi.fn(), deleteMany: vi.fn(), findFirst: vi.fn() },
+  $transaction: vi.fn(),
+};
+
+vi.mock("../lib/prisma.js", () => ({ prisma: prismaMock }));
+
+vi.mock("../lib/profile.js", () => ({
+  resolveProfile: async (request: { profileId?: string }) => {
+    request.profileId = PROFILE_ID;
+  },
+}));
+
+const nextEpisodeMock = { computeNextEpisode: vi.fn() };
+vi.mock("../lib/next-episode.js", () => nextEpisodeMock);
+
+const tmdbClientMock = { getTmdb: vi.fn() };
+vi.mock("../lib/tmdb-client.js", () => tmdbClientMock);
+
+const metadataLibMock = { upsertMetadata: vi.fn() };
+vi.mock("../lib/metadata.js", () => metadataLibMock);
+
+const seriesProgressLibMock = { upsertSeriesProgressIfNewer: vi.fn() };
+vi.mock("../lib/series-progress.js", () => seriesProgressLibMock);
+
+const watchEventLibMock = { recordWatchEvent: vi.fn() };
+vi.mock("../lib/watch-event.js", () => watchEventLibMock);
+
+const resetMocks = () => {
+  vi.clearAllMocks();
+  prismaMock.kV.findMany.mockResolvedValue([]);
+};
+
+const buildApp = async (): Promise<FastifyInstance> => {
+  vi.resetModules();
+  const { default: seriesRoutes } = await import("./series.js");
+  const app = Fastify();
+  await app.register(seriesRoutes);
+  await app.ready();
+  return app;
+};
+
+describe("series routes — completion drops from Continue Watching", () => {
+  beforeEach(() => {
+    resetMocks();
+  });
+
+  describe("GET /series/progress", () => {
+    it("drops a show once watched episodes reach the total, even if next-episode math disagrees", async () => {
+      prismaMock.seriesProgress.findMany.mockResolvedValue([
+        {
+          seriesImdbId: "tt-office",
+          lastSeason: 8,
+          lastEpisode: 21,
+          lastWatchedAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ]);
+      prismaMock.metadata.findMany.mockResolvedValue([
+        {
+          imdbId: "tt-office",
+          name: "The Office",
+          poster: null,
+          background: null,
+          totalSeasons: 9,
+          totalEpisodes: 186,
+          tmdbId: 2316,
+        },
+      ]);
+      // Simulate 186 distinct watched (season, episode) pairs.
+      prismaMock.watchEvent.groupBy.mockResolvedValue(
+        Array.from({ length: 186 }, (_, i) => ({
+          seriesImdbId: "tt-office",
+          season: 1,
+          episode: i + 1,
+          _count: { _all: 1 },
+        }))
+      );
+      // Even though the season-based fallback thinks there's a next episode...
+      nextEpisodeMock.computeNextEpisode.mockResolvedValue({ season: 8, episode: 22 });
+
+      const app = await buildApp();
+      const response = await app.inject({ method: "GET", url: "/series/progress" });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json().progress).toEqual([]);
+      await app.close();
+    });
+
+    it("keeps a show with unwatched episodes remaining", async () => {
+      prismaMock.seriesProgress.findMany.mockResolvedValue([
+        {
+          seriesImdbId: "tt-office",
+          lastSeason: 8,
+          lastEpisode: 10,
+          lastWatchedAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ]);
+      prismaMock.metadata.findMany.mockResolvedValue([
+        {
+          imdbId: "tt-office",
+          name: "The Office",
+          poster: null,
+          background: null,
+          totalSeasons: 9,
+          totalEpisodes: 186,
+          tmdbId: 2316,
+        },
+      ]);
+      prismaMock.watchEvent.groupBy.mockResolvedValue(
+        Array.from({ length: 100 }, (_, i) => ({
+          seriesImdbId: "tt-office",
+          season: 1,
+          episode: i + 1,
+          _count: { _all: 1 },
+        }))
+      );
+      nextEpisodeMock.computeNextEpisode.mockResolvedValue({ season: 8, episode: 11 });
+
+      const app = await buildApp();
+      const response = await app.inject({ method: "GET", url: "/series/progress" });
+
+      expect(response.statusCode).toBe(200);
+      const progress = response.json().progress;
+      expect(progress).toHaveLength(1);
+      expect(progress[0].nextSeason).toBe(8);
+      expect(progress[0].nextEpisode).toBe(11);
+      await app.close();
+    });
+  });
+
+  describe("POST /series/:imdbId/watch-next", () => {
+    it("returns 409 once watched episodes reach the total instead of marking a phantom episode", async () => {
+      prismaMock.seriesProgress.findUnique.mockResolvedValue({
+        seriesImdbId: "tt-office",
+        lastSeason: 8,
+        lastEpisode: 21,
+      });
+      prismaMock.metadata.findUnique.mockResolvedValue({ tmdbId: 2316, totalEpisodes: 186 });
+      prismaMock.watchEvent.findMany.mockResolvedValue(
+        Array.from({ length: 186 }, (_, i) => ({ season: 1, episode: i + 1 }))
+      );
+
+      const app = await buildApp();
+      const response = await app.inject({ method: "POST", url: "/series/tt-office/watch-next" });
+
+      expect(response.statusCode).toBe(409);
+      expect(prismaMock.watchEvent.create).not.toHaveBeenCalled();
+      await app.close();
+    });
+  });
+});

--- a/apps/api/src/routes/series.ts
+++ b/apps/api/src/routes/series.ts
@@ -122,6 +122,15 @@ const seriesRoutes: FastifyPluginAsync = async (app) => {
     const progressWithNulls = await Promise.all(
       progressRows.map(async (row) => {
         const meta = metaByImdbId.get(row.seriesImdbId);
+        const watchedEpisodes = watchedBySeriesId.get(row.seriesImdbId) ?? null;
+        const totalEpisodes = meta?.totalEpisodes ?? null;
+        // Fully watched by the same episode count shown on the card — drop
+        // from Continue Watching regardless of what the TMDB per-season
+        // math below (used only to pick the next episode) concludes, since
+        // that math can be wrong or unavailable and never signal completion.
+        if (totalEpisodes !== null && watchedEpisodes !== null && watchedEpisodes >= totalEpisodes) {
+          return null;
+        }
         const next = await computeNextEpisode(
           row.seriesImdbId,
           meta?.tmdbId ?? null,
@@ -144,7 +153,7 @@ const seriesRoutes: FastifyPluginAsync = async (app) => {
           background: meta?.background ?? null,
           totalSeasons: meta?.totalSeasons ?? null,
           totalEpisodes: meta?.totalEpisodes ?? null,
-          watchedEpisodes: watchedBySeriesId.get(row.seriesImdbId) ?? null,
+          watchedEpisodes,
         };
       })
     );
@@ -203,8 +212,19 @@ const seriesRoutes: FastifyPluginAsync = async (app) => {
 
       const meta = await prisma.metadata.findUnique({
         where: { imdbId_type: { imdbId, type: "series" } },
-        select: { tmdbId: true },
+        select: { tmdbId: true, totalEpisodes: true },
       });
+
+      if (meta?.totalEpisodes != null) {
+        const watchedEpisodes = await prisma.watchEvent.findMany({
+          where: { profileId, type: "episode", seriesImdbId: imdbId, season: { not: null }, episode: { not: null } },
+          select: { season: true, episode: true },
+          distinct: ["season", "episode"],
+        });
+        if (watchedEpisodes.length >= meta.totalEpisodes) {
+          return reply.code(409).send({ error: "Series already fully watched" });
+        }
+      }
 
       const next = await computeNextEpisode(imdbId, meta?.tmdbId ?? null, row.lastSeason, row.lastEpisode);
       if (!next) return reply.code(409).send({ error: "Series already fully watched" });

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -640,7 +640,9 @@ export function DashboardPage() {
         void load();
       }, 1200);
     } catch {
-      // best-effort; UI simply won't show the optimistic "done" state
+      // Mark failed (e.g. the series turned out to already be fully watched) —
+      // reload so a now-stale card can be dropped from the list.
+      void load();
     } finally {
       setMarkingNext((prev) => { const next = new Set(prev); next.delete(imdbId); return next; });
     }


### PR DESCRIPTION
The dashboard's Continue Watching list decided completion purely from
TMDB per-season episode-count math (computeNextEpisode), which never
agreed with the "X of Y episodes" count actually shown on the card and
could never conclude a show was done when TMDB season data was
missing, stale, or renumbered. Shows fully watched by the displayed
count (e.g. The Office at 186/186) stayed stuck with a bogus "Mark"
button for an episode that doesn't exist.

Treat watched-episodes >= total-episodes as authoritative for both the
progress list and the mark-next-episode endpoint, and refresh the
dashboard list if marking fails so a stale card doesn't linger.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Completed series are now correctly removed from progress views.
  * Prevented “watch next” from creating phantom episodes after a series is fully watched.
  * Dashboard progress now refreshes automatically when marking an episode as watched fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->