### PR TITLE
Fix high-severity self-hoster longevity gaps from project review

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,24 @@
+---
+name: Bug report
+about: Something isn't working as expected
+title: ""
+labels: bug
+---
+
+**What happened?**
+
+**What did you expect to happen?**
+
+**How are you running Cataloggy?**
+- [ ] Docker Compose
+- [ ] Local dev (`pnpm dev`)
+
+**Relevant logs**
+
+```
+paste `docker compose logs api` / `addon` / `web` output here (redact any tokens/secrets)
+```
+
+**Environment**
+- Cataloggy version/image tag:
+- Browser/device (if a web UI issue):

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,13 @@
+---
+name: Feature request
+about: Suggest an idea for Cataloggy
+title: ""
+labels: enhancement
+---
+
+**What problem would this solve?**
+
+**What would you like to happen?**
+
+**Anything else?**
+Alternatives you've considered, related integrations, etc.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,24 @@ jobs:
     permissions:
       contents: read
 
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: cataloggy
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d cataloggy"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/cataloggy
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -32,6 +50,12 @@ jobs:
 
       - name: Generate Prisma client
         run: pnpm --filter @cataloggy/api prisma:generate
+
+      # Applies every migration against a real Postgres so a broken migration
+      # fails CI instead of crashing a self-hoster's api container on update
+      # (the same `prisma migrate deploy` command runs at container start).
+      - name: Run database migrations
+        run: pnpm --filter @cataloggy/api exec prisma migrate deploy
 
       - name: Lint
         run: pnpm lint

--- a/.github/workflows/dockerpublish.yml
+++ b/.github/workflows/dockerpublish.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - "v*"
   workflow_dispatch:
 
 env:
@@ -72,13 +74,32 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
+      # Every image also gets a `sha-<short-sha>` tag (and a semver tag when
+      # triggered by a `vX.Y.Z` tag push) so self-hosters can pin a known-good
+      # version and roll back, instead of only ever having `:latest`.
+      - name: Compute image tags
+        id: vars
+        run: |
+          SHORT_SHA=$(git rev-parse --short=12 HEAD)
+          VERSION=""
+          if [[ "${{ github.ref_type }}" == "tag" ]]; then
+            VERSION="${{ github.ref_name }}"
+          fi
+          {
+            echo "sha=$SHORT_SHA"
+            echo "version=$VERSION"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Build and push API image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: apps/api/Dockerfile
           push: true
-          tags: ${{ env.IMAGE_PREFIX }}-api:latest
+          tags: |
+            ${{ env.IMAGE_PREFIX }}-api:latest
+            ${{ env.IMAGE_PREFIX }}-api:sha-${{ steps.vars.outputs.sha }}
+            ${{ steps.vars.outputs.version && format('{0}-api:{1}', env.IMAGE_PREFIX, steps.vars.outputs.version) }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -88,7 +109,10 @@ jobs:
           context: .
           file: apps/addon/Dockerfile
           push: true
-          tags: ${{ env.IMAGE_PREFIX }}-addon:latest
+          tags: |
+            ${{ env.IMAGE_PREFIX }}-addon:latest
+            ${{ env.IMAGE_PREFIX }}-addon:sha-${{ steps.vars.outputs.sha }}
+            ${{ steps.vars.outputs.version && format('{0}-addon:{1}', env.IMAGE_PREFIX, steps.vars.outputs.version) }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -98,6 +122,9 @@ jobs:
           context: .
           file: apps/web/Dockerfile
           push: true
-          tags: ${{ env.IMAGE_PREFIX }}-web:latest
+          tags: |
+            ${{ env.IMAGE_PREFIX }}-web:latest
+            ${{ env.IMAGE_PREFIX }}-web:sha-${{ steps.vars.outputs.sha }}
+            ${{ steps.vars.outputs.version && format('{0}-web:{1}', env.IMAGE_PREFIX, steps.vars.outputs.version) }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/dockerpublish.yml
+++ b/.github/workflows/dockerpublish.yml
@@ -82,8 +82,8 @@ jobs:
         run: |
           SHORT_SHA=$(git rev-parse --short=12 HEAD)
           VERSION=""
-          if [[ "${{ github.ref_type }}" == "tag" ]]; then
-            VERSION="${{ github.ref_name }}"
+          if [[ "$GITHUB_REF_TYPE" == "tag" ]]; then
+            VERSION="$GITHUB_REF_NAME"
           fi
           {
             echo "sha=$SHORT_SHA"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,65 @@
+name: Security
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  schedule:
+    # Weekly on Monday 06:00 UTC — catches newly-disclosed CVEs in existing
+    # dependencies, not just ones introduced by a given push/PR.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+jobs:
+  codeql:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        with:
+          languages: javascript-typescript
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        with:
+          category: "/language:javascript-typescript"
+
+  dependency-audit:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@008330803749db0355799c700092d9a85fd074e9 # v6.0.9
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Fails the job on high/critical severity advisories. Dependabot keeps
+      # dependencies generally up to date, but this catches actively
+      # exploited CVEs in between its weekly bumps and flags anything it
+      # can't auto-resolve (e.g. no non-breaking fix available yet).
+      - name: Audit dependencies
+        run: pnpm audit --audit-level=high

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,3 +31,6 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `/search` no longer throws an uncaught exception (and a bare 500) when the upstream TMDB request fails.
 - Bumped a transitive `serialize-javascript` dependency (via `workbox-build`) to patch a high-severity RCE advisory ([GHSA-5c6j-r48x-rmvq](https://github.com/advisories/GHSA-5c6j-r48x-rmvq)).
 - `getDefaultWatchlist` now retries on a concurrent-create race instead of throwing a raw Prisma error (matching `getDefaultCollection`'s existing behavior).
+- `PATCH /profiles/:id` now requires the profile's current PIN to change or remove an *existing* PIN (reusing the same verification/lockout logic as `/verify`); previously anyone with Settings access could strip another profile's PIN protection without ever knowing it.
+- The addon's mutation-token check no longer assumes the incoming token is a string — a repeated query param (`?token=a&token=b`) would have thrown instead of being rejected cleanly.
+- `dockerpublish.yml` reads the git ref type/name from the runner's `GITHUB_REF_TYPE`/`GITHUB_REF_NAME` environment variables instead of interpolating `github.ref_type`/`github.ref_name` into a shell script.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to Cataloggy are documented in this file, starting from this entry onward. Earlier history predates this file — see `git log` for the full commit history.
+
+Format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Dates are UTC.
+
+## [Unreleased]
+
+### Added
+
+- Docker images are now also published with a `sha-<short-sha>` tag (and a semver tag for `vX.Y.Z` tag pushes), so self-hosters can pin a known-good version and roll back instead of only ever running `:latest`.
+- CI now applies every Prisma migration against a real Postgres service before running tests, catching broken migrations before they reach a self-hoster's `api` container.
+- CI now runs CodeQL static analysis and a `pnpm audit` dependency check (weekly, plus every push/PR).
+- README: guidance on pinning/rolling back image versions, and on recovering if a database migration fails on container start.
+- `CONTRIBUTING.md`.
+
+### Changed
+
+- `docker-compose.yml` services now use `restart: unless-stopped`, so the stack recovers automatically after a host reboot or crash instead of staying down.
+- `apps/addon`'s Dockerfile is now a multi-stage build (matching `apps/api`/`apps/web`), shipping a smaller runtime image without the full pnpm workspace/devDependencies.
+- The web app now detects an invalid or rotated API token globally (via a `WWW-Authenticate` response header on bearer-auth failures) and returns to the setup wizard, instead of every page showing a generic "Unable to connect" error for the rest of the session.
+- The Stremio addon's mark-watched/scrobble endpoints now require a token derived from the shared API token, instead of relying solely on a spoofable `Origin` header check.
+- TMDB and Trakt API calls now time out after 10s, matching the existing IGDB/Steam client behavior, instead of hanging indefinitely on a slow/unresponsive upstream.
+
+### Fixed
+
+- `/search` no longer throws an uncaught exception (and a bare 500) when the upstream TMDB request fails.
+- Bumped a transitive `serialize-javascript` dependency (via `workbox-build`) to patch a high-severity RCE advisory ([GHSA-5c6j-r48x-rmvq](https://github.com/advisories/GHSA-5c6j-r48x-rmvq)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - CI now runs CodeQL static analysis and a `pnpm audit` dependency check (weekly, plus every push/PR).
 - README: guidance on pinning/rolling back image versions, and on recovering if a database migration fails on container start.
 - `CONTRIBUTING.md`.
+- A "Sync Status" Settings section and `GET /settings/job-status` endpoint surfacing the last failure of each scheduled background job (Trakt poll/watchlist sync, episode notifications, AI recs refresh, Steam sync, scrobble cleanup), so a self-hoster without Sentry configured can still notice a silently-broken sync.
+- A visible "update available" prompt for the web PWA instead of the service worker silently swapping itself in.
+- `PATCH /profiles/:id` for renaming a profile or setting/changing/removing its PIN, plus a Settings UI to do so — previously only creating and switching profiles was possible from the app; deleting one (already supported server-side) had no UI entry point at all.
+- Test coverage for previously-untested modules: `lib/collection.ts`, `lib/watchlist.ts`, `lib/series-progress.ts`, `routes/watch.ts`, the Plex/Jellyfin webhook handlers, and the new profile-management/job-status endpoints.
 
 ### Changed
 
@@ -26,3 +30,4 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - `/search` no longer throws an uncaught exception (and a bare 500) when the upstream TMDB request fails.
 - Bumped a transitive `serialize-javascript` dependency (via `workbox-build`) to patch a high-severity RCE advisory ([GHSA-5c6j-r48x-rmvq](https://github.com/advisories/GHSA-5c6j-r48x-rmvq)).
+- `getDefaultWatchlist` now retries on a concurrent-create race instead of throwing a raw Prisma error (matching `getDefaultCollection`'s existing behavior).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+# Contributing to Cataloggy
+
+Cataloggy is a personal, self-hosted project. Contributions are welcome, but keep in mind it's built and maintained around one person's real usage — not every feature request will fit, and response time may be slow.
+
+## Getting set up
+
+```bash
+pnpm install
+pnpm --filter @cataloggy/api prisma:generate
+pnpm dev
+```
+
+See the [README](README.md) for full setup instructions, including the Docker Compose path and required environment variables. You'll need a local Postgres instance (or `docker compose up db`) for the API to start.
+
+## Project structure
+
+```text
+cataloggy/
+  apps/
+    api/        # Fastify API + Prisma
+    addon/      # Stremio/Omni addon service
+    web/        # React + Vite PWA frontend
+  packages/
+    shared/     # shared types/utilities
+```
+
+Each app is its own pnpm workspace package with its own `package.json` scripts (`dev`, `build`, `typecheck`, `lint`, `test` where applicable). Run them from the repo root with `pnpm --filter @cataloggy/<app> <script>`, or use the root-level scripts (`pnpm dev`, `pnpm build`, `pnpm typecheck`, `pnpm lint`, `pnpm test`) to run across every workspace at once.
+
+## Before opening a PR
+
+Run the same checks CI runs:
+
+```bash
+pnpm lint
+pnpm typecheck
+pnpm test
+pnpm build
+```
+
+`apps/api` tests need `@cataloggy/shared` built first if you haven't run `pnpm typecheck`/`pnpm build` yet — `pnpm --filter @cataloggy/shared build` handles that.
+
+For changes that touch a running feature (not just types/tests), actually exercise it — start the stack with `pnpm dev` (or `docker compose up`) and click through the affected flow. Type checks and unit tests catch a lot, but not everything.
+
+If your change adds a Prisma migration, make sure it applies cleanly against a fresh database (`pnpm --filter @cataloggy/api exec prisma migrate deploy`) — CI runs every migration against a real Postgres instance and will fail if it doesn't.
+
+## Commit style
+
+Write commit messages that explain *why*, not just *what* — the diff already shows what changed. Imperative mood (`Fix ...`, `Add ...`, not `Fixed`/`Added`) is preferred, matching the existing history. No fixed prefix convention is enforced.
+
+## Reporting bugs / requesting features
+
+Open a GitHub issue. For bugs, include: what you expected, what happened instead, and relevant logs (`docker compose logs api`/`addon`/`web`). For self-hosting/environment issues, mention how you're running it (Docker Compose vs. local dev) and your `.env` configuration with secrets redacted.
+
+## Security issues
+
+Please don't open a public issue for a security vulnerability. See the [Security section of the README](README.md#security) for Cataloggy's threat model (it's designed for trusted-LAN self-hosting, not public internet exposure) — if you've found something outside that model, reach out to [the maintainer](https://github.com/TheShield2594) privately first (e.g. via a GitHub private security advisory on this repo) rather than filing a public issue.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ cataloggy/
    docker compose up --build
    ```
 
+   By default `docker-compose.yml` runs the `:latest` image for each service, which always points at the most recent build from `main`. To pin a known-good version instead (recommended once you have a working setup, so `docker compose pull` can't silently update you into a broken state), every image is also published with a `sha-<short-sha>` tag, and with a semver tag (e.g. `v1.2.0`) for tagged releases. Replace `:latest` with a specific tag in the `image:` line for each service to pin it, and roll back the same way if an update causes problems.
+
 3. Run the smoke checks:
 
    ```bash

--- a/README.md
+++ b/README.md
@@ -205,6 +205,17 @@ In addition to full database backups, Settings → Data lets you export your lis
 
 Settings → Data also supports importing directly from other trackers' CSV exports via `POST /import/external` (`format`: `letterboxd-diary`, `letterboxd-ratings`, `imdb-ratings`, or `simkl`). Letterboxd exports don't include IMDb IDs, so titles are resolved against TMDB on a best-effort basis; unmatched rows are skipped and reported in the import summary.
 
+### Updating safely / if a migration fails
+
+The `api` container runs `prisma migrate deploy` automatically on every start, applying any new database migrations that shipped since your last update. This is usually seamless, but two things are worth knowing before you run `docker compose pull && docker compose up -d` on a long-unattended instance:
+
+- **Back up first.** Run `./scripts/backup.sh` before pulling a new image. Prisma migrations aren't automatically reversible, so a backup taken right before updating is your fastest way back to a known-good state if something goes wrong.
+- **If `prisma migrate deploy` fails on startup**, the `api` container will exit and `docker compose ps` will show it restarting in a crash loop rather than serving traffic — check `docker compose logs api` for the failing migration. To recover:
+  1. Restore the database from the backup you took before updating (`./scripts/restore.sh <backup-file>`) — rolling back the image alone won't undo a partially-applied migration.
+  2. Roll back to the previous working image tag (see "Docker Compose install" above for pinning by `sha-<short-sha>` or a semver tag) and start it against the restored database.
+
+If you don't have a recent backup when this happens, don't guess at manually editing the `_prisma_migrations` table — that's how partial-migration failures turn into data loss. Open an issue with the failing migration name and the error from `docker compose logs api` instead.
+
 ## Security
 
 Cataloggy is designed for self-hosting on a trusted local network (LAN), not for direct exposure to the internet. Known limitations:
@@ -240,6 +251,10 @@ Cataloggy is designed for self-hosting on a trusted local network (LAN), not for
   ```bash
   pnpm --filter @cataloggy/api prisma:push
   ```
+
+## Contributing
+
+Want to contribute? See [CONTRIBUTING.md](CONTRIBUTING.md) for dev setup, checks to run before opening a PR, and how to report bugs. Notable changes are tracked in [CHANGELOG.md](CHANGELOG.md).
 
 ## Author
 

--- a/apps/addon/Dockerfile
+++ b/apps/addon/Dockerfile
@@ -1,8 +1,7 @@
-FROM node:26-alpine
+FROM node:26-alpine AS build
 
 WORKDIR /app
 RUN npm install -g corepack@latest && corepack enable
-RUN apk add --no-cache wget
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json eslint.config.mjs .npmrc ./
 COPY apps/addon/package.json ./apps/addon/package.json
@@ -16,11 +15,27 @@ COPY apps/addon ./apps/addon
 COPY packages/shared ./packages/shared
 
 RUN pnpm --filter @cataloggy/shared build
-RUN cd apps/addon && pnpm exec tsc -p tsconfig.json
+RUN pnpm --filter @cataloggy/addon build
+
+RUN pnpm prune --prod
+
+FROM node:26-alpine AS runtime
+
+WORKDIR /app
+RUN apk add --no-cache wget
+
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/package.json ./package.json
+COPY --from=build /app/apps/addon/package.json ./apps/addon/package.json
+COPY --from=build /app/apps/addon/node_modules ./apps/addon/node_modules
+COPY --from=build /app/apps/addon/dist ./apps/addon/dist
+COPY --from=build /app/packages/shared/package.json ./packages/shared/package.json
+COPY --from=build /app/packages/shared/dist ./packages/shared/dist
+
 RUN addgroup -S app && adduser -S app -G app && chown -R app:app /app
 USER app
 ENV NODE_ENV=production
 
 EXPOSE 7001
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s CMD wget -q --spider http://127.0.0.1:7001/health || exit 1
-CMD ["pnpm", "--filter", "@cataloggy/addon", "start"]
+CMD ["node", "apps/addon/dist/index.js"]

--- a/apps/addon/Dockerfile
+++ b/apps/addon/Dockerfile
@@ -23,16 +23,16 @@ FROM node:26-alpine AS runtime
 
 WORKDIR /app
 RUN apk add --no-cache wget
+RUN addgroup -S app && adduser -S app -G app
 
-COPY --from=build /app/node_modules ./node_modules
-COPY --from=build /app/package.json ./package.json
-COPY --from=build /app/apps/addon/package.json ./apps/addon/package.json
-COPY --from=build /app/apps/addon/node_modules ./apps/addon/node_modules
-COPY --from=build /app/apps/addon/dist ./apps/addon/dist
-COPY --from=build /app/packages/shared/package.json ./packages/shared/package.json
-COPY --from=build /app/packages/shared/dist ./packages/shared/dist
+COPY --from=build --chown=app:app /app/node_modules ./node_modules
+COPY --from=build --chown=app:app /app/package.json ./package.json
+COPY --from=build --chown=app:app /app/apps/addon/package.json ./apps/addon/package.json
+COPY --from=build --chown=app:app /app/apps/addon/node_modules ./apps/addon/node_modules
+COPY --from=build --chown=app:app /app/apps/addon/dist ./apps/addon/dist
+COPY --from=build --chown=app:app /app/packages/shared/package.json ./packages/shared/package.json
+COPY --from=build --chown=app:app /app/packages/shared/dist ./packages/shared/dist
 
-RUN addgroup -S app && adduser -S app -G app && chown -R app:app /app
 USER app
 ENV NODE_ENV=production
 

--- a/apps/addon/src/index.ts
+++ b/apps/addon/src/index.ts
@@ -1,3 +1,4 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
 import { Sentry } from "./lib/sentry.js";
 import Fastify, { type FastifyRequest, type FastifyReply, type RawRequestDefaultExpression } from "fastify";
 import rateLimit from "@fastify/rate-limit";
@@ -572,11 +573,12 @@ app.get<{ Params: { type: string; id: string } }>("/subtitles/:type/:id.json", a
   }
 
   const addonBase = ADDON_PUBLIC_BASE ?? `http://localhost:${process.env.PORT ?? 7001}`;
+  const tokenQuery = MUTATION_TOKEN ? `?token=${MUTATION_TOKEN}` : "";
 
   if (type === "movie") {
     const subtitles: StremioSubtitle[] = [{
       id: `cataloggy-watch-${imdbId}`,
-      url: `${addonBase}/mark-watched/${type}/${imdbId}.srt`,
+      url: `${addonBase}/mark-watched/${type}/${imdbId}.srt${tokenQuery}`,
       lang: "Cataloggy: Mark Watched",
     }];
     return reply.send({ subtitles });
@@ -589,7 +591,7 @@ app.get<{ Params: { type: string; id: string } }>("/subtitles/:type/:id.json", a
     if (!isNaN(season) && !isNaN(episode)) {
       const subtitles: StremioSubtitle[] = [{
         id: `cataloggy-watch-${imdbId}-s${season}e${episode}`,
-        url: `${addonBase}/mark-watched/episode/${imdbId}/${season}/${episode}.srt`,
+        url: `${addonBase}/mark-watched/episode/${imdbId}/${season}/${episode}.srt${tokenQuery}`,
         lang: `Cataloggy: Mark S${season}E${episode} Watched`,
       }];
       return reply.send({ subtitles });
@@ -599,11 +601,32 @@ app.get<{ Params: { type: string; id: string } }>("/subtitles/:type/:id.json", a
   return reply.send({ subtitles: [] });
 });
 
-// ─── CSRF guard for mutation endpoints ───
-// Stremio (desktop/mobile app, not a browser) doesn't send an Origin header
-// when calling subtitle/scrobble URLs. Browsers always send one for
-// cross-origin fetch/img requests, so reject those to stop arbitrary web
-// pages from triggering mark-watched/scrobble side effects via CORS *.
+// ─── Auth guard for mutation endpoints ───
+// The addon's URL is necessarily shared (to install it in Stremio/Omni), so
+// anyone who has it can reach these routes. An Origin-header check alone
+// isn't real auth — it only stops browser-issued cross-origin requests;
+// nothing stops a direct script/curl request from setting its own Origin
+// header. So mutations additionally require a token derived from the shared
+// CATALOGGY_API_TOKEN (never the raw token itself, to cap the blast radius
+// if a URL containing it leaks — e.g. via proxy/access logs).
+//
+// Stremio's subtitle mechanism can only fetch a plain URL (no custom
+// headers), so /mark-watched/*.srt carries the token as a query param,
+// embedded server-side when the /subtitles route builds the URL. Scrobble
+// callers (media-player integrations, capable of setting headers) send it
+// as a standard Bearer token instead.
+const MUTATION_TOKEN = CATALOGGY_API_TOKEN
+  ? createHmac("sha256", CATALOGGY_API_TOKEN).update("cataloggy-addon-mutation").digest("hex")
+  : null;
+
+const isValidMutationToken = (candidate: string | undefined | null): boolean => {
+  if (!MUTATION_TOKEN || !candidate) return false;
+  const a = Buffer.from(candidate);
+  const b = Buffer.from(MUTATION_TOKEN);
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+};
+
 const STREMIO_WEB_ORIGINS = ["https://web.strem.io", "https://app.strem.io"];
 
 const isAllowedMutationOrigin = (request: FastifyRequest): boolean => {
@@ -624,34 +647,37 @@ const SERIES_NO_EPISODE_SRT = `1
 Cannot mark a series as watched — select a specific episode first
 `;
 
-app.get<{ Params: { type: string; imdbId: string } }>("/mark-watched/:type/:imdbId.srt", async (request, reply) => {
-  reply.header("Access-Control-Allow-Origin", "*");
-  reply.header("Content-Type", "text/srt; charset=utf-8");
+app.get<{ Params: { type: string; imdbId: string }; Querystring: { token?: string } }>(
+  "/mark-watched/:type/:imdbId.srt",
+  async (request, reply) => {
+    reply.header("Access-Control-Allow-Origin", "*");
+    reply.header("Content-Type", "text/srt; charset=utf-8");
 
-  const { type, imdbId } = request.params;
+    const { type, imdbId } = request.params;
 
-  if (!isAllowedMutationOrigin(request)) {
-    request.log.warn({ origin: request.headers.origin }, "Rejected mark-watched request from disallowed origin");
+    if (!isValidMutationToken(request.query.token) || !isAllowedMutationOrigin(request)) {
+      request.log.warn({ origin: request.headers.origin }, "Rejected mark-watched request: missing/invalid token or disallowed origin");
+      return reply.send(MINIMAL_SRT);
+    }
+
+    try {
+      if (type === "movie") {
+        await apiPost("/watch", { type: "movie", imdbId });
+        request.log.info({ type, imdbId }, "Marked as watched from Stremio");
+      } else {
+        // For series without episode info, return honest feedback instead of a silent no-op
+        request.log.info({ type, imdbId }, "Series mark-watched requested without episode info — no-op");
+        return reply.send(SERIES_NO_EPISODE_SRT);
+      }
+    } catch (error) {
+      request.log.error(error, "Failed to mark as watched");
+    }
+
     return reply.send(MINIMAL_SRT);
   }
+);
 
-  try {
-    if (type === "movie") {
-      await apiPost("/watch", { type: "movie", imdbId });
-      request.log.info({ type, imdbId }, "Marked as watched from Stremio");
-    } else {
-      // For series without episode info, return honest feedback instead of a silent no-op
-      request.log.info({ type, imdbId }, "Series mark-watched requested without episode info — no-op");
-      return reply.send(SERIES_NO_EPISODE_SRT);
-    }
-  } catch (error) {
-    request.log.error(error, "Failed to mark as watched");
-  }
-
-  return reply.send(MINIMAL_SRT);
-});
-
-app.get<{ Params: { type: string; imdbId: string; season: string; episode: string } }>(
+app.get<{ Params: { type: string; imdbId: string; season: string; episode: string }; Querystring: { token?: string } }>(
   "/mark-watched/:type/:imdbId/:season/:episode.srt",
   async (request, reply) => {
     reply.header("Access-Control-Allow-Origin", "*");
@@ -661,8 +687,8 @@ app.get<{ Params: { type: string; imdbId: string; season: string; episode: strin
     const season = parseInt(seasonStr, 10);
     const episode = parseInt(episodeStr, 10);
 
-    if (!isAllowedMutationOrigin(request)) {
-      request.log.warn({ origin: request.headers.origin }, "Rejected mark-watched request from disallowed origin");
+    if (!isValidMutationToken(request.query.token) || !isAllowedMutationOrigin(request)) {
+      request.log.warn({ origin: request.headers.origin }, "Rejected mark-watched request: missing/invalid token or disallowed origin");
       return reply.send(MINIMAL_SRT);
     }
 
@@ -695,9 +721,11 @@ app.post<{ Body: unknown }>("/scrobble/:action", async (request, reply) => {
     return reply.code(400).send({ error: "action must be one of: start, pause, stop" });
   }
 
-  if (!isAllowedMutationOrigin(request)) {
-    request.log.warn({ origin: request.headers.origin }, "Rejected scrobble request from disallowed origin");
-    return reply.code(403).send({ error: "Origin not allowed" });
+  const authHeader = request.headers.authorization;
+  const bearerToken = authHeader?.startsWith("Bearer ") ? authHeader.slice("Bearer ".length).trim() : undefined;
+  if (!isValidMutationToken(bearerToken) || !isAllowedMutationOrigin(request)) {
+    request.log.warn({ origin: request.headers.origin }, "Rejected scrobble request: missing/invalid token or disallowed origin");
+    return reply.code(403).send({ error: "Unauthorized" });
   }
 
   if (!request.body || typeof request.body !== "object") {

--- a/apps/addon/src/index.ts
+++ b/apps/addon/src/index.ts
@@ -619,8 +619,12 @@ const MUTATION_TOKEN = CATALOGGY_API_TOKEN
   ? createHmac("sha256", CATALOGGY_API_TOKEN).update("cataloggy-addon-mutation").digest("hex")
   : null;
 
-const isValidMutationToken = (candidate: string | undefined | null): boolean => {
-  if (!MUTATION_TOKEN || !candidate) return false;
+const isValidMutationToken = (candidate: unknown): boolean => {
+  // Fastify doesn't validate query/header types against the route's TS generics at
+  // runtime, so a repeated query param (e.g. "?token=a&token=b") can arrive here as
+  // a string[] despite the declared type — guard explicitly rather than let
+  // Buffer.from throw on a non-string value.
+  if (!MUTATION_TOKEN || typeof candidate !== "string" || !candidate) return false;
   const a = Buffer.from(candidate);
   const b = Buffer.from(MUTATION_TOKEN);
   if (a.length !== b.length) return false;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -14,6 +14,7 @@ import { getDefaultProfileId } from "./lib/profile.js";
 import { checkUpcomingEpisodesAndNotify } from "./lib/notify-episodes.js";
 import { isSteamSyncConfigured, syncSteamLibrary } from "./lib/steam-sync.js";
 import { cleanupStaleSessions, SCROBBLE_CLEANUP_INTERVAL_MS } from "./routes/scrobble.js";
+import { recordJobFailure, recordJobSuccess, type JobName } from "./lib/job-status.js";
 
 // Route modules
 import healthRoutes from "./routes/health.js";
@@ -136,9 +137,20 @@ app.register(gamesSteamRoutes);
 
 // ─── Startup ───
 
-const reportBackgroundError = (error: unknown, message: string) => {
+const reportBackgroundError = (error: unknown, message: string, job?: JobName) => {
   app.log.error(error, message);
   Sentry.captureException(error);
+  if (job) {
+    void recordJobFailure(job, error).catch((kvError) => {
+      app.log.error(kvError, `Failed to persist job-status failure for ${job}`);
+    });
+  }
+};
+
+const reportJobSuccess = (job: JobName) => {
+  void recordJobSuccess(job).catch((error) => {
+    app.log.error(error, `Failed to clear job-status failure for ${job}`);
+  });
 };
 
 const start = async () => {
@@ -171,12 +183,16 @@ const start = async () => {
     setInterval(() => {
       void (async () => {
         const profileId = await getDefaultProfileId();
-        await pollTraktHistory(app.log, profileId).catch((error) => {
-          reportBackgroundError(error, "Scheduled Trakt history poll failed");
-        });
-        await syncTraktWatchlist(app.log, profileId).catch((error) => {
-          reportBackgroundError(error, "Scheduled Trakt watchlist sync failed");
-        });
+        await pollTraktHistory(app.log, profileId)
+          .then(() => reportJobSuccess("trakt-history-poll"))
+          .catch((error) => {
+            reportBackgroundError(error, "Scheduled Trakt history poll failed", "trakt-history-poll");
+          });
+        await syncTraktWatchlist(app.log, profileId)
+          .then(() => reportJobSuccess("trakt-watchlist-sync"))
+          .catch((error) => {
+            reportBackgroundError(error, "Scheduled Trakt watchlist sync failed", "trakt-watchlist-sync");
+          });
       })().catch((error) => {
         reportBackgroundError(error, "Scheduled Trakt poll failed");
       });
@@ -186,16 +202,20 @@ const start = async () => {
   }
 
   setInterval(() => {
-    void cleanupStaleSessions(app.log).catch((error) => {
-      reportBackgroundError(error, "Scrobble session cleanup failed");
-    });
+    void cleanupStaleSessions(app.log)
+      .then(() => reportJobSuccess("scrobble-cleanup"))
+      .catch((error) => {
+        reportBackgroundError(error, "Scrobble session cleanup failed", "scrobble-cleanup");
+      });
   }, SCROBBLE_CLEANUP_INTERVAL_MS);
 
   if (NOTIFICATION_CHECK_INTERVAL_SEC > 0) {
     setInterval(() => {
-      void checkUpcomingEpisodesAndNotify(app.log).catch((error) => {
-        reportBackgroundError(error, "Scheduled upcoming-episode notification check failed");
-      });
+      void checkUpcomingEpisodesAndNotify(app.log)
+        .then(() => reportJobSuccess("episode-notifications"))
+        .catch((error) => {
+          reportBackgroundError(error, "Scheduled upcoming-episode notification check failed", "episode-notifications");
+        });
     }, NOTIFICATION_CHECK_INTERVAL_SEC * 1000);
   } else {
     app.log.info(
@@ -215,13 +235,17 @@ const start = async () => {
 
   if (AI_REFRESH_INTERVAL_SEC > 0) {
     setTimeout(() => {
-      void refreshAiRecommendations().catch((error) => {
-        reportBackgroundError(error, "Initial AI recommendations refresh failed");
-      });
-      setInterval(() => {
-        void refreshAiRecommendations().catch((error) => {
-          reportBackgroundError(error, "Scheduled AI recommendations refresh failed");
+      void refreshAiRecommendations()
+        .then(() => reportJobSuccess("ai-recommendations"))
+        .catch((error) => {
+          reportBackgroundError(error, "Initial AI recommendations refresh failed", "ai-recommendations");
         });
+      setInterval(() => {
+        void refreshAiRecommendations()
+          .then(() => reportJobSuccess("ai-recommendations"))
+          .catch((error) => {
+            reportBackgroundError(error, "Scheduled AI recommendations refresh failed", "ai-recommendations");
+          });
       }, AI_REFRESH_INTERVAL_SEC * 1000);
     }, 2 * 60 * 1000);
   } else {
@@ -238,13 +262,17 @@ const start = async () => {
 
   if (STEAM_SYNC_INTERVAL_SEC > 0) {
     setTimeout(() => {
-      void refreshSteamLibrary().catch((error) => {
-        reportBackgroundError(error, "Initial Steam library sync failed");
-      });
-      setInterval(() => {
-        void refreshSteamLibrary().catch((error) => {
-          reportBackgroundError(error, "Scheduled Steam library sync failed");
+      void refreshSteamLibrary()
+        .then(() => reportJobSuccess("steam-sync"))
+        .catch((error) => {
+          reportBackgroundError(error, "Initial Steam library sync failed", "steam-sync");
         });
+      setInterval(() => {
+        void refreshSteamLibrary()
+          .then(() => reportJobSuccess("steam-sync"))
+          .catch((error) => {
+            reportBackgroundError(error, "Scheduled Steam library sync failed", "steam-sync");
+          });
       }, STEAM_SYNC_INTERVAL_SEC * 1000);
     }, 2 * 60 * 1000);
   } else {

--- a/apps/api/src/lib/auth.test.ts
+++ b/apps/api/src/lib/auth.test.ts
@@ -4,8 +4,13 @@ import type { FastifyReply, FastifyRequest } from "fastify";
 class FakeReply {
   statusCode?: number;
   body?: unknown;
+  headers: Record<string, string> = {};
   code(code: number) {
     this.statusCode = code;
+    return this;
+  }
+  header(name: string, value: string) {
+    this.headers[name] = value;
     return this;
   }
   send(payload: unknown) {
@@ -50,6 +55,7 @@ describe("verifyToken", () => {
     await verifyToken(makeRequest(undefined), reply as unknown as FastifyReply);
 
     expect(reply.statusCode).toBe(401);
+    expect(reply.headers["WWW-Authenticate"]).toBe("Bearer");
   });
 
   it("returns 401 for a malformed Authorization header", async () => {
@@ -72,6 +78,7 @@ describe("verifyToken", () => {
     await verifyToken(makeRequest("Bearer wrong-token"), reply as unknown as FastifyReply);
 
     expect(reply.statusCode).toBe(401);
+    expect(reply.headers["WWW-Authenticate"]).toBe("Bearer");
   });
 
   it("lets the request through for the correct token", async () => {

--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -13,7 +13,10 @@ export const verifyToken = async (request: FastifyRequest, reply: FastifyReply) 
 
   const authHeader = request.headers.authorization;
   if (!authHeader?.startsWith("Bearer ")) {
-    return reply.code(401).send({ error: "Unauthorized" });
+    // WWW-Authenticate (RFC 6750) marks this as a bearer-token failure specifically,
+    // distinct from route-level 401s (e.g. an incorrect profile PIN) — the web client
+    // uses it to tell "your API token is invalid, re-enter it" apart from other 401s.
+    return reply.code(401).header("WWW-Authenticate", "Bearer").send({ error: "Unauthorized" });
   }
 
   const token = authHeader.slice("Bearer ".length).trim();
@@ -21,6 +24,6 @@ export const verifyToken = async (request: FastifyRequest, reply: FastifyReply) 
   const expectedTokenDigest = toSha256Digest(API_TOKEN);
 
   if (!timingSafeEqual(tokenDigest, expectedTokenDigest)) {
-    return reply.code(401).send({ error: "Unauthorized" });
+    return reply.code(401).header("WWW-Authenticate", "Bearer").send({ error: "Unauthorized" });
   }
 };

--- a/apps/api/src/lib/collection.test.ts
+++ b/apps/api/src/lib/collection.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Prisma } from "@prisma/client";
+
+const prismaMock = {
+  list: { findFirst: vi.fn(), create: vi.fn() },
+  profile: { findFirst: vi.fn(), create: vi.fn() },
+};
+
+vi.mock("./prisma.js", () => ({ prisma: prismaMock }));
+
+const P2002 = new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
+  code: "P2002",
+  clientVersion: "test",
+});
+
+describe("ensureDefaultCollection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.profile.findFirst.mockResolvedValue({ id: "profile-1" });
+  });
+
+  it("does nothing when a collection already exists", async () => {
+    prismaMock.list.findFirst.mockResolvedValue({ id: "list-1" });
+    const { ensureDefaultCollection } = await import("./collection.js");
+
+    await ensureDefaultCollection();
+
+    expect(prismaMock.list.create).not.toHaveBeenCalled();
+  });
+
+  it("creates a collection when none exists", async () => {
+    prismaMock.list.findFirst.mockResolvedValue(null);
+    prismaMock.list.create.mockResolvedValue({ id: "list-1" });
+    const { ensureDefaultCollection } = await import("./collection.js");
+
+    await ensureDefaultCollection();
+
+    expect(prismaMock.list.create).toHaveBeenCalledWith({
+      data: { kind: "collection", name: "Collection", profileId: "profile-1" },
+    });
+  });
+
+  it("swallows a P2002 race from a concurrent creator", async () => {
+    prismaMock.list.findFirst.mockResolvedValue(null);
+    prismaMock.list.create.mockRejectedValue(P2002);
+    const { ensureDefaultCollection } = await import("./collection.js");
+
+    await expect(ensureDefaultCollection()).resolves.toBeUndefined();
+  });
+
+  it("rethrows non-P2002 errors", async () => {
+    prismaMock.list.findFirst.mockResolvedValue(null);
+    prismaMock.list.create.mockRejectedValue(new Error("connection lost"));
+    const { ensureDefaultCollection } = await import("./collection.js");
+
+    await expect(ensureDefaultCollection()).rejects.toThrow("connection lost");
+  });
+});
+
+describe("getDefaultCollection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the existing collection for the given profile", async () => {
+    prismaMock.list.findFirst.mockResolvedValue({ id: "list-1" });
+    const { getDefaultCollection } = await import("./collection.js");
+
+    const result = await getDefaultCollection("profile-1");
+
+    expect(result).toEqual({ id: "list-1" });
+    expect(prismaMock.list.create).not.toHaveBeenCalled();
+  });
+
+  it("creates one when none exists", async () => {
+    prismaMock.list.findFirst.mockResolvedValue(null);
+    prismaMock.list.create.mockResolvedValue({ id: "list-new" });
+    const { getDefaultCollection } = await import("./collection.js");
+
+    const result = await getDefaultCollection("profile-1");
+
+    expect(result).toEqual({ id: "list-new" });
+  });
+
+  it("retries the lookup and returns the winner's row on a P2002 race", async () => {
+    prismaMock.list.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ id: "winner" });
+    prismaMock.list.create.mockRejectedValue(P2002);
+    const { getDefaultCollection } = await import("./collection.js");
+
+    const result = await getDefaultCollection("profile-1");
+
+    expect(result).toEqual({ id: "winner" });
+    expect(prismaMock.list.findFirst).toHaveBeenCalledTimes(2);
+  });
+
+  it("rethrows if a P2002 race retry still finds nothing", async () => {
+    prismaMock.list.findFirst.mockResolvedValue(null);
+    prismaMock.list.create.mockRejectedValue(P2002);
+    const { getDefaultCollection } = await import("./collection.js");
+
+    await expect(getDefaultCollection("profile-1")).rejects.toBe(P2002);
+  });
+});

--- a/apps/api/src/lib/collection.test.ts
+++ b/apps/api/src/lib/collection.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { Prisma } from "@prisma/client";
+import { P2002 } from "./test-fixtures/prisma-errors.js";
 
 const prismaMock = {
   list: { findFirst: vi.fn(), create: vi.fn() },
@@ -7,11 +7,6 @@ const prismaMock = {
 };
 
 vi.mock("./prisma.js", () => ({ prisma: prismaMock }));
-
-const P2002 = new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
-  code: "P2002",
-  clientVersion: "test",
-});
 
 describe("ensureDefaultCollection", () => {
   beforeEach(() => {
@@ -40,8 +35,10 @@ describe("ensureDefaultCollection", () => {
     });
   });
 
-  it("swallows a P2002 race from a concurrent creator", async () => {
-    prismaMock.list.findFirst.mockResolvedValue(null);
+  it("resolves without throwing when a P2002 race retry finds the winner's row", async () => {
+    prismaMock.list.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ id: "winner" });
     prismaMock.list.create.mockRejectedValue(P2002);
     const { ensureDefaultCollection } = await import("./collection.js");
 

--- a/apps/api/src/lib/collection.ts
+++ b/apps/api/src/lib/collection.ts
@@ -1,47 +1,28 @@
-import { ListKind, Prisma } from "@prisma/client";
+import { ListKind } from "@prisma/client";
 import { prisma } from "./prisma.js";
 import { getDefaultProfileId } from "./profile.js";
+import { findOrCreateTolerant } from "./prisma-tolerant.js";
 
 export const ensureDefaultCollection = async () => {
   const profileId = await getDefaultProfileId();
-  const existing = await prisma.list.findFirst({
-    where: { kind: ListKind.collection, profileId },
-  });
-  if (existing) return;
-
-  try {
-    await prisma.list.create({ data: { kind: ListKind.collection, name: "Collection", profileId } });
-  } catch (error) {
-    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
-      // race condition — another instance created it first
-      return;
-    }
-    throw error;
-  }
+  await findOrCreateTolerant(
+    () => prisma.list.findFirst({ where: { kind: ListKind.collection, profileId } }),
+    () => prisma.list.create({ data: { kind: ListKind.collection, name: "Collection", profileId } })
+  );
 };
 
 export const getDefaultCollection = async (profileId?: string) => {
   const resolvedProfileId = profileId ?? (await getDefaultProfileId());
 
-  const collection = await prisma.list.findFirst({
-    where: { kind: ListKind.collection, profileId: resolvedProfileId },
-    orderBy: { createdAt: "asc" },
-  });
-
-  if (collection) return collection;
-
-  try {
-    return await prisma.list.create({
-      data: { kind: ListKind.collection, name: "Collection", profileId: resolvedProfileId },
-    });
-  } catch (error) {
-    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
-      const retry = await prisma.list.findFirst({
+  return findOrCreateTolerant(
+    () =>
+      prisma.list.findFirst({
         where: { kind: ListKind.collection, profileId: resolvedProfileId },
         orderBy: { createdAt: "asc" },
-      });
-      if (retry) return retry;
-    }
-    throw error;
-  }
+      }),
+    () =>
+      prisma.list.create({
+        data: { kind: ListKind.collection, name: "Collection", profileId: resolvedProfileId },
+      })
+  );
 };

--- a/apps/api/src/lib/job-status.test.ts
+++ b/apps/api/src/lib/job-status.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const prismaMock = {
+  kV: { upsert: vi.fn(), deleteMany: vi.fn(), findMany: vi.fn() },
+};
+
+vi.mock("./prisma.js", () => ({ prisma: prismaMock }));
+
+describe("job-status", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("recordJobFailure upserts a KV row keyed by job name with the error message", async () => {
+    const { recordJobFailure } = await import("./job-status.js");
+    await recordJobFailure("steam-sync", new Error("Steam API unreachable"));
+
+    expect(prismaMock.kV.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { key: "job-status:steam-sync" },
+        create: expect.objectContaining({ key: "job-status:steam-sync", value: "Steam API unreachable" }),
+        update: expect.objectContaining({ value: "Steam API unreachable" }),
+      })
+    );
+  });
+
+  it("recordJobFailure stringifies non-Error values and truncates long messages", async () => {
+    const { recordJobFailure } = await import("./job-status.js");
+    await recordJobFailure("ai-recommendations", "a".repeat(3000));
+
+    const call = prismaMock.kV.upsert.mock.calls[0][0];
+    expect(call.create.value.length).toBe(2000);
+    expect(call.create.value).toBe("a".repeat(2000));
+  });
+
+  it("recordJobSuccess deletes the KV row for that job", async () => {
+    const { recordJobSuccess } = await import("./job-status.js");
+    await recordJobSuccess("trakt-history-poll");
+
+    expect(prismaMock.kV.deleteMany).toHaveBeenCalledWith({ where: { key: "job-status:trakt-history-poll" } });
+  });
+
+  it("getFailedJobStatuses strips the KV key prefix back to the job name", async () => {
+    prismaMock.kV.findMany.mockResolvedValue([
+      { key: "job-status:steam-sync", value: "boom", updatedAt: new Date("2026-01-01T00:00:00Z") },
+    ]);
+
+    const { getFailedJobStatuses } = await import("./job-status.js");
+    const result = await getFailedJobStatuses();
+
+    expect(result).toEqual([
+      { job: "steam-sync", message: "boom", failedAt: "2026-01-01T00:00:00.000Z" },
+    ]);
+    expect(prismaMock.kV.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { key: { startsWith: "job-status:" } } })
+    );
+  });
+
+  it("getFailedJobStatuses returns an empty array when nothing has failed", async () => {
+    prismaMock.kV.findMany.mockResolvedValue([]);
+
+    const { getFailedJobStatuses } = await import("./job-status.js");
+    const result = await getFailedJobStatuses();
+
+    expect(result).toEqual([]);
+  });
+});

--- a/apps/api/src/lib/job-status.ts
+++ b/apps/api/src/lib/job-status.ts
@@ -1,0 +1,45 @@
+import { prisma } from "./prisma.js";
+
+// Persists the last failure of each scheduled background job to the KV table
+// so a self-hoster without Sentry configured (the default — no error data
+// leaves the server unless opted in) can still notice a silently-broken sync
+// from the Settings page, instead of it only ever showing up in server logs.
+const JOB_STATUS_KEY_PREFIX = "job-status:";
+
+export type JobName =
+  | "trakt-history-poll"
+  | "trakt-watchlist-sync"
+  | "scrobble-cleanup"
+  | "episode-notifications"
+  | "ai-recommendations"
+  | "steam-sync";
+
+const MAX_MESSAGE_LENGTH = 2000;
+
+export async function recordJobFailure(job: JobName, error: unknown): Promise<void> {
+  const message = (error instanceof Error ? error.message : String(error)).slice(0, MAX_MESSAGE_LENGTH);
+  const now = new Date();
+  await prisma.kV.upsert({
+    where: { key: JOB_STATUS_KEY_PREFIX + job },
+    create: { key: JOB_STATUS_KEY_PREFIX + job, value: message, updatedAt: now },
+    update: { value: message, updatedAt: now },
+  });
+}
+
+export async function recordJobSuccess(job: JobName): Promise<void> {
+  await prisma.kV.deleteMany({ where: { key: JOB_STATUS_KEY_PREFIX + job } });
+}
+
+export type JobFailure = { job: JobName; message: string; failedAt: string };
+
+export async function getFailedJobStatuses(): Promise<JobFailure[]> {
+  const rows = await prisma.kV.findMany({
+    where: { key: { startsWith: JOB_STATUS_KEY_PREFIX } },
+    orderBy: { updatedAt: "desc" },
+  });
+  return rows.map((row) => ({
+    job: row.key.slice(JOB_STATUS_KEY_PREFIX.length) as JobName,
+    message: row.value,
+    failedAt: row.updatedAt.toISOString(),
+  }));
+}

--- a/apps/api/src/lib/prisma-tolerant.ts
+++ b/apps/api/src/lib/prisma-tolerant.ts
@@ -1,0 +1,26 @@
+import { Prisma } from "@prisma/client";
+
+export const isUniqueConstraintError = (error: unknown): boolean =>
+  error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002";
+
+// Finds an existing row, or creates one if none exists yet. If a concurrent
+// request wins a create-vs-create race (P2002), re-runs the lookup instead of
+// throwing — the loser ends up returning the winner's row, like a real
+// "find or create" would.
+export async function findOrCreateTolerant<T>(
+  find: () => Promise<T | null>,
+  create: () => Promise<T>
+): Promise<T> {
+  const existing = await find();
+  if (existing) return existing;
+
+  try {
+    return await create();
+  } catch (error) {
+    if (isUniqueConstraintError(error)) {
+      const retry = await find();
+      if (retry) return retry;
+    }
+    throw error;
+  }
+}

--- a/apps/api/src/lib/series-progress.test.ts
+++ b/apps/api/src/lib/series-progress.test.ts
@@ -1,16 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { Prisma } from "@prisma/client";
+import { P2002 } from "./test-fixtures/prisma-errors.js";
 
 const prismaMock = {
   seriesProgress: { updateMany: vi.fn(), create: vi.fn() },
 };
 
 vi.mock("./prisma.js", () => ({ prisma: prismaMock }));
-
-const P2002 = new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
-  code: "P2002",
-  clientVersion: "test",
-});
 
 describe("isIncomingSeriesProgressNewer", () => {
   it("prefers the later watched timestamp regardless of season/episode", async () => {

--- a/apps/api/src/lib/series-progress.test.ts
+++ b/apps/api/src/lib/series-progress.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Prisma } from "@prisma/client";
+
+const prismaMock = {
+  seriesProgress: { updateMany: vi.fn(), create: vi.fn() },
+};
+
+vi.mock("./prisma.js", () => ({ prisma: prismaMock }));
+
+const P2002 = new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
+  code: "P2002",
+  clientVersion: "test",
+});
+
+describe("isIncomingSeriesProgressNewer", () => {
+  it("prefers the later watched timestamp regardless of season/episode", async () => {
+    const { isIncomingSeriesProgressNewer } = await import("./series-progress.js");
+    const existing = { lastSeason: 5, lastEpisode: 10, lastWatchedAt: new Date("2026-01-01T00:00:00Z") };
+    const incoming = { lastSeason: 1, lastEpisode: 1, lastWatchedAt: new Date("2026-01-02T00:00:00Z") };
+
+    expect(isIncomingSeriesProgressNewer(existing, incoming)).toBe(true);
+  });
+
+  it("falls back to season when timestamps tie", async () => {
+    const { isIncomingSeriesProgressNewer } = await import("./series-progress.js");
+    const at = new Date("2026-01-01T00:00:00Z");
+    const existing = { lastSeason: 1, lastEpisode: 10, lastWatchedAt: at };
+    const incoming = { lastSeason: 2, lastEpisode: 1, lastWatchedAt: at };
+
+    expect(isIncomingSeriesProgressNewer(existing, incoming)).toBe(true);
+  });
+
+  it("falls back to episode when timestamp and season tie", async () => {
+    const { isIncomingSeriesProgressNewer } = await import("./series-progress.js");
+    const at = new Date("2026-01-01T00:00:00Z");
+    const existing = { lastSeason: 1, lastEpisode: 2, lastWatchedAt: at };
+    const incoming = { lastSeason: 1, lastEpisode: 5, lastWatchedAt: at };
+
+    expect(isIncomingSeriesProgressNewer(existing, incoming)).toBe(true);
+  });
+
+  it("returns false when incoming is strictly older/behind", async () => {
+    const { isIncomingSeriesProgressNewer } = await import("./series-progress.js");
+    const existing = { lastSeason: 3, lastEpisode: 3, lastWatchedAt: new Date("2026-01-05T00:00:00Z") };
+    const incoming = { lastSeason: 3, lastEpisode: 2, lastWatchedAt: new Date("2026-01-01T00:00:00Z") };
+
+    expect(isIncomingSeriesProgressNewer(existing, incoming)).toBe(false);
+  });
+});
+
+describe("upsertSeriesProgressIfNewer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not create a row when the update matched an existing newer-or-equal row", async () => {
+    prismaMock.seriesProgress.updateMany.mockResolvedValue({ count: 1 });
+    const { upsertSeriesProgressIfNewer } = await import("./series-progress.js");
+
+    await upsertSeriesProgressIfNewer("profile-1", "tt123", {
+      lastSeason: 2,
+      lastEpisode: 3,
+      lastWatchedAt: new Date("2026-01-01T00:00:00Z"),
+    });
+
+    expect(prismaMock.seriesProgress.create).not.toHaveBeenCalled();
+  });
+
+  it("creates a row when no existing row was old enough to update (first watch)", async () => {
+    prismaMock.seriesProgress.updateMany.mockResolvedValue({ count: 0 });
+    prismaMock.seriesProgress.create.mockResolvedValue({});
+    const { upsertSeriesProgressIfNewer } = await import("./series-progress.js");
+
+    await upsertSeriesProgressIfNewer("profile-1", "tt123", {
+      lastSeason: 1,
+      lastEpisode: 1,
+      lastWatchedAt: new Date("2026-01-01T00:00:00Z"),
+    });
+
+    expect(prismaMock.seriesProgress.create).toHaveBeenCalledWith({
+      data: {
+        profileId: "profile-1",
+        seriesImdbId: "tt123",
+        lastSeason: 1,
+        lastEpisode: 1,
+        lastWatchedAt: new Date("2026-01-01T00:00:00Z"),
+        updatedAt: new Date("2026-01-01T00:00:00Z"),
+      },
+    });
+  });
+
+  it("swallows a P2002 race when a concurrent request already created the row", async () => {
+    prismaMock.seriesProgress.updateMany.mockResolvedValue({ count: 0 });
+    prismaMock.seriesProgress.create.mockRejectedValue(P2002);
+    const { upsertSeriesProgressIfNewer } = await import("./series-progress.js");
+
+    await expect(
+      upsertSeriesProgressIfNewer("profile-1", "tt123", {
+        lastSeason: 1,
+        lastEpisode: 1,
+        lastWatchedAt: new Date("2026-01-01T00:00:00Z"),
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it("rethrows non-P2002 errors from create", async () => {
+    prismaMock.seriesProgress.updateMany.mockResolvedValue({ count: 0 });
+    prismaMock.seriesProgress.create.mockRejectedValue(new Error("connection lost"));
+    const { upsertSeriesProgressIfNewer } = await import("./series-progress.js");
+
+    await expect(
+      upsertSeriesProgressIfNewer("profile-1", "tt123", {
+        lastSeason: 1,
+        lastEpisode: 1,
+        lastWatchedAt: new Date("2026-01-01T00:00:00Z"),
+      })
+    ).rejects.toThrow("connection lost");
+  });
+});

--- a/apps/api/src/lib/series-progress.ts
+++ b/apps/api/src/lib/series-progress.ts
@@ -1,5 +1,5 @@
-import { Prisma } from "@prisma/client";
 import { prisma } from "./prisma.js";
+import { isUniqueConstraintError } from "./prisma-tolerant.js";
 import type { SeriesProgressCandidate } from "./types.js";
 
 export const isIncomingSeriesProgressNewer = (
@@ -58,6 +58,6 @@ export const upsertSeriesProgressIfNewer = async (
       },
     });
   } catch (error) {
-    if (!(error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002")) throw error;
+    if (!isUniqueConstraintError(error)) throw error;
   }
 };

--- a/apps/api/src/lib/test-fixtures/prisma-errors.ts
+++ b/apps/api/src/lib/test-fixtures/prisma-errors.ts
@@ -1,0 +1,6 @@
+import { Prisma } from "@prisma/client";
+
+export const P2002 = new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
+  code: "P2002",
+  clientVersion: "test",
+});

--- a/apps/api/src/lib/watchlist.test.ts
+++ b/apps/api/src/lib/watchlist.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Prisma } from "@prisma/client";
+
+const prismaMock = {
+  list: { findFirst: vi.fn(), create: vi.fn() },
+  profile: { findFirst: vi.fn(), create: vi.fn() },
+};
+
+vi.mock("./prisma.js", () => ({ prisma: prismaMock }));
+
+const P2002 = new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
+  code: "P2002",
+  clientVersion: "test",
+});
+
+describe("ensureDefaultWatchlist", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.profile.findFirst.mockResolvedValue({ id: "profile-1" });
+  });
+
+  it("does nothing when a watchlist already exists", async () => {
+    prismaMock.list.findFirst.mockResolvedValue({ id: "list-1" });
+    const { ensureDefaultWatchlist } = await import("./watchlist.js");
+
+    await ensureDefaultWatchlist();
+
+    expect(prismaMock.list.create).not.toHaveBeenCalled();
+  });
+
+  it("creates a watchlist when none exists", async () => {
+    prismaMock.list.findFirst.mockResolvedValue(null);
+    prismaMock.list.create.mockResolvedValue({ id: "list-1" });
+    const { ensureDefaultWatchlist } = await import("./watchlist.js");
+
+    await ensureDefaultWatchlist();
+
+    expect(prismaMock.list.create).toHaveBeenCalledWith({
+      data: { kind: "watchlist", name: "Watchlist", profileId: "profile-1" },
+    });
+  });
+
+  it("swallows a P2002 race from a concurrent creator", async () => {
+    prismaMock.list.findFirst.mockResolvedValue(null);
+    prismaMock.list.create.mockRejectedValue(P2002);
+    const { ensureDefaultWatchlist } = await import("./watchlist.js");
+
+    await expect(ensureDefaultWatchlist()).resolves.toBeUndefined();
+  });
+});
+
+describe("getDefaultWatchlist", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the existing watchlist for the given profile", async () => {
+    prismaMock.list.findFirst.mockResolvedValue({ id: "list-1" });
+    const { getDefaultWatchlist } = await import("./watchlist.js");
+
+    const result = await getDefaultWatchlist("profile-1");
+
+    expect(result).toEqual({ id: "list-1" });
+    expect(prismaMock.list.create).not.toHaveBeenCalled();
+  });
+
+  it("creates one when none exists", async () => {
+    prismaMock.list.findFirst.mockResolvedValue(null);
+    prismaMock.list.create.mockResolvedValue({ id: "list-new" });
+    const { getDefaultWatchlist } = await import("./watchlist.js");
+
+    const result = await getDefaultWatchlist("profile-1");
+
+    expect(result).toEqual({ id: "list-new" });
+  });
+
+  it("retries the lookup and returns the winner's row on a P2002 race instead of throwing", async () => {
+    prismaMock.list.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ id: "winner" });
+    prismaMock.list.create.mockRejectedValue(P2002);
+    const { getDefaultWatchlist } = await import("./watchlist.js");
+
+    const result = await getDefaultWatchlist("profile-1");
+
+    expect(result).toEqual({ id: "winner" });
+    expect(prismaMock.list.findFirst).toHaveBeenCalledTimes(2);
+  });
+
+  it("rethrows if a P2002 race retry still finds nothing", async () => {
+    prismaMock.list.findFirst.mockResolvedValue(null);
+    prismaMock.list.create.mockRejectedValue(P2002);
+    const { getDefaultWatchlist } = await import("./watchlist.js");
+
+    await expect(getDefaultWatchlist("profile-1")).rejects.toBe(P2002);
+  });
+});

--- a/apps/api/src/lib/watchlist.test.ts
+++ b/apps/api/src/lib/watchlist.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { Prisma } from "@prisma/client";
+import { P2002 } from "./test-fixtures/prisma-errors.js";
 
 const prismaMock = {
   list: { findFirst: vi.fn(), create: vi.fn() },
@@ -7,11 +7,6 @@ const prismaMock = {
 };
 
 vi.mock("./prisma.js", () => ({ prisma: prismaMock }));
-
-const P2002 = new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
-  code: "P2002",
-  clientVersion: "test",
-});
 
 describe("ensureDefaultWatchlist", () => {
   beforeEach(() => {
@@ -40,8 +35,10 @@ describe("ensureDefaultWatchlist", () => {
     });
   });
 
-  it("swallows a P2002 race from a concurrent creator", async () => {
-    prismaMock.list.findFirst.mockResolvedValue(null);
+  it("resolves without throwing when a P2002 race retry finds the winner's row", async () => {
+    prismaMock.list.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ id: "winner" });
     prismaMock.list.create.mockRejectedValue(P2002);
     const { ensureDefaultWatchlist } = await import("./watchlist.js");
 

--- a/apps/api/src/lib/watchlist.ts
+++ b/apps/api/src/lib/watchlist.ts
@@ -1,48 +1,28 @@
-import { ListKind, Prisma } from "@prisma/client";
+import { ListKind } from "@prisma/client";
 import { prisma } from "./prisma.js";
 import { getDefaultProfileId } from "./profile.js";
+import { findOrCreateTolerant } from "./prisma-tolerant.js";
 
 export const ensureDefaultWatchlist = async () => {
   const profileId = await getDefaultProfileId();
-  const existing = await prisma.list.findFirst({
-    where: { kind: ListKind.watchlist, name: "Watchlist", profileId },
-  });
-  if (existing) return;
-
-  try {
-    await prisma.list.create({ data: { kind: ListKind.watchlist, name: "Watchlist", profileId } });
-  } catch (error) {
-    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
-      // race condition — another instance created it first
-      return;
-    }
-    throw error;
-  }
+  await findOrCreateTolerant(
+    () => prisma.list.findFirst({ where: { kind: ListKind.watchlist, name: "Watchlist", profileId } }),
+    () => prisma.list.create({ data: { kind: ListKind.watchlist, name: "Watchlist", profileId } })
+  );
 };
 
 export const getDefaultWatchlist = async (profileId?: string) => {
   const resolvedProfileId = profileId ?? (await getDefaultProfileId());
 
-  const watchlist = await prisma.list.findFirst({
-    where: { kind: ListKind.watchlist, name: "Watchlist", profileId: resolvedProfileId },
-    orderBy: { createdAt: "asc" },
-  });
-
-  if (watchlist) return watchlist;
-
-  try {
-    return await prisma.list.create({
-      data: { kind: ListKind.watchlist, name: "Watchlist", profileId: resolvedProfileId },
-    });
-  } catch (error) {
-    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
-      // race condition — another concurrent request created it first
-      const retry = await prisma.list.findFirst({
+  return findOrCreateTolerant(
+    () =>
+      prisma.list.findFirst({
         where: { kind: ListKind.watchlist, name: "Watchlist", profileId: resolvedProfileId },
         orderBy: { createdAt: "asc" },
-      });
-      if (retry) return retry;
-    }
-    throw error;
-  }
+      }),
+    () =>
+      prisma.list.create({
+        data: { kind: ListKind.watchlist, name: "Watchlist", profileId: resolvedProfileId },
+      })
+  );
 };

--- a/apps/api/src/lib/watchlist.ts
+++ b/apps/api/src/lib/watchlist.ts
@@ -30,7 +30,19 @@ export const getDefaultWatchlist = async (profileId?: string) => {
 
   if (watchlist) return watchlist;
 
-  return prisma.list.create({
-    data: { kind: ListKind.watchlist, name: "Watchlist", profileId: resolvedProfileId },
-  });
+  try {
+    return await prisma.list.create({
+      data: { kind: ListKind.watchlist, name: "Watchlist", profileId: resolvedProfileId },
+    });
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
+      // race condition — another concurrent request created it first
+      const retry = await prisma.list.findFirst({
+        where: { kind: ListKind.watchlist, name: "Watchlist", profileId: resolvedProfileId },
+        orderBy: { createdAt: "asc" },
+      });
+      if (retry) return retry;
+    }
+    throw error;
+  }
 };

--- a/apps/api/src/routes/profiles.test.ts
+++ b/apps/api/src/routes/profiles.test.ts
@@ -6,7 +6,7 @@ const PROFILE_ID = "11111111-1111-4111-8111-111111111111";
 const hashPin = (pin: string) => createHash("sha256").update(pin).digest("hex");
 
 const prismaMock = {
-  profile: { findMany: vi.fn(), create: vi.fn(), findUnique: vi.fn(), count: vi.fn(), delete: vi.fn() },
+  profile: { findMany: vi.fn(), create: vi.fn(), findUnique: vi.fn(), count: vi.fn(), delete: vi.fn(), update: vi.fn() },
   kV: { findUnique: vi.fn(), upsert: vi.fn(), deleteMany: vi.fn() },
   $transaction: vi.fn(),
   $executeRaw: vi.fn(),
@@ -195,6 +195,98 @@ describe("profiles routes", () => {
       expect(lockedResponse.json()).toEqual(
         expect.objectContaining({ error: expect.stringContaining("Too many incorrect attempts") })
       );
+      await app.close();
+    });
+  });
+
+  describe("PATCH /profiles/:id", () => {
+    it("rejects a non-UUID id", async () => {
+      const app = await buildApp();
+      const response = await app.inject({ method: "PATCH", url: "/profiles/not-a-uuid", payload: { name: "Alice" } });
+      expect(response.statusCode).toBe(400);
+      await app.close();
+    });
+
+    it("404s for an unknown profile", async () => {
+      prismaMock.profile.findUnique.mockResolvedValue(null);
+      const app = await buildApp();
+      const response = await app.inject({ method: "PATCH", url: `/profiles/${PROFILE_ID}`, payload: { name: "Alice" } });
+      expect(response.statusCode).toBe(404);
+      await app.close();
+    });
+
+    it("rejects an empty body (nothing to update)", async () => {
+      prismaMock.profile.findUnique.mockResolvedValue({ id: PROFILE_ID, name: "Alice", pinHash: null });
+      const app = await buildApp();
+      const response = await app.inject({ method: "PATCH", url: `/profiles/${PROFILE_ID}`, payload: {} });
+      expect(response.statusCode).toBe(400);
+      expect(prismaMock.profile.update).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it("rejects a blank name", async () => {
+      prismaMock.profile.findUnique.mockResolvedValue({ id: PROFILE_ID, name: "Alice", pinHash: null });
+      const app = await buildApp();
+      const response = await app.inject({ method: "PATCH", url: `/profiles/${PROFILE_ID}`, payload: { name: "  " } });
+      expect(response.statusCode).toBe(400);
+      await app.close();
+    });
+
+    it("renames a profile", async () => {
+      prismaMock.profile.findUnique.mockResolvedValue({ id: PROFILE_ID, name: "Alice", pinHash: null });
+      prismaMock.profile.update.mockResolvedValue({ id: PROFILE_ID, name: "Alicia", pinHash: null });
+      const app = await buildApp();
+
+      const response = await app.inject({ method: "PATCH", url: `/profiles/${PROFILE_ID}`, payload: { name: "Alicia" } });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json().profile).toEqual({ id: PROFILE_ID, name: "Alicia", hasPin: false });
+      expect(prismaMock.profile.update).toHaveBeenCalledWith({
+        where: { id: PROFILE_ID },
+        data: { name: "Alicia" },
+      });
+      await app.close();
+    });
+
+    it("sets a PIN and clears any prior lockout attempts", async () => {
+      prismaMock.profile.findUnique.mockResolvedValue({ id: PROFILE_ID, name: "Alice", pinHash: null });
+      prismaMock.profile.update.mockResolvedValue({ id: PROFILE_ID, name: "Alice", pinHash: hashPin("9999") });
+      const app = await buildApp();
+
+      const response = await app.inject({ method: "PATCH", url: `/profiles/${PROFILE_ID}`, payload: { pin: "9999" } });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json().profile.hasPin).toBe(true);
+      expect(prismaMock.profile.update).toHaveBeenCalledWith({
+        where: { id: PROFILE_ID },
+        data: { pinHash: hashPin("9999") },
+      });
+      expect(prismaMock.kV.deleteMany).toHaveBeenCalled();
+      await app.close();
+    });
+
+    it("removes a PIN when pin is explicitly null", async () => {
+      prismaMock.profile.findUnique.mockResolvedValue({ id: PROFILE_ID, name: "Alice", pinHash: hashPin("1234") });
+      prismaMock.profile.update.mockResolvedValue({ id: PROFILE_ID, name: "Alice", pinHash: null });
+      const app = await buildApp();
+
+      const response = await app.inject({ method: "PATCH", url: `/profiles/${PROFILE_ID}`, payload: { pin: null } });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json().profile.hasPin).toBe(false);
+      expect(prismaMock.profile.update).toHaveBeenCalledWith({
+        where: { id: PROFILE_ID },
+        data: { pinHash: null },
+      });
+      await app.close();
+    });
+
+    it("rejects a blank pin string (use null to remove)", async () => {
+      prismaMock.profile.findUnique.mockResolvedValue({ id: PROFILE_ID, name: "Alice", pinHash: null });
+      const app = await buildApp();
+      const response = await app.inject({ method: "PATCH", url: `/profiles/${PROFILE_ID}`, payload: { pin: "  " } });
+      expect(response.statusCode).toBe(400);
+      expect(prismaMock.profile.update).not.toHaveBeenCalled();
       await app.close();
     });
   });

--- a/apps/api/src/routes/profiles.test.ts
+++ b/apps/api/src/routes/profiles.test.ts
@@ -265,12 +265,16 @@ describe("profiles routes", () => {
       await app.close();
     });
 
-    it("removes a PIN when pin is explicitly null", async () => {
+    it("removes a PIN when pin is explicitly null and the correct currentPin is given", async () => {
       prismaMock.profile.findUnique.mockResolvedValue({ id: PROFILE_ID, name: "Alice", pinHash: hashPin("1234") });
       prismaMock.profile.update.mockResolvedValue({ id: PROFILE_ID, name: "Alice", pinHash: null });
       const app = await buildApp();
 
-      const response = await app.inject({ method: "PATCH", url: `/profiles/${PROFILE_ID}`, payload: { pin: null } });
+      const response = await app.inject({
+        method: "PATCH",
+        url: `/profiles/${PROFILE_ID}`,
+        payload: { pin: null, currentPin: "1234" },
+      });
 
       expect(response.statusCode).toBe(200);
       expect(response.json().profile.hasPin).toBe(false);
@@ -278,6 +282,7 @@ describe("profiles routes", () => {
         where: { id: PROFILE_ID },
         data: { pinHash: null },
       });
+      expect(prismaMock.kV.deleteMany).toHaveBeenCalled();
       await app.close();
     });
 
@@ -288,6 +293,65 @@ describe("profiles routes", () => {
       expect(response.statusCode).toBe(400);
       expect(prismaMock.profile.update).not.toHaveBeenCalled();
       await app.close();
+    });
+
+    describe("changing/removing an existing PIN requires the current PIN", () => {
+      it("rejects a PIN change with no currentPin provided", async () => {
+        prismaMock.profile.findUnique.mockResolvedValue({ id: PROFILE_ID, name: "Alice", pinHash: hashPin("1234") });
+        const app = await buildApp();
+
+        const response = await app.inject({ method: "PATCH", url: `/profiles/${PROFILE_ID}`, payload: { pin: "9999" } });
+
+        expect(response.statusCode).toBe(401);
+        expect(prismaMock.profile.update).not.toHaveBeenCalled();
+        await app.close();
+      });
+
+      it("rejects an incorrect currentPin and records a failed attempt", async () => {
+        prismaMock.profile.findUnique.mockResolvedValue({ id: PROFILE_ID, name: "Alice", pinHash: hashPin("1234") });
+        const app = await buildApp();
+
+        const response = await app.inject({
+          method: "PATCH",
+          url: `/profiles/${PROFILE_ID}`,
+          payload: { pin: "9999", currentPin: "0000" },
+        });
+
+        expect(response.statusCode).toBe(401);
+        expect(prismaMock.profile.update).not.toHaveBeenCalled();
+        expect(prismaMock.$transaction).toHaveBeenCalled();
+        await app.close();
+      });
+
+      it("changes the PIN when the correct currentPin is given", async () => {
+        prismaMock.profile.findUnique.mockResolvedValue({ id: PROFILE_ID, name: "Alice", pinHash: hashPin("1234") });
+        prismaMock.profile.update.mockResolvedValue({ id: PROFILE_ID, name: "Alice", pinHash: hashPin("9999") });
+        const app = await buildApp();
+
+        const response = await app.inject({
+          method: "PATCH",
+          url: `/profiles/${PROFILE_ID}`,
+          payload: { pin: "9999", currentPin: "1234" },
+        });
+
+        expect(response.statusCode).toBe(200);
+        expect(prismaMock.profile.update).toHaveBeenCalledWith({
+          where: { id: PROFILE_ID },
+          data: { pinHash: hashPin("9999") },
+        });
+        await app.close();
+      });
+
+      it("does not require currentPin when setting a PIN for the first time", async () => {
+        prismaMock.profile.findUnique.mockResolvedValue({ id: PROFILE_ID, name: "Alice", pinHash: null });
+        prismaMock.profile.update.mockResolvedValue({ id: PROFILE_ID, name: "Alice", pinHash: hashPin("9999") });
+        const app = await buildApp();
+
+        const response = await app.inject({ method: "PATCH", url: `/profiles/${PROFILE_ID}`, payload: { pin: "9999" } });
+
+        expect(response.statusCode).toBe(200);
+        await app.close();
+      });
     });
   });
 

--- a/apps/api/src/routes/profiles.ts
+++ b/apps/api/src/routes/profiles.ts
@@ -159,7 +159,7 @@ const profilesRoutes: FastifyPluginAsync = async (app) => {
     const profile = await prisma.profile.findUnique({ where: { id: request.params.id } });
     if (!profile) return reply.code(404).send({ error: "Profile not found" });
 
-    const body = (request.body ?? {}) as { name?: unknown; pin?: unknown };
+    const body = (request.body ?? {}) as { name?: unknown; pin?: unknown; currentPin?: unknown };
     const data: { name?: string; pinHash?: string | null } = {};
 
     if (body.name !== undefined) {
@@ -177,6 +177,25 @@ const profilesRoutes: FastifyPluginAsync = async (app) => {
         data.pinHash = hashPin(body.pin.trim());
       } else {
         return reply.code(400).send({ error: "pin must be a non-empty string or null when provided" });
+      }
+
+      // Changing or removing an *existing* PIN requires proving you know it —
+      // otherwise PIN protection is meaningless from Settings (anyone with app
+      // access could strip it without ever seeing the PIN). Setting a PIN for
+      // the first time needs no proof, since there's nothing to bypass yet.
+      if (profile.pinHash) {
+        const lockout = await getPinLockout(profile.id);
+        if (lockout.locked) {
+          return reply
+            .code(429)
+            .send({ error: "Too many incorrect attempts. Try again later.", retryAfterSec: lockout.retryAfterSec });
+        }
+
+        const currentPin = typeof body.currentPin === "string" ? body.currentPin.trim() : "";
+        if (!currentPin || !pinMatches(currentPin, profile.pinHash)) {
+          await recordPinFailure(profile.id);
+          return reply.code(401).send({ error: "Incorrect current PIN" });
+        }
       }
     }
 

--- a/apps/api/src/routes/profiles.ts
+++ b/apps/api/src/routes/profiles.ts
@@ -151,6 +151,50 @@ const profilesRoutes: FastifyPluginAsync = async (app) => {
     },
   );
 
+  app.patch<{ Params: { id: string }; Body: unknown }>("/profiles/:id", async (request, reply) => {
+    if (!UUID_V4_PATTERN.test(request.params.id)) {
+      return reply.code(400).send({ error: "id must be a valid UUID" });
+    }
+
+    const profile = await prisma.profile.findUnique({ where: { id: request.params.id } });
+    if (!profile) return reply.code(404).send({ error: "Profile not found" });
+
+    const body = (request.body ?? {}) as { name?: unknown; pin?: unknown };
+    const data: { name?: string; pinHash?: string | null } = {};
+
+    if (body.name !== undefined) {
+      if (typeof body.name !== "string" || !body.name.trim()) {
+        return reply.code(400).send({ error: "name must be a non-empty string when provided" });
+      }
+      data.name = body.name.trim();
+    }
+
+    // pin: omitted = leave as-is, null = remove PIN protection, string = set/change PIN.
+    if (body.pin !== undefined) {
+      if (body.pin === null) {
+        data.pinHash = null;
+      } else if (typeof body.pin === "string" && body.pin.trim()) {
+        data.pinHash = hashPin(body.pin.trim());
+      } else {
+        return reply.code(400).send({ error: "pin must be a non-empty string or null when provided" });
+      }
+    }
+
+    if (Object.keys(data).length === 0) {
+      return reply.code(400).send({ error: "name or pin must be provided" });
+    }
+
+    const updated = await prisma.profile.update({ where: { id: profile.id }, data });
+
+    // The PIN just changed (or was removed) — any outstanding lockout/attempt
+    // count from the old PIN no longer applies.
+    if (data.pinHash !== undefined) {
+      await clearPinAttempts(profile.id);
+    }
+
+    return { profile: { id: updated.id, name: updated.name, hasPin: updated.pinHash != null } };
+  });
+
   app.delete<{ Params: { id: string } }>("/profiles/:id", async (request, reply) => {
     if (!UUID_V4_PATTERN.test(request.params.id)) {
       return reply.code(400).send({ error: "id must be a valid UUID" });

--- a/apps/api/src/routes/search.ts
+++ b/apps/api/src/routes/search.ts
@@ -33,9 +33,15 @@ const searchRoutes: FastifyPluginAsync = async (app) => {
         return reply.code(500).send({ error: "TMDB integration is not configured" });
       }
 
-      const allResults = isAll
-        ? await tmdb.searchMulti(query)
-        : await tmdb.search(type!, query);
+      let allResults;
+      try {
+        allResults = isAll
+          ? await tmdb.searchMulti(query)
+          : await tmdb.search(type!, query);
+      } catch (error) {
+        request.log.error(error, "TMDB search failed");
+        return reply.code(502).send({ error: "TMDB search failed" });
+      }
 
       const results = allResults.slice(0, 20);
 

--- a/apps/api/src/routes/settings.ts
+++ b/apps/api/src/routes/settings.ts
@@ -12,6 +12,7 @@ import {
 import { OMDB_API_KEY_KV, getOmdbApiKey } from "../lib/omdb.js";
 import { RPDB_API_KEY_KV, getRpdbApiKey, buildRpdbPosterUrl } from "../lib/rpdb.js";
 import { trendingCache } from "../lib/cache.js";
+import { getFailedJobStatuses } from "../lib/job-status.js";
 
 const settingsRoutes: FastifyPluginAsync = async (app) => {
   app.get("/settings/preferences", async () => {
@@ -183,6 +184,15 @@ const settingsRoutes: FastifyPluginAsync = async (app) => {
   app.get("/rpdb/config", async () => {
     const apiKey = await getRpdbApiKey();
     return { enabled: !!apiKey, apiKey: apiKey ?? null };
+  });
+
+  // ─── Background job status ───
+  // Surfaces scheduled-job failures (Steam sync, Trakt poll, episode
+  // notifications, AI recs) that would otherwise only be visible in server
+  // logs or Sentry (opt-in, off by default) — see lib/job-status.ts.
+  app.get("/settings/job-status", async () => {
+    const failures = await getFailedJobStatuses();
+    return { failures };
   });
 };
 

--- a/apps/api/src/routes/watch.test.ts
+++ b/apps/api/src/routes/watch.test.ts
@@ -1,0 +1,347 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import Fastify, { type FastifyInstance } from "fastify";
+
+const PROFILE_ID = "11111111-1111-4111-8111-111111111111";
+
+const txMock = {
+  watchEvent: { findFirst: vi.fn(), delete: vi.fn() },
+  seriesProgress: { upsert: vi.fn(), deleteMany: vi.fn() },
+};
+
+const prismaMock = {
+  watchEvent: {
+    findFirst: vi.fn(),
+    findMany: vi.fn(),
+    update: vi.fn(),
+    aggregate: vi.fn(),
+    count: vi.fn(),
+  },
+  metadata: { findMany: vi.fn() },
+  rating: { findMany: vi.fn() },
+  $transaction: vi.fn(async (callback: (tx: typeof txMock) => unknown) => callback(txMock)),
+  $queryRaw: vi.fn(),
+};
+
+vi.mock("../lib/prisma.js", () => ({ prisma: prismaMock }));
+
+vi.mock("../lib/profile.js", () => ({
+  resolveProfile: async (request: { profileId?: string }) => {
+    request.profileId = PROFILE_ID;
+  },
+}));
+
+const watchEventMock = { recordWatchEvent: vi.fn() };
+vi.mock("../lib/watch-event.js", () => watchEventMock);
+
+const buildApp = async (): Promise<FastifyInstance> => {
+  vi.resetModules();
+  const { default: watchRoutes } = await import("./watch.js");
+  const app = Fastify();
+  await app.register(watchRoutes);
+  await app.ready();
+  return app;
+};
+
+const resetMocks = () => {
+  vi.clearAllMocks();
+  prismaMock.$transaction.mockImplementation(async (callback: (tx: typeof txMock) => unknown) => callback(txMock));
+  prismaMock.$queryRaw.mockResolvedValue([{ longest_streak: 0n, current_streak: 0n }]);
+  prismaMock.metadata.findMany.mockResolvedValue([]);
+  prismaMock.rating.findMany.mockResolvedValue([]);
+};
+
+describe("watch routes", () => {
+  beforeEach(() => {
+    resetMocks();
+  });
+
+  describe("POST /watch — validation", () => {
+    it("rejects an invalid type", async () => {
+      const app = await buildApp();
+      const response = await app.inject({ method: "POST", url: "/watch", payload: { type: "bogus", imdbId: "tt1" } });
+      expect(response.statusCode).toBe(400);
+      await app.close();
+    });
+
+    it("rejects a missing imdbId", async () => {
+      const app = await buildApp();
+      const response = await app.inject({ method: "POST", url: "/watch", payload: { type: "movie" } });
+      expect(response.statusCode).toBe(400);
+      await app.close();
+    });
+
+    it("rejects a negative season", async () => {
+      const app = await buildApp();
+      const response = await app.inject({
+        method: "POST",
+        url: "/watch",
+        payload: { type: "episode", imdbId: "tt1", season: -1 },
+      });
+      expect(response.statusCode).toBe(400);
+      await app.close();
+    });
+
+    it("rejects an invalid watchedAt string", async () => {
+      const app = await buildApp();
+      const response = await app.inject({
+        method: "POST",
+        url: "/watch",
+        payload: { type: "movie", imdbId: "tt1", watchedAt: "not-a-date" },
+      });
+      expect(response.statusCode).toBe(400);
+      await app.close();
+    });
+
+    it("rejects a non-string note", async () => {
+      const app = await buildApp();
+      const response = await app.inject({
+        method: "POST",
+        url: "/watch",
+        payload: { type: "movie", imdbId: "tt1", note: 42 },
+      });
+      expect(response.statusCode).toBe(400);
+      await app.close();
+    });
+  });
+
+  describe("POST /watch — success", () => {
+    it("records a movie watch event and returns 201 when newly created", async () => {
+      watchEventMock.recordWatchEvent.mockResolvedValue({
+        watchEvent: { id: "we-1", traktHistoryId: null },
+        wasCreated: true,
+      });
+
+      const app = await buildApp();
+      const response = await app.inject({
+        method: "POST",
+        url: "/watch",
+        payload: { type: "movie", imdbId: "tt1" },
+      });
+
+      expect(response.statusCode).toBe(201);
+      expect(watchEventMock.recordWatchEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "movie", imdbId: "tt1", source: "manual" })
+      );
+      await app.close();
+    });
+
+    it("returns 200 (not 201) when the event already existed (a replay)", async () => {
+      watchEventMock.recordWatchEvent.mockResolvedValue({
+        watchEvent: { id: "we-1", traktHistoryId: null },
+        wasCreated: false,
+      });
+
+      const app = await buildApp();
+      const response = await app.inject({
+        method: "POST",
+        url: "/watch",
+        payload: { type: "movie", imdbId: "tt1" },
+      });
+
+      expect(response.statusCode).toBe(200);
+      await app.close();
+    });
+
+    it("serializes a bigint traktHistoryId to a string in the response", async () => {
+      watchEventMock.recordWatchEvent.mockResolvedValue({
+        watchEvent: { id: "we-1", traktHistoryId: 123456789012345n },
+        wasCreated: true,
+      });
+
+      const app = await buildApp();
+      const response = await app.inject({ method: "POST", url: "/watch", payload: { type: "movie", imdbId: "tt1" } });
+
+      expect(response.json().watchEvent.traktHistoryId).toBe("123456789012345");
+      await app.close();
+    });
+  });
+
+  describe("PATCH /watch/:eventId", () => {
+    it("404s when the event doesn't belong to this profile", async () => {
+      prismaMock.watchEvent.findFirst.mockResolvedValue(null);
+      const app = await buildApp();
+      const response = await app.inject({ method: "PATCH", url: "/watch/we-1", payload: { note: "hi" } });
+      expect(response.statusCode).toBe(404);
+      await app.close();
+    });
+
+    it("updates the note", async () => {
+      prismaMock.watchEvent.findFirst.mockResolvedValue({ id: "we-1", traktHistoryId: null });
+      prismaMock.watchEvent.update.mockResolvedValue({ id: "we-1", note: "great episode", traktHistoryId: null });
+
+      const app = await buildApp();
+      const response = await app.inject({ method: "PATCH", url: "/watch/we-1", payload: { note: "great episode" } });
+
+      expect(response.statusCode).toBe(200);
+      expect(prismaMock.watchEvent.update).toHaveBeenCalledWith({
+        where: { id: "we-1" },
+        data: { note: "great episode" },
+      });
+      await app.close();
+    });
+
+    it("rejects a non-string, non-null note", async () => {
+      const app = await buildApp();
+      const response = await app.inject({ method: "PATCH", url: "/watch/we-1", payload: { note: 5 } });
+      expect(response.statusCode).toBe(400);
+      await app.close();
+    });
+  });
+
+  describe("DELETE /watch/:eventId", () => {
+    it("404s when the event doesn't belong to this profile", async () => {
+      txMock.watchEvent.findFirst.mockResolvedValue(null);
+      const app = await buildApp();
+      const response = await app.inject({ method: "DELETE", url: "/watch/we-1" });
+      expect(response.statusCode).toBe(404);
+      await app.close();
+    });
+
+    it("deletes a movie watch event without touching series progress", async () => {
+      txMock.watchEvent.findFirst.mockResolvedValue({ id: "we-1", type: "movie", seriesImdbId: null });
+      const app = await buildApp();
+      const response = await app.inject({ method: "DELETE", url: "/watch/we-1" });
+
+      expect(response.statusCode).toBe(204);
+      expect(txMock.watchEvent.delete).toHaveBeenCalledWith({ where: { id: "we-1" } });
+      expect(txMock.seriesProgress.upsert).not.toHaveBeenCalled();
+      expect(txMock.seriesProgress.deleteMany).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it("rewinds series progress to the next-latest episode after deleting an episode event", async () => {
+      txMock.watchEvent.findFirst
+        .mockResolvedValueOnce({ id: "we-1", type: "episode", seriesImdbId: "tt-series" })
+        .mockResolvedValueOnce({ season: 1, episode: 4, watchedAt: new Date("2026-01-01T00:00:00Z") });
+
+      const app = await buildApp();
+      const response = await app.inject({ method: "DELETE", url: "/watch/we-1" });
+
+      expect(response.statusCode).toBe(204);
+      expect(txMock.seriesProgress.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { profileId_seriesImdbId: { profileId: PROFILE_ID, seriesImdbId: "tt-series" } },
+          update: expect.objectContaining({ lastSeason: 1, lastEpisode: 4 }),
+        })
+      );
+      expect(txMock.seriesProgress.deleteMany).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it("clears series progress entirely when no earlier episode is left", async () => {
+      txMock.watchEvent.findFirst
+        .mockResolvedValueOnce({ id: "we-1", type: "episode", seriesImdbId: "tt-series" })
+        .mockResolvedValueOnce(null);
+
+      const app = await buildApp();
+      const response = await app.inject({ method: "DELETE", url: "/watch/we-1" });
+
+      expect(response.statusCode).toBe(204);
+      expect(txMock.seriesProgress.deleteMany).toHaveBeenCalledWith({
+        where: { profileId: PROFILE_ID, seriesImdbId: "tt-series" },
+      });
+      expect(txMock.seriesProgress.upsert).not.toHaveBeenCalled();
+      await app.close();
+    });
+  });
+
+  describe("GET /watch/history", () => {
+    it("returns an empty list when there is no history", async () => {
+      prismaMock.watchEvent.findMany.mockResolvedValue([]);
+      const app = await buildApp();
+      const response = await app.inject({ method: "GET", url: "/watch/history" });
+      expect(response.json()).toEqual({ history: [] });
+      await app.close();
+    });
+
+    it("attaches metadata name/poster and serializes traktHistoryId", async () => {
+      prismaMock.watchEvent.findMany.mockResolvedValue([
+        { id: "we-1", type: "movie", imdbId: "tt1", seriesImdbId: null, traktHistoryId: 42n },
+      ]);
+      prismaMock.metadata.findMany.mockResolvedValue([{ imdbId: "tt1", type: "movie", name: "Movie A", poster: "p.jpg" }]);
+
+      const app = await buildApp();
+      const response = await app.inject({ method: "GET", url: "/watch/history" });
+
+      expect(response.json().history[0]).toEqual(
+        expect.objectContaining({ name: "Movie A", poster: "p.jpg", traktHistoryId: "42" })
+      );
+      await app.close();
+    });
+
+    it("clamps an out-of-range limit query param to the 1-200 window", async () => {
+      prismaMock.watchEvent.findMany.mockResolvedValue([]);
+      const app = await buildApp();
+      await app.inject({ method: "GET", url: "/watch/history?limit=9999" });
+
+      expect(prismaMock.watchEvent.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ take: 200 })
+      );
+      await app.close();
+    });
+  });
+
+  describe("GET /watch/stats", () => {
+    it("aggregates movie/episode counts and plays-this-week", async () => {
+      prismaMock.watchEvent.aggregate
+        .mockResolvedValueOnce({ _count: 10, _sum: { plays: 15 } })
+        .mockResolvedValueOnce({ _count: 20, _sum: { plays: 30 } });
+      prismaMock.watchEvent.count.mockResolvedValue(3);
+
+      const app = await buildApp();
+      const response = await app.inject({ method: "GET", url: "/watch/stats" });
+
+      expect(response.json()).toEqual({
+        totalMovies: 10,
+        totalEpisodes: 20,
+        totalPlays: 45,
+        playsThisWeek: 3,
+      });
+      await app.close();
+    });
+  });
+
+  describe("GET /watch/stats/year/:year", () => {
+    it("rejects a malformed year", async () => {
+      const app = await buildApp();
+      const response = await app.inject({ method: "GET", url: "/watch/stats/year/abcd" });
+      expect(response.statusCode).toBe(400);
+      await app.close();
+    });
+
+    it("rejects a year before 1900", async () => {
+      const app = await buildApp();
+      const response = await app.inject({ method: "GET", url: "/watch/stats/year/1899" });
+      expect(response.statusCode).toBe(400);
+      await app.close();
+    });
+
+    it("returns zeroed totals for a year with no events", async () => {
+      prismaMock.watchEvent.findMany.mockResolvedValue([]);
+      const app = await buildApp();
+      const response = await app.inject({ method: "GET", url: "/watch/stats/year/2026" });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual(
+        expect.objectContaining({ year: 2026, totalMovies: 0, totalEpisodes: 0, totalRuntimeMinutes: 0 })
+      );
+      await app.close();
+    });
+  });
+
+  describe("GET /watch/stats/detailed", () => {
+    it("surfaces the current/longest streak from the raw SQL query", async () => {
+      prismaMock.watchEvent.findMany.mockResolvedValue([]);
+      prismaMock.$queryRaw.mockResolvedValue([{ longest_streak: 12n, current_streak: 3n }]);
+
+      const app = await buildApp();
+      const response = await app.inject({ method: "GET", url: "/watch/stats/detailed" });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual(
+        expect.objectContaining({ longestStreak: 12, currentStreak: 3 })
+      );
+      await app.close();
+    });
+  });
+});

--- a/apps/api/src/routes/webhooks/jellyfin.test.ts
+++ b/apps/api/src/routes/webhooks/jellyfin.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import Fastify, { type FastifyInstance } from "fastify";
+
+const webhookAuthMock = { verifyWebhookSecret: vi.fn(() => true) };
+vi.mock("../../lib/webhook-auth.js", () => webhookAuthMock);
+
+const watchEventMock = { recordWatchEvent: vi.fn() };
+vi.mock("../../lib/watch-event.js", () => watchEventMock);
+
+const buildApp = async (): Promise<FastifyInstance> => {
+  vi.resetModules();
+  const { default: jellyfinWebhookRoutes } = await import("./jellyfin.js");
+  const app = Fastify();
+  await app.register(jellyfinWebhookRoutes);
+  await app.ready();
+  return app;
+};
+
+describe("POST /webhooks/jellyfin", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    webhookAuthMock.verifyWebhookSecret.mockReturnValue(true);
+    watchEventMock.recordWatchEvent.mockResolvedValue({ watchEvent: { id: "we-1" }, wasCreated: true });
+  });
+
+  it("rejects requests that fail webhook secret verification", async () => {
+    webhookAuthMock.verifyWebhookSecret.mockReturnValue(false);
+    const app = await buildApp();
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/webhooks/jellyfin",
+      payload: { NotificationType: "PlaybackStop" },
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(watchEventMock.recordWatchEvent).not.toHaveBeenCalled();
+    await app.close();
+  });
+
+  it("400s on an empty body", async () => {
+    const app = await buildApp();
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/webhooks/jellyfin",
+      payload: "",
+      headers: { "content-type": "application/json" },
+    });
+
+    expect(response.statusCode).toBe(400);
+    await app.close();
+  });
+
+  it("ignores notification types other than PlaybackStop", async () => {
+    const app = await buildApp();
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/webhooks/jellyfin",
+      payload: { NotificationType: "PlaybackStart" },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ status: "ignored", type: "PlaybackStart" });
+    expect(watchEventMock.recordWatchEvent).not.toHaveBeenCalled();
+    await app.close();
+  });
+
+  it("skips PlaybackStop events with no IMDb provider id", async () => {
+    const app = await buildApp();
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/webhooks/jellyfin",
+      payload: { NotificationType: "PlaybackStop", ItemType: "Movie" },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ status: "skipped", reason: "no_imdb_id" });
+    expect(watchEventMock.recordWatchEvent).not.toHaveBeenCalled();
+    await app.close();
+  });
+
+  it("records a movie watch event", async () => {
+    const app = await buildApp();
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/webhooks/jellyfin",
+      payload: { NotificationType: "PlaybackStop", ItemType: "Movie", Provider_imdb: "tt1111111" },
+    });
+
+    expect(response.statusCode).toBe(201);
+    expect(watchEventMock.recordWatchEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "movie", imdbId: "tt1111111", source: "Jellyfin" })
+    );
+    await app.close();
+  });
+
+  it("records an episode watch event with season/episode", async () => {
+    const app = await buildApp();
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/webhooks/jellyfin",
+      payload: {
+        NotificationType: "PlaybackStop",
+        ItemType: "Episode",
+        Provider_imdb: "tt2222222",
+        Season: 3,
+        Episode: 7,
+      },
+    });
+
+    expect(response.statusCode).toBe(201);
+    expect(watchEventMock.recordWatchEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "episode",
+        imdbId: "tt2222222",
+        seriesImdbId: "tt2222222",
+        season: 3,
+        episode: 7,
+        source: "Jellyfin",
+      })
+    );
+    await app.close();
+  });
+});

--- a/apps/api/src/routes/webhooks/jellyfin.test.ts
+++ b/apps/api/src/routes/webhooks/jellyfin.test.ts
@@ -38,17 +38,22 @@ describe("POST /webhooks/jellyfin", () => {
     await app.close();
   });
 
-  it("400s on an empty body", async () => {
+  it("400s with the route's own error when the parsed body is null", async () => {
     const app = await buildApp();
 
+    // A genuinely empty request body never reaches the route handler — Fastify's
+    // JSON parser itself rejects it before the handler's `if (!body)` check runs.
+    // A literal JSON `null` body does reach the handler, so this exercises that
+    // check specifically instead of just asserting "some 400 happened".
     const response = await app.inject({
       method: "POST",
       url: "/webhooks/jellyfin",
-      payload: "",
+      payload: "null",
       headers: { "content-type": "application/json" },
     });
 
     expect(response.statusCode).toBe(400);
+    expect(response.json()).toEqual({ error: "Empty body" });
     await app.close();
   });
 

--- a/apps/api/src/routes/webhooks/plex.test.ts
+++ b/apps/api/src/routes/webhooks/plex.test.ts
@@ -1,0 +1,179 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import Fastify, { type FastifyInstance } from "fastify";
+
+const webhookAuthMock = { verifyWebhookSecret: vi.fn(() => true) };
+vi.mock("../../lib/webhook-auth.js", () => webhookAuthMock);
+
+const watchEventMock = { recordWatchEvent: vi.fn() };
+vi.mock("../../lib/watch-event.js", () => watchEventMock);
+
+const buildApp = async (): Promise<FastifyInstance> => {
+  vi.resetModules();
+  const { default: plexWebhookRoutes } = await import("./plex.js");
+  const app = Fastify();
+  await app.register(plexWebhookRoutes);
+  await app.ready();
+  return app;
+};
+
+const buildMultipartBody = (payload: unknown, boundary = "boundary123") =>
+  [
+    `--${boundary}`,
+    'Content-Disposition: form-data; name="payload"',
+    "",
+    JSON.stringify(payload),
+    `--${boundary}--`,
+  ].join("\r\n");
+
+describe("POST /webhooks/plex", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    webhookAuthMock.verifyWebhookSecret.mockReturnValue(true);
+    watchEventMock.recordWatchEvent.mockResolvedValue({ watchEvent: { id: "we-1" }, wasCreated: true });
+  });
+
+  it("rejects requests that fail webhook secret verification", async () => {
+    webhookAuthMock.verifyWebhookSecret.mockReturnValue(false);
+    const app = await buildApp();
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/webhooks/plex",
+      headers: { "content-type": `multipart/form-data; boundary=b` },
+      payload: buildMultipartBody({ event: "media.scrobble" }, "b"),
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(watchEventMock.recordWatchEvent).not.toHaveBeenCalled();
+    await app.close();
+  });
+
+  it("400s when no payload field is found in a multipart body", async () => {
+    const app = await buildApp();
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/webhooks/plex",
+      headers: { "content-type": "multipart/form-data; boundary=b" },
+      payload: `--b\r\nContent-Disposition: form-data; name="other"\r\n\r\nnope\r\n--b--`,
+    });
+
+    expect(response.statusCode).toBe(400);
+    await app.close();
+  });
+
+  it("400s on malformed JSON inside the payload field", async () => {
+    const app = await buildApp();
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/webhooks/plex",
+      headers: { "content-type": "multipart/form-data; boundary=b" },
+      payload: `--b\r\nContent-Disposition: form-data; name="payload"\r\n\r\n{not json}\r\n--b--`,
+    });
+
+    expect(response.statusCode).toBe(400);
+    await app.close();
+  });
+
+  it("ignores non-scrobble events without recording a watch event", async () => {
+    const app = await buildApp();
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/webhooks/plex",
+      headers: { "content-type": "multipart/form-data; boundary=b" },
+      payload: buildMultipartBody({ event: "media.play" }, "b"),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ status: "ignored", event: "media.play" });
+    expect(watchEventMock.recordWatchEvent).not.toHaveBeenCalled();
+    await app.close();
+  });
+
+  it("skips scrobble events with no resolvable IMDb ID", async () => {
+    const app = await buildApp();
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/webhooks/plex",
+      headers: { "content-type": "multipart/form-data; boundary=b" },
+      payload: buildMultipartBody({ event: "media.scrobble", Metadata: { type: "movie" } }, "b"),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ status: "skipped", reason: "no_imdb_id" });
+    expect(watchEventMock.recordWatchEvent).not.toHaveBeenCalled();
+    await app.close();
+  });
+
+  it("records a movie watch event, extracting the IMDb id from the Guid array", async () => {
+    const app = await buildApp();
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/webhooks/plex",
+      headers: { "content-type": "multipart/form-data; boundary=b" },
+      payload: buildMultipartBody(
+        {
+          event: "media.scrobble",
+          Metadata: { type: "movie", Guid: [{ id: "tvdb://123" }, { id: "imdb://tt9999999" }] },
+        },
+        "b"
+      ),
+    });
+
+    expect(response.statusCode).toBe(201);
+    expect(watchEventMock.recordWatchEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "movie", imdbId: "tt9999999", source: "Plex" })
+    );
+    await app.close();
+  });
+
+  it("records an episode watch event with season/episode from the legacy guid field", async () => {
+    const app = await buildApp();
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/webhooks/plex",
+      headers: { "content-type": "multipart/form-data; boundary=b" },
+      payload: buildMultipartBody(
+        {
+          event: "media.scrobble",
+          Metadata: { type: "episode", guid: "imdb://tt1234567", parentIndex: 2, index: 5 },
+        },
+        "b"
+      ),
+    });
+
+    expect(response.statusCode).toBe(201);
+    expect(watchEventMock.recordWatchEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "episode",
+        imdbId: "tt1234567",
+        seriesImdbId: "tt1234567",
+        season: 2,
+        episode: 5,
+        source: "Plex",
+      })
+    );
+    await app.close();
+  });
+
+  it("accepts a plain JSON body (no multipart wrapper)", async () => {
+    const app = await buildApp();
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/webhooks/plex",
+      payload: { event: "media.scrobble", Metadata: { type: "movie", guid: "imdb://tt5555555" } },
+    });
+
+    expect(response.statusCode).toBe(201);
+    expect(watchEventMock.recordWatchEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ imdbId: "tt5555555" })
+    );
+    await app.close();
+  });
+});

--- a/apps/api/src/tmdb.ts
+++ b/apps/api/src/tmdb.ts
@@ -207,6 +207,8 @@ export const STREAMING_PROVIDERS: Record<string, { id: number; name: string }> =
   crunchyroll: { id: 283, name: "Crunchyroll" },
 };
 
+const REQUEST_TIMEOUT_MS = 10_000;
+
 export class TmdbClient {
   private static readonly baseUrl = "https://api.themoviedb.org/3";
   private static readonly imageBaseUrl = "https://image.tmdb.org/t/p/w500";
@@ -646,7 +648,8 @@ export class TmdbClient {
     const response = await fetch(url, {
       headers: {
         Accept: "application/json"
-      }
+      },
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS)
     });
 
     if (!response.ok) {

--- a/apps/api/src/trakt.ts
+++ b/apps/api/src/trakt.ts
@@ -4,6 +4,7 @@ import type { PrismaClient } from "@prisma/client";
 const TRAKT_API_BASE = "https://api.trakt.tv";
 const MAX_PAGES = 100;
 const DEFAULT_POLL_MAX_PAGES = 20;
+const REQUEST_TIMEOUT_MS = 10_000;
 
 function parsePollMaxPages(raw: string | undefined): number {
   const parsed = raw !== undefined ? Number.parseInt(raw, 10) : NaN;
@@ -343,7 +344,8 @@ export class TraktClient {
     const response = await fetch(url, {
       method: options.method,
       headers: { "User-Agent": "Cataloggy/1.0", ...options.headers },
-      body: options.body
+      body: options.body,
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS)
     });
 
     if (response.status === 401 && options.allowRefresh !== false) {
@@ -378,7 +380,8 @@ export class TraktClient {
         client_id: this.clientId,
         client_secret: this.clientSecret,
         grant_type: "refresh_token"
-      })
+      }),
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS)
     });
 
     if (!response.ok) {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -42,6 +42,12 @@ export function App() {
   const [sidebarPinned, setSidebarPinned] = useState(() => localStorage.getItem(PIN_KEY) === "1");
   const sidebarPad = sidebarPinned ? "sm:pl-[15rem]" : "sm:pl-16";
 
+  useEffect(() => {
+    const handleUnauthorized = () => setNeedsSetup(true);
+    window.addEventListener("cataloggy:unauthorized", handleUnauthorized);
+    return () => window.removeEventListener("cataloggy:unauthorized", handleUnauthorized);
+  }, []);
+
   if (needsSetup) {
     return (
       <SetupWizard

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -830,6 +830,12 @@ export const api = {
       body: JSON.stringify(pin ? { pin } : {}),
     });
   },
+  updateProfile(profileId: string, payload: { name?: string; pin?: string | null }) {
+    return request<{ profile: Profile }>(`/profiles/${encodeURIComponent(profileId)}`, {
+      method: "PATCH",
+      body: JSON.stringify(payload),
+    });
+  },
   deleteProfile(profileId: string) {
     return request<void>(`/profiles/${encodeURIComponent(profileId)}`, { method: "DELETE" });
   },

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -471,6 +471,15 @@ async function request<T>(path: string, init?: RequestInit & { timeoutMs?: numbe
         // not JSON — use the raw body as-is
       }
     }
+    // A 401 with a WWW-Authenticate header (RFC 6750) comes from the bearer-token
+    // auth middleware itself, meaning the stored token is missing/invalid/rotated —
+    // as opposed to a route-level 401 like an incorrect profile PIN. Clear it and
+    // tell the app to fall back to the setup wizard instead of leaving every page
+    // stuck on a generic "Unable to connect" error for the rest of the session.
+    if (response.status === 401 && response.headers.get("www-authenticate")) {
+      runtimeConfig.setToken("");
+      window.dispatchEvent(new Event("cataloggy:unauthorized"));
+    }
     throw new ApiError(message || `Request failed: ${response.status}`, response.status);
   }
 

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -379,6 +379,12 @@ export type SteamSyncSummary = {
   unmatched: number;
 };
 
+export type JobFailure = {
+  job: string;
+  message: string;
+  failedAt: string;
+};
+
 const authHeaders = (hasBody: boolean) => {
   const token = runtimeConfig.getToken();
   const headers: Record<string, string> = {
@@ -605,6 +611,9 @@ export const api = {
   },
   removeOmdbKey() {
     return request<{ configured: boolean }>("/omdb/key", { method: "DELETE" });
+  },
+  getJobStatus() {
+    return request<{ failures: JobFailure[] }>("/settings/job-status");
   },
   getDetailedStats() {
     return request<DetailedWatchStats>("/watch/stats/detailed");

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -830,7 +830,7 @@ export const api = {
       body: JSON.stringify(pin ? { pin } : {}),
     });
   },
-  updateProfile(profileId: string, payload: { name?: string; pin?: string | null }) {
+  updateProfile(profileId: string, payload: { name?: string; pin?: string | null; currentPin?: string }) {
     return request<{ profile: Profile }>(`/profiles/${encodeURIComponent(profileId)}`, {
       method: "PATCH",
       body: JSON.stringify(payload),

--- a/apps/web/src/components/UpdatePrompt.tsx
+++ b/apps/web/src/components/UpdatePrompt.tsx
@@ -1,0 +1,51 @@
+import { useEffect, useState } from "react";
+import { registerSW } from "virtual:pwa-register";
+import { RefreshCw, X } from "lucide-react";
+
+// registerType is "prompt" (see vite.config.ts) rather than "autoUpdate" —
+// a new service worker install/reload is surfaced here instead of silently
+// taking over, since an unannounced reload can drop in-progress state (e.g.
+// a check-in) on TV/remote-control UIs where that's harder to notice/recover from.
+export function UpdatePrompt() {
+  const [needRefresh, setNeedRefresh] = useState(false);
+  const [updateSW, setUpdateSW] = useState<((reloadPage?: boolean) => Promise<void>) | null>(null);
+
+  useEffect(() => {
+    const update = registerSW({
+      immediate: true,
+      onNeedRefresh: () => setNeedRefresh(true)
+    });
+    setUpdateSW(() => update);
+  }, []);
+
+  if (!needRefresh) return null;
+
+  return (
+    <div
+      role="status"
+      className="fixed bottom-6 left-1/2 z-[110] flex -translate-x-1/2 items-center gap-3 rounded-xl border px-5 py-3.5 shadow-md"
+      style={{ borderLeftWidth: "4px", borderColor: "var(--border)", background: "var(--bg-1)" }}
+    >
+      <RefreshCw aria-hidden="true" className="h-5 w-5 flex-none text-claw-600" />
+      <span className="text-sm font-medium" style={{ color: "var(--text)" }}>
+        A new version of Cataloggy is available.
+      </span>
+      <button
+        type="button"
+        onClick={() => updateSW?.(true)}
+        className="flex-none rounded-md bg-claw-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-claw-600"
+      >
+        Reload
+      </button>
+      <button
+        type="button"
+        onClick={() => setNeedRefresh(false)}
+        aria-label="Dismiss update notification"
+        className="ml-1 flex-none rounded-md p-1 hover:bg-[var(--surface-strong)]"
+        style={{ color: "var(--text-mute)" }}
+      >
+        <X aria-hidden="true" className="h-3.5 w-3.5" />
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/JobStatusSettings.tsx
+++ b/apps/web/src/components/settings/JobStatusSettings.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useState } from "react";
+import { AlertTriangle, Loader2 } from "lucide-react";
+import { api, JobFailure } from "../../api";
+import { StatusBadge } from "./StatusBadge";
+import { timeAgo } from "../../utils/timeAgo";
+
+const JOB_LABELS: Record<string, string> = {
+  "trakt-history-poll": "Trakt history sync",
+  "trakt-watchlist-sync": "Trakt watchlist sync",
+  "scrobble-cleanup": "Scrobble session cleanup",
+  "episode-notifications": "Upcoming episode notifications",
+  "ai-recommendations": "AI recommendations refresh",
+  "steam-sync": "Steam library sync",
+};
+
+// These scheduled jobs run on a timer with no user in the loop, so a failure
+// is otherwise silent unless Sentry is configured (opt-in, off by default —
+// see README's Security section). This surfaces the last failure of each so
+// it's visible without needing Sentry.
+export function JobStatusSettings() {
+  const [loading, setLoading] = useState(true);
+  const [failures, setFailures] = useState<JobFailure[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    void (async () => {
+      try {
+        const result = await api.getJobStatus();
+        setFailures(result.failures);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to load job status");
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2 text-sm" style={{ color: "var(--text-dim)" }}>
+        <Loader2 size={16} className="animate-spin" /> Checking background job status...
+      </div>
+    );
+  }
+
+  if (error) {
+    return <p className="text-sm text-rose-600">{error}</p>;
+  }
+
+  if (failures.length === 0) {
+    return (
+      <div className="flex items-center gap-3">
+        <StatusBadge ok label="All scheduled jobs healthy" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-sm leading-relaxed" style={{ color: "var(--text-dim)" }}>
+        These background jobs failed on their most recent run. They'll clear automatically once a run succeeds again.
+      </p>
+      {failures.map((failure) => (
+        <div
+          key={failure.job}
+          className="flex flex-col gap-1 rounded-xl border px-4 py-3 text-sm"
+          style={{ borderColor: "var(--border)", background: "var(--bg-1)" }}
+        >
+          <div className="flex items-center gap-2 font-semibold" style={{ color: "var(--text)" }}>
+            <AlertTriangle size={16} className="flex-none text-amber-500" />
+            {JOB_LABELS[failure.job] ?? failure.job}
+            <span className="ml-auto text-xs font-normal" style={{ color: "var(--text-mute)" }}>
+              {timeAgo(failure.failedAt)}
+            </span>
+          </div>
+          <p className="font-mono text-xs break-words" style={{ color: "var(--text-dim)" }}>{failure.message}</p>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/ProfileSettings.tsx
+++ b/apps/web/src/components/settings/ProfileSettings.tsx
@@ -58,8 +58,12 @@ function RenameForm({ profile, onSaved, onCancel }: { profile: Profile; onSaved:
   );
 }
 
+// Changing or removing an *existing* PIN requires the current one (enforced
+// server-side too) — otherwise anyone with the app open could strip another
+// profile's PIN protection without ever knowing it, defeating its purpose.
 function PinForm({ profile, onSaved, onCancel }: { profile: Profile; onSaved: (p: Profile) => void; onCancel: () => void }) {
   const [pin, setPin] = useState("");
+  const [currentPin, setCurrentPin] = useState("");
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -67,13 +71,86 @@ function PinForm({ profile, onSaved, onCancel }: { profile: Profile; onSaved: (p
     e.preventDefault();
     const trimmed = pin.trim();
     if (!trimmed) return;
+    if (profile.hasPin && !currentPin.trim()) return;
     setSaving(true);
     setError(null);
     try {
-      const { profile: updated } = await api.updateProfile(profile.id, { pin: trimmed });
+      const { profile: updated } = await api.updateProfile(profile.id, {
+        pin: trimmed,
+        ...(profile.hasPin ? { currentPin: currentPin.trim() } : {}),
+      });
       onSaved(updated);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Could not set PIN.");
+      if (err instanceof ApiError && err.status === 401) {
+        setError("Incorrect current PIN.");
+      } else {
+        setError(err instanceof Error ? err.message : "Could not set PIN.");
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <form onSubmit={submit} className="flex flex-1 flex-wrap items-center gap-2">
+      {profile.hasPin && (
+        <input
+          autoFocus
+          type="password"
+          inputMode="numeric"
+          value={currentPin}
+          onChange={(e) => setCurrentPin(e.target.value)}
+          placeholder="Current PIN"
+          className="w-full min-w-0 flex-1 rounded-lg border px-2.5 py-1.5 text-sm focus:border-claw-500 focus:outline-none focus:ring-2 focus:ring-claw-500/15"
+          style={{ borderColor: "var(--border)", color: "var(--text)", background: "var(--bg-1)" }}
+        />
+      )}
+      <input
+        autoFocus={!profile.hasPin}
+        type="password"
+        inputMode="numeric"
+        value={pin}
+        onChange={(e) => setPin(e.target.value)}
+        placeholder={profile.hasPin ? "New PIN" : "PIN"}
+        className="w-full min-w-0 flex-1 rounded-lg border px-2.5 py-1.5 text-sm focus:border-claw-500 focus:outline-none focus:ring-2 focus:ring-claw-500/15"
+        style={{ borderColor: "var(--border)", color: "var(--text)", background: "var(--bg-1)" }}
+      />
+      <button
+        type="submit"
+        disabled={saving || !pin.trim() || (profile.hasPin && !currentPin.trim())}
+        aria-label="Save PIN"
+        className="flex-none rounded-lg p-1.5 text-emerald-600 hover:bg-[var(--surface-strong)] disabled:opacity-50"
+      >
+        {saving ? <Loader2 size={16} className="animate-spin" /> : <Check size={16} />}
+      </button>
+      <button type="button" onClick={onCancel} aria-label="Cancel" className="flex-none rounded-lg p-1.5 hover:bg-[var(--surface-strong)]" style={{ color: "var(--text-mute)" }}>
+        <X size={16} />
+      </button>
+      {error && <p className="w-full text-xs text-rose-600">{error}</p>}
+    </form>
+  );
+}
+
+function RemovePinForm({ profile, onSaved, onCancel }: { profile: Profile; onSaved: (p: Profile) => void; onCancel: () => void }) {
+  const [currentPin, setCurrentPin] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = async (e: FormEvent) => {
+    e.preventDefault();
+    const trimmed = currentPin.trim();
+    if (!trimmed) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const { profile: updated } = await api.updateProfile(profile.id, { pin: null, currentPin: trimmed });
+      onSaved(updated);
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 401) {
+        setError("Incorrect current PIN.");
+      } else {
+        setError(err instanceof Error ? err.message : "Could not remove PIN.");
+      }
     } finally {
       setSaving(false);
     }
@@ -85,13 +162,13 @@ function PinForm({ profile, onSaved, onCancel }: { profile: Profile; onSaved: (p
         autoFocus
         type="password"
         inputMode="numeric"
-        value={pin}
-        onChange={(e) => setPin(e.target.value)}
-        placeholder={profile.hasPin ? "New PIN" : "PIN"}
+        value={currentPin}
+        onChange={(e) => setCurrentPin(e.target.value)}
+        placeholder="Current PIN to confirm removal"
         className="w-full min-w-0 rounded-lg border px-2.5 py-1.5 text-sm focus:border-claw-500 focus:outline-none focus:ring-2 focus:ring-claw-500/15"
         style={{ borderColor: "var(--border)", color: "var(--text)", background: "var(--bg-1)" }}
       />
-      <button type="submit" disabled={saving || !pin.trim()} aria-label="Save PIN" className="flex-none rounded-lg p-1.5 text-emerald-600 hover:bg-[var(--surface-strong)] disabled:opacity-50">
+      <button type="submit" disabled={saving || !currentPin.trim()} aria-label="Confirm PIN removal" className="flex-none rounded-lg p-1.5 text-emerald-600 hover:bg-[var(--surface-strong)] disabled:opacity-50">
         {saving ? <Loader2 size={16} className="animate-spin" /> : <Check size={16} />}
       </button>
       <button type="button" onClick={onCancel} aria-label="Cancel" className="flex-none rounded-lg p-1.5 hover:bg-[var(--surface-strong)]" style={{ color: "var(--text-mute)" }}>
@@ -115,21 +192,10 @@ function ProfileRow({
   onUpdated: (p: Profile) => void;
   onDeleted: (id: string) => void;
 }) {
-  const [editing, setEditing] = useState<"none" | "name" | "pin">("none");
+  const [editing, setEditing] = useState<"none" | "name" | "pin" | "removePin">("none");
   const [deleting, setDeleting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const { showToast } = useToast();
-
-  const removePin = async () => {
-    setError(null);
-    try {
-      const { profile: updated } = await api.updateProfile(profile.id, { pin: null });
-      onUpdated(updated);
-      showToast(`PIN removed for ${updated.name}`);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Could not remove PIN.");
-    }
-  };
 
   const remove = async () => {
     if (
@@ -172,6 +238,12 @@ function ProfileRow({
             onSaved={(p) => { onUpdated(p); setEditing("none"); showToast(`PIN ${profile.hasPin ? "changed" : "set"} for ${p.name}`); }}
             onCancel={() => setEditing("none")}
           />
+        ) : editing === "removePin" ? (
+          <RemovePinForm
+            profile={profile}
+            onSaved={(p) => { onUpdated(p); setEditing("none"); showToast(`PIN removed for ${p.name}`); }}
+            onCancel={() => setEditing("none")}
+          />
         ) : (
           <>
             <div className="flex min-w-0 flex-1 items-center gap-2">
@@ -204,7 +276,7 @@ function ProfileRow({
             {profile.hasPin && (
               <button
                 type="button"
-                onClick={removePin}
+                onClick={() => setEditing("removePin")}
                 aria-label={`Remove PIN for ${profile.name}`}
                 className="flex-none rounded-lg p-1.5 transition-colors hover:bg-[var(--surface-strong)]"
                 style={{ color: "var(--text-mute)" }}

--- a/apps/web/src/components/settings/ProfileSettings.tsx
+++ b/apps/web/src/components/settings/ProfileSettings.tsx
@@ -1,16 +1,278 @@
-import { Users } from "lucide-react";
+import { FormEvent, useEffect, useState } from "react";
+import { AlertCircle, Check, Loader2, Lock, Pencil, Trash2, Unlock, Users, X } from "lucide-react";
+import { api, ApiError, Profile } from "../../api";
 import { useProfile } from "../../hooks/useProfile";
+import { useToast } from "../../hooks/useToast";
+
+const AVATAR_COLORS = ["#f97316", "#0ea5e9", "#a855f7", "#22c55e", "#ec4899", "#eab308"];
+
+function avatarColor(name: string) {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) hash = (hash * 31 + name.charCodeAt(i)) | 0;
+  return AVATAR_COLORS[Math.abs(hash) % AVATAR_COLORS.length];
+}
+
+function initials(name: string) {
+  return name.trim().slice(0, 2).toUpperCase();
+}
+
+function RenameForm({ profile, onSaved, onCancel }: { profile: Profile; onSaved: (p: Profile) => void; onCancel: () => void }) {
+  const [name, setName] = useState(profile.name);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = async (e: FormEvent) => {
+    e.preventDefault();
+    const trimmed = name.trim();
+    if (!trimmed || trimmed === profile.name) return onCancel();
+    setSaving(true);
+    setError(null);
+    try {
+      const { profile: updated } = await api.updateProfile(profile.id, { name: trimmed });
+      onSaved(updated);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not rename profile.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <form onSubmit={submit} className="flex flex-1 items-center gap-2">
+      <input
+        autoFocus
+        type="text"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        className="w-full min-w-0 rounded-lg border px-2.5 py-1.5 text-sm focus:border-claw-500 focus:outline-none focus:ring-2 focus:ring-claw-500/15"
+        style={{ borderColor: "var(--border)", color: "var(--text)", background: "var(--bg-1)" }}
+      />
+      <button type="submit" disabled={saving} aria-label="Save name" className="flex-none rounded-lg p-1.5 text-emerald-600 hover:bg-[var(--surface-strong)]">
+        {saving ? <Loader2 size={16} className="animate-spin" /> : <Check size={16} />}
+      </button>
+      <button type="button" onClick={onCancel} aria-label="Cancel rename" className="flex-none rounded-lg p-1.5 hover:bg-[var(--surface-strong)]" style={{ color: "var(--text-mute)" }}>
+        <X size={16} />
+      </button>
+      {error && <p className="w-full text-xs text-rose-600">{error}</p>}
+    </form>
+  );
+}
+
+function PinForm({ profile, onSaved, onCancel }: { profile: Profile; onSaved: (p: Profile) => void; onCancel: () => void }) {
+  const [pin, setPin] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = async (e: FormEvent) => {
+    e.preventDefault();
+    const trimmed = pin.trim();
+    if (!trimmed) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const { profile: updated } = await api.updateProfile(profile.id, { pin: trimmed });
+      onSaved(updated);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not set PIN.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <form onSubmit={submit} className="flex flex-1 items-center gap-2">
+      <input
+        autoFocus
+        type="password"
+        inputMode="numeric"
+        value={pin}
+        onChange={(e) => setPin(e.target.value)}
+        placeholder={profile.hasPin ? "New PIN" : "PIN"}
+        className="w-full min-w-0 rounded-lg border px-2.5 py-1.5 text-sm focus:border-claw-500 focus:outline-none focus:ring-2 focus:ring-claw-500/15"
+        style={{ borderColor: "var(--border)", color: "var(--text)", background: "var(--bg-1)" }}
+      />
+      <button type="submit" disabled={saving || !pin.trim()} aria-label="Save PIN" className="flex-none rounded-lg p-1.5 text-emerald-600 hover:bg-[var(--surface-strong)] disabled:opacity-50">
+        {saving ? <Loader2 size={16} className="animate-spin" /> : <Check size={16} />}
+      </button>
+      <button type="button" onClick={onCancel} aria-label="Cancel" className="flex-none rounded-lg p-1.5 hover:bg-[var(--surface-strong)]" style={{ color: "var(--text-mute)" }}>
+        <X size={16} />
+      </button>
+      {error && <p className="w-full text-xs text-rose-600">{error}</p>}
+    </form>
+  );
+}
+
+function ProfileRow({
+  profile,
+  isActive,
+  isOnlyProfile,
+  onUpdated,
+  onDeleted,
+}: {
+  profile: Profile;
+  isActive: boolean;
+  isOnlyProfile: boolean;
+  onUpdated: (p: Profile) => void;
+  onDeleted: (id: string) => void;
+}) {
+  const [editing, setEditing] = useState<"none" | "name" | "pin">("none");
+  const [deleting, setDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const { showToast } = useToast();
+
+  const removePin = async () => {
+    setError(null);
+    try {
+      const { profile: updated } = await api.updateProfile(profile.id, { pin: null });
+      onUpdated(updated);
+      showToast(`PIN removed for ${updated.name}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not remove PIN.");
+    }
+  };
+
+  const remove = async () => {
+    if (
+      !window.confirm(
+        `Delete the "${profile.name}" profile? Its watch history, lists, and stats will be permanently deleted.`
+      )
+    ) {
+      return;
+    }
+    setDeleting(true);
+    setError(null);
+    try {
+      await api.deleteProfile(profile.id);
+      onDeleted(profile.id);
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : "Could not delete profile.");
+      setDeleting(false);
+    }
+  };
+
+  return (
+    <div className="rounded-xl border px-3 py-2.5" style={{ borderColor: "var(--border)", background: "var(--bg-1)" }}>
+      <div className="flex items-center gap-3">
+        <span
+          className="flex h-8 w-8 flex-none items-center justify-center rounded-full text-xs font-bold text-white"
+          style={{ backgroundColor: avatarColor(profile.name) }}
+        >
+          {initials(profile.name)}
+        </span>
+
+        {editing === "name" ? (
+          <RenameForm
+            profile={profile}
+            onSaved={(p) => { onUpdated(p); setEditing("none"); }}
+            onCancel={() => setEditing("none")}
+          />
+        ) : editing === "pin" ? (
+          <PinForm
+            profile={profile}
+            onSaved={(p) => { onUpdated(p); setEditing("none"); showToast(`PIN ${profile.hasPin ? "changed" : "set"} for ${p.name}`); }}
+            onCancel={() => setEditing("none")}
+          />
+        ) : (
+          <>
+            <div className="flex min-w-0 flex-1 items-center gap-2">
+              <span className="truncate text-sm font-medium" style={{ color: "var(--text)" }}>{profile.name}</span>
+              {isActive && (
+                <span className="flex-none rounded-full bg-claw-500/10 px-2 py-0.5 text-2xs font-medium text-claw-600">Active</span>
+              )}
+              {profile.hasPin ? (
+                <Lock size={13} className="flex-none" style={{ color: "var(--text-mute)" }} />
+              ) : null}
+            </div>
+            <button
+              type="button"
+              onClick={() => setEditing("name")}
+              aria-label={`Rename ${profile.name}`}
+              className="flex-none rounded-lg p-1.5 transition-colors hover:bg-[var(--surface-strong)]"
+              style={{ color: "var(--text-mute)" }}
+            >
+              <Pencil size={14} />
+            </button>
+            <button
+              type="button"
+              onClick={() => setEditing("pin")}
+              aria-label={profile.hasPin ? `Change PIN for ${profile.name}` : `Set PIN for ${profile.name}`}
+              className="flex-none rounded-lg p-1.5 transition-colors hover:bg-[var(--surface-strong)]"
+              style={{ color: "var(--text-mute)" }}
+            >
+              <Lock size={14} />
+            </button>
+            {profile.hasPin && (
+              <button
+                type="button"
+                onClick={removePin}
+                aria-label={`Remove PIN for ${profile.name}`}
+                className="flex-none rounded-lg p-1.5 transition-colors hover:bg-[var(--surface-strong)]"
+                style={{ color: "var(--text-mute)" }}
+              >
+                <Unlock size={14} />
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={remove}
+              disabled={deleting || isOnlyProfile}
+              title={isOnlyProfile ? "Can't delete the only profile" : "Delete profile"}
+              aria-label={`Delete ${profile.name}`}
+              className="flex-none rounded-lg p-1.5 transition-colors hover:bg-rose-500/10 hover:text-rose-600 disabled:opacity-30 disabled:hover:bg-transparent disabled:hover:text-[var(--text-mute)]"
+              style={{ color: "var(--text-mute)" }}
+            >
+              {deleting ? <Loader2 size={14} className="animate-spin" /> : <Trash2 size={14} />}
+            </button>
+          </>
+        )}
+      </div>
+      {error && <p className="mt-1.5 flex items-center gap-1.5 text-xs text-rose-600"><AlertCircle size={13} /> {error}</p>}
+    </div>
+  );
+}
 
 export function ProfileSettings() {
-  const { profile, openSwitcher } = useProfile();
+  const { profile: activeProfile, setProfile: setActiveProfile, openSwitcher } = useProfile();
+  const [profiles, setProfiles] = useState<Profile[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const { showToast } = useToast();
+
+  useEffect(() => {
+    void (async () => {
+      try {
+        const { profiles: fetched } = await api.getProfiles();
+        setProfiles(fetched);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to load profiles");
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  const handleUpdated = (updated: Profile) => {
+    setProfiles((prev) => prev.map((p) => (p.id === updated.id ? updated : p)));
+    if (activeProfile?.id === updated.id) setActiveProfile(updated);
+  };
+
+  const handleDeleted = (id: string) => {
+    setProfiles((prev) => prev.filter((p) => p.id !== id));
+    showToast("Profile deleted");
+    if (activeProfile?.id === id) {
+      // The profile we were using is gone — force re-selection instead of
+      // leaving every subsequent API call scoped to a now-nonexistent profile.
+      openSwitcher();
+    }
+  };
 
   return (
     <div className="space-y-4">
       <p className="text-sm leading-relaxed" style={{ color: "var(--text-dim)" }}>
-        {profile ? <>Currently watching as <strong>{profile.name}</strong>. </> : null}
-        Switch to a different profile, or create a new one. Each profile has its own watch history,
-        lists, and stats.
+        {activeProfile ? <>Currently watching as <strong>{activeProfile.name}</strong>. </> : null}
+        Each profile has its own watch history, lists, and stats. Rename, PIN-protect, or delete profiles below.
       </p>
+
       <button
         type="button"
         onClick={openSwitcher}
@@ -19,6 +281,27 @@ export function ProfileSettings() {
       >
         <Users size={16} /> Switch Profile
       </button>
+
+      {loading ? (
+        <div className="flex items-center gap-2 text-sm" style={{ color: "var(--text-dim)" }}>
+          <Loader2 size={16} className="animate-spin" /> Loading profiles...
+        </div>
+      ) : error ? (
+        <p className="flex items-center gap-2 text-sm text-rose-600"><AlertCircle size={16} /> {error}</p>
+      ) : (
+        <div className="space-y-2">
+          {profiles.map((profile) => (
+            <ProfileRow
+              key={profile.id}
+              profile={profile}
+              isActive={activeProfile?.id === profile.id}
+              isOnlyProfile={profiles.length === 1}
+              onUpdated={handleUpdated}
+              onDeleted={handleDeleted}
+            />
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -2,13 +2,11 @@ import "./sentry";
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
-import { registerSW } from "virtual:pwa-register";
 import { App } from "./App";
 import { ErrorBoundary } from "./components/ErrorBoundary";
+import { UpdatePrompt } from "./components/UpdatePrompt";
 import "@fontsource-variable/plus-jakarta-sans";
 import "./index.css";
-
-registerSW({ immediate: true });
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
@@ -16,6 +14,7 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
       <BrowserRouter>
         <App />
       </BrowserRouter>
+      <UpdatePrompt />
     </ErrorBoundary>
   </React.StrictMode>
 );

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -1,5 +1,5 @@
 import { useSearchParams } from "react-router-dom";
-import { Key, Link, Database, Info, Clapperboard, Image, Globe, Star, Sparkles, Bell, Users } from "lucide-react";
+import { Key, Link, Database, Info, Clapperboard, Image, Globe, Star, Sparkles, Bell, Users, Activity } from "lucide-react";
 import { Section } from "../components/settings/Section";
 import { ApiTokenSettings } from "../components/settings/ApiTokenSettings";
 import { TraktSettings } from "../components/settings/TraktSettings";
@@ -11,6 +11,7 @@ import { DataSettings } from "../components/settings/DataSettings";
 import { PreferencesSettings } from "../components/settings/PreferencesSettings";
 import { PushSettings } from "../components/settings/PushSettings";
 import { ProfileSettings } from "../components/settings/ProfileSettings";
+import { JobStatusSettings } from "../components/settings/JobStatusSettings";
 
 declare const __APP_VERSION__: string;
 const APP_VERSION = typeof __APP_VERSION__ !== "undefined" ? __APP_VERSION__ : "unknown";
@@ -74,6 +75,10 @@ export function SettingsPage() {
 
           <Section title="Notifications" icon={<Bell size={20} />} storageKey="notifications">
             <PushSettings />
+          </Section>
+
+          <Section title="Sync Status" icon={<Activity size={20} />} storageKey="job-status" defaultOpen={false}>
+            <JobStatusSettings />
           </Section>
 
           <Section title="About" icon={<Info size={20} />} storageKey="about">

--- a/apps/web/src/sw.js
+++ b/apps/web/src/sw.js
@@ -92,6 +92,14 @@ self.addEventListener("message", (event) => {
     // Ack on the reply port (if the caller sent one) so it can await
     // completion instead of firing-and-forgetting the postMessage.
     done.then(() => event.ports[0]?.postMessage({ done: true }));
+    return;
+  }
+
+  // Sent by the page's update-available prompt (see UpdatePrompt.tsx) once
+  // the user chooses to reload — without this, a waiting SW never activates
+  // and the "Reload" button would appear to do nothing.
+  if (event.data?.type === "SKIP_WAITING") {
+    self.skipWaiting();
   }
 });
 

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
   plugins: [
     react(),
     VitePWA({
-      registerType: "autoUpdate",
+      registerType: "prompt",
       strategies: "injectManifest",
       srcDir: "src",
       filename: "sw.js",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - "5432:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
+    restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres -d cataloggy"]
       interval: 5s
@@ -58,6 +59,7 @@ services:
     depends_on:
       db:
         condition: service_healthy
+    restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "wget -q --spider http://127.0.0.1:7000/health || exit 1"]
       interval: 10s
@@ -84,6 +86,7 @@ services:
     depends_on:
       api:
         condition: service_healthy
+    restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "wget -q --spider http://127.0.0.1:7001/health || exit 1"]
       interval: 10s
@@ -112,6 +115,7 @@ services:
     depends_on:
       api:
         condition: service_healthy
+    restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "wget -q --spider http://127.0.0.1:7002/ || exit 1"]
       interval: 10s

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "pnpm": {
     "overrides": {
       "workbox-build": "^7.4.1",
-      "workbox-window": "^7.4.1"
+      "workbox-window": "^7.4.1",
+      "serialize-javascript": "^7.0.3"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   workbox-build: ^7.4.1
   workbox-window: ^7.4.1
+  serialize-javascript: ^7.0.3
 
 importers:
 
@@ -2933,9 +2934,6 @@ packages:
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
 
-  randombytes@2.1.0:
-    resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
-
   rc9@3.0.1:
     resolution: {integrity: sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==}
 
@@ -3090,8 +3088,9 @@ packages:
   seq-queue@0.0.5:
     resolution: {integrity: sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q==}
 
-  serialize-javascript@6.0.2:
-    resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
+  serialize-javascript@7.0.7:
+    resolution: {integrity: sha512-YAy8Od6KV+uuwUuU50np8fGB/Aues6Y0nAhA9y/hId74PlKUcme4pXcBD46NWKr1Q4osN/iseZ17YqO1XfmI8g==}
+    engines: {node: '>=20.0.0'}
 
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
@@ -4797,7 +4796,7 @@ snapshots:
 
   '@rollup/plugin-terser@0.4.4(rollup@2.80.0)':
     dependencies:
-      serialize-javascript: 6.0.2
+      serialize-javascript: 7.0.7
       smob: 1.6.2
       terser: 5.49.0
     optionalDependencies:
@@ -6479,10 +6478,6 @@ snapshots:
 
   quick-format-unescaped@4.0.4: {}
 
-  randombytes@2.1.0:
-    dependencies:
-      safe-buffer: 5.2.1
-
   rc9@3.0.1:
     dependencies:
       defu: 6.1.7
@@ -6648,9 +6643,7 @@ snapshots:
 
   seq-queue@0.0.5: {}
 
-  serialize-javascript@6.0.2:
-    dependencies:
-      randombytes: 2.1.0
+  serialize-javascript@7.0.7: {}
 
   set-cookie-parser@2.7.2: {}
 


### PR DESCRIPTION
- docker-compose: restart: unless-stopped on all services so the stack
  recovers after a host reboot or crash instead of staying down.
- dockerpublish.yml: also tag images with sha-<short-sha> and semver on
  tag pushes, so a self-hoster can pin a known-good version and roll
  back instead of only ever having :latest.
- ci.yml: run `prisma migrate deploy` against a real Postgres service so
  a broken migration fails CI instead of crashing the api container on
  a self-hoster's next update.
- api/auth.ts + web api.ts/App.tsx: bearer-auth 401s now carry a
  WWW-Authenticate header, which the web client uses to distinguish an
  invalid/rotated API token from route-level 401s (e.g. wrong PIN) and
  route back to the setup wizard instead of dead-ending on every page.
- addon/index.ts: mark-watched/scrobble mutation endpoints now require
  a token derived from the shared API token instead of relying only on
  a spoofable Origin header check.
- api/tmdb.ts, trakt.ts: add request timeouts matching the existing
  IGDB/Steam client pattern; routes/search.ts now catches TMDB failures
  instead of throwing an uncaught 500 on the highest-traffic route.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Manage profile names and PIN protection directly from Settings.
  - View scheduled-job sync health and recent failures.
  - Receive a prompt when a new app update is available.
  - Added clearer deployment, updating, and contribution guidance.

- **Bug Fixes**
  - Search now reports a clear error when catalog services are unavailable.
  - Improved recovery when multiple requests create the default watchlist simultaneously.

- **Security & Reliability**
  - Strengthened authentication for state-changing actions.
  - Added safer service recovery and request timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->