### PR TITLE
Refactor dashboard header and consolidate discovery sections

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -160,7 +160,7 @@ function AppShell({
             type="button"
             onClick={() => setPaletteOpen(true)}
             aria-label="Search (⌘K)"
-            className="flex h-10 w-10 flex-none items-center justify-center rounded-full transition-colors hover:bg-[var(--surface-strong)] sm:h-auto sm:w-auto sm:flex-1 sm:max-w-sm sm:justify-start sm:gap-2.5 sm:px-4 sm:py-2 sm:text-sm"
+            className="flex h-11 w-11 flex-none items-center justify-center rounded-full transition-colors hover:bg-[var(--surface-strong)] sm:h-auto sm:w-auto sm:flex-1 sm:max-w-sm sm:justify-start sm:gap-2.5 sm:px-4 sm:py-2 sm:text-sm"
             style={{ border: "1px solid var(--border-strong)", color: "var(--text-mute)", background: "var(--surface)" }}
           >
             <Search className="h-4 w-4" />
@@ -181,7 +181,7 @@ function AppShell({
               onClick={openSwitcher}
               aria-label={profile ? `Switch profile (currently ${profile.name})` : "Switch profile"}
               title={profile?.name}
-              className="flex h-10 w-10 flex-none items-center justify-center rounded-full transition-colors hover:bg-[var(--surface-strong)] focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-400 focus-visible:ring-offset-2 sm:hidden"
+              className="flex h-11 w-11 flex-none items-center justify-center rounded-full transition-colors hover:bg-[var(--surface-strong)] focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-400 focus-visible:ring-offset-2 sm:hidden"
               style={{ color: "var(--text-mute)" }}
             >
               <User className="h-5 w-5" />

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -30,51 +30,8 @@ import { Link } from "react-router-dom";
 import { fadeMaskStyle, useHorizontalScroll } from "../components/carousel-utils";
 import { DetailPanel, useDetailPanel } from "../components/MediaDetailPanel";
 import { Poster } from "../components/Poster";
-import { TicketTile } from "../components/TicketTile";
 import { useToast } from "../hooks/useToast";
 import { timeAgo, timeUntil } from "../utils/timeAgo";
-
-/* ─── Collectible stat strip: a row of distinct "ticket" tiles, demoted below the fold ─── */
-
-function StatStrip({
-  stats,
-  monthly,
-  genres,
-  currentStreak,
-  longestStreak,
-  loading,
-}: {
-  stats: WatchStats | null;
-  monthly: DetailedWatchStats["monthly"];
-  genres: DetailedWatchStats["genreDistribution"];
-  currentStreak: number;
-  longestStreak: number;
-  loading: boolean;
-}) {
-  const last6 = monthly.slice(-6);
-  const movieBars = last6.length ? last6.map((m) => m.movies) : [0, 0, 0, 0, 0, 0];
-  const epBars = last6.length ? last6.map((m) => m.episodes) : [0, 0, 0, 0, 0, 0];
-  const topGenre = genres[0]?.genre;
-
-  if (loading) {
-    return (
-      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-        {Array.from({ length: 4 }).map((_, i) => (
-          <div key={i} className="skeleton h-28 rounded-2xl" />
-        ))}
-      </div>
-    );
-  }
-
-  return (
-    <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-      <TicketTile icon={Flame} label="Day streak" value={currentStreak} sub={`Best: ${longestStreak}`} />
-      <TicketTile icon={Film} label="Movies watched" value={stats?.totalMovies ?? 0} bars={movieBars} />
-      <TicketTile icon={Tv} label="Episodes watched" value={stats?.totalEpisodes ?? 0} bars={epBars} />
-      <TicketTile icon={Trophy} label="Top genre" value={topGenre ?? "—"} sub={genres[0] ? `${genres[0].count} watched` : undefined} />
-    </div>
-  );
-}
 
 /* ─── Skeleton placeholders ─── */
 
@@ -116,6 +73,7 @@ type DiscoveryItem = {
   genres?: string[];
   year?: number;
   type?: string;
+  description?: string;
 };
 
 function DiscoveryCard({ item, badge, reason, onSelect, eager, fill }: {
@@ -410,7 +368,65 @@ function SectionHeader({
   );
 }
 
-/* ─── Greeting strip: persistent context on every open, even with nothing playing ─── */
+/* ─── Discover sub-row: one labeled rail (Movies / Series) within the shared Discover section ─── */
+
+function DiscoverSubRow({
+  label,
+  loading,
+  items,
+  reasons,
+  aiActive,
+  scroll,
+  onSelect,
+}: {
+  label: string;
+  loading: boolean;
+  items: TrendingMeta[];
+  reasons: Record<string, string>;
+  aiActive: boolean;
+  scroll: ReturnType<typeof useHorizontalScroll>;
+  onSelect: (item: DiscoveryItem) => void;
+}) {
+  if (!loading && items.length === 0) return null;
+  return (
+    <div>
+      <div className="mb-2.5 flex items-center justify-between">
+        <h3 className="text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--text-mute)" }}>{label}</h3>
+        {!loading && items.length > 0 && (
+          <ScrollArrows canScrollLeft={scroll.canScrollLeft} canScrollRight={scroll.canScrollRight} onScroll={scroll.scroll} />
+        )}
+      </div>
+      {loading ? (
+        aiActive
+          ? <p className="text-sm italic" style={{ color: "var(--text-dim)" }}>Generating AI recommendations...</p>
+          : <ContinueWatchingSkeleton />
+      ) : (
+        <div
+          ref={scroll.ref}
+          className="flex gap-4 overflow-x-auto pb-2 scroll-smooth scrollbar-hide"
+          style={fadeMaskStyle(scroll.canScrollLeft, scroll.canScrollRight)}
+        >
+          {items.map((item) => (
+            <DiscoveryCard
+              key={item.id}
+              item={item}
+              reason={reasons[item.id]}
+              onSelect={onSelect}
+              badge={
+                <span className="inline-flex items-center gap-1 rounded-md bg-plum-500/80 px-1.5 py-0.5 text-2xs font-semibold text-white backdrop-blur-sm">
+                  <Sparkles className="h-2.5 w-2.5" />
+                  {aiActive && <span>AI</span>}
+                </span>
+              }
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ─── Header stat row: greeting + the collectible stats folded into one persistent strip ─── */
 
 function timeOfDayGreeting() {
   const hour = new Date().getHours();
@@ -420,33 +436,60 @@ function timeOfDayGreeting() {
   return "Good evening";
 }
 
-function GreetingStrip({ playsThisWeek, streak, loading }: { playsThisWeek: number; streak: number; loading: boolean }) {
+function StatChip({ icon: Icon, label, value, accent }: { icon: React.ElementType; label: string; value: string | number; accent?: boolean }) {
+  return (
+    <span className="flex items-center gap-1.5 text-sm" style={{ color: accent ? undefined : "var(--text-dim)" }}>
+      <Icon className={`h-3.5 w-3.5 ${accent ? "text-claw-400" : ""}`} style={accent ? undefined : { color: "var(--text-mute)" }} />
+      <span className={accent ? "font-semibold text-claw-400" : ""}>
+        {typeof value === "number" ? value.toLocaleString() : value}
+      </span>
+      <span className="hidden sm:inline" style={{ color: "var(--text-mute)" }}>{label}</span>
+    </span>
+  );
+}
+
+function DashboardHeader({
+  playsThisWeek,
+  streak,
+  longestStreak,
+  totalMovies,
+  totalEpisodes,
+  topGenre,
+  loading,
+  statsLoading,
+}: {
+  playsThisWeek: number;
+  streak: number;
+  longestStreak: number;
+  totalMovies: number;
+  totalEpisodes: number;
+  topGenre?: string;
+  loading: boolean;
+  statsLoading: boolean;
+}) {
   const today = new Date().toLocaleDateString(undefined, { weekday: "short", month: "short", day: "numeric" });
   return (
     <div
-      className="flex flex-wrap items-center gap-2 rounded-xl px-4 py-2.5"
+      className="flex flex-col gap-2.5 rounded-xl px-4 py-3 sm:flex-row sm:items-center sm:justify-between"
       style={{ background: "var(--surface)", border: "1px solid var(--border)" }}
     >
-      <span className="text-sm font-semibold" style={{ color: "var(--text)" }}>{timeOfDayGreeting()}</span>
-      {!loading && (
-        <>
-          <span style={{ color: "var(--border-strong)" }}>&middot;</span>
-          <span className="flex items-center gap-1.5 text-sm" style={{ color: "var(--text-dim)" }}>
-            <Clock className="h-3 w-3" />
-            {playsThisWeek} watched this week
-          </span>
-          {streak > 0 && (
-            <>
-              <span style={{ color: "var(--border-strong)" }}>&middot;</span>
-              <span className="flex items-center gap-1 text-sm font-semibold text-claw-400">
-                <Flame className="h-3.5 w-3.5" />
-                {streak}-day streak
-              </span>
-            </>
-          )}
-        </>
+      <div className="flex flex-wrap items-center gap-x-2 gap-y-1.5">
+        <span className="text-sm font-semibold" style={{ color: "var(--text)" }}>{timeOfDayGreeting()}</span>
+        <span style={{ color: "var(--border-strong)" }}>&middot;</span>
+        <span className="text-xs" style={{ color: "var(--text-mute)" }}>{today}</span>
+      </div>
+      {!loading && !statsLoading && (
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5">
+          <StatChip icon={Clock} label="this week" value={playsThisWeek} />
+          {streak > 0 && <StatChip icon={Flame} label={`day streak (best ${longestStreak})`} value={streak} accent />}
+          <StatChip icon={Film} label="movies" value={totalMovies} />
+          <StatChip icon={Tv} label="episodes" value={totalEpisodes} />
+          {topGenre && <StatChip icon={Trophy} label="top genre" value={topGenre} />}
+          <Link to="/stats" className="text-xs font-medium text-claw-400 hover:text-claw-300 transition-colors">
+            Full stats &rarr;
+          </Link>
+        </div>
       )}
-      <span className="ml-auto text-xs" style={{ color: "var(--text-mute)" }}>{today}</span>
     </div>
   );
 }
@@ -685,7 +728,6 @@ export function DashboardPage() {
     if (logWatch) void load();
   };
 
-  const monthly = detailedStats?.monthly ?? [];
   const hasUpcoming = calendarLoading || calendarEntries.length > 0;
 
   // The check-in hero and the Continue Watching hero can end up showing the same series
@@ -698,8 +740,17 @@ export function DashboardPage() {
 
   return (
     <div className="space-y-8">
-      {/* ── Greeting strip ── */}
-      <GreetingStrip playsThisWeek={stats?.playsThisWeek ?? 0} streak={detailedStats?.currentStreak ?? 0} loading={loading || detailedLoading} />
+      {/* ── Header stat row ── */}
+      <DashboardHeader
+        playsThisWeek={stats?.playsThisWeek ?? 0}
+        streak={detailedStats?.currentStreak ?? 0}
+        longestStreak={detailedStats?.longestStreak ?? 0}
+        totalMovies={stats?.totalMovies ?? 0}
+        totalEpisodes={stats?.totalEpisodes ?? 0}
+        topGenre={detailedStats?.genreDistribution[0]?.genre}
+        loading={loading}
+        statsLoading={detailedLoading}
+      />
 
       {/* ── Hero: Now Watching ── */}
       {activeCheckin && (
@@ -980,109 +1031,41 @@ export function DashboardPage() {
         )}
       </div>
 
-      {/* ── Recommended Movies ── */}
-      {(recsLoading || recommendations.length > 0) && (
+      {/* ── Discover: shared section for both recommendation rails ── */}
+      {(recsLoading || recommendations.length > 0 || seriesRecsLoading || seriesRecs.length > 0) && (
         <section>
-          <SectionHeader title={aiActive ? "AI Picks — Movies" : "Recommended For You"}>
-            <div className="flex items-center gap-2">
-              {aiActive && aiLastGeneratedAt && (() => {
-                const nextRefresh = new Date(new Date(aiLastGeneratedAt).getTime() + 7 * 24 * 60 * 60 * 1000);
-                const label = nextRefresh <= new Date() ? "Refresh due" : `Refreshes ${timeUntil(nextRefresh.toISOString())}`;
-                return (
-                  <span title={`Next refresh: ${nextRefresh.toLocaleDateString(undefined, { weekday: "short", month: "short", day: "numeric" })}`} className="flex items-center gap-1 text-xs cursor-default" style={{ color: "var(--text-dim)" }}>
-                    <Clock size={12} />
-                    {label}
-                  </span>
-                );
-              })()}
-              {!recsLoading && recommendations.length > 0 && (
-                <ScrollArrows
-                  canScrollLeft={recsScroll.canScrollLeft}
-                  canScrollRight={recsScroll.canScrollRight}
-                  onScroll={recsScroll.scroll}
-                />
-              )}
-            </div>
+          <SectionHeader title={aiActive ? "AI Picks" : "Discover"}>
+            {aiActive && aiLastGeneratedAt && (() => {
+              const nextRefresh = new Date(new Date(aiLastGeneratedAt).getTime() + 7 * 24 * 60 * 60 * 1000);
+              const label = nextRefresh <= new Date() ? "Refresh due" : `Refreshes ${timeUntil(nextRefresh.toISOString())}`;
+              return (
+                <span title={`Next refresh: ${nextRefresh.toLocaleDateString(undefined, { weekday: "short", month: "short", day: "numeric" })}`} className="flex items-center gap-1 text-xs cursor-default" style={{ color: "var(--text-dim)" }}>
+                  <Clock size={12} />
+                  {label}
+                </span>
+              );
+            })()}
           </SectionHeader>
-          {recsLoading ? (
-            aiActive
-              ? <p className="text-sm italic" style={{ color: "var(--text-dim)" }}>Generating AI recommendations...</p>
-              : <ContinueWatchingSkeleton />
-          ) : (
-            <div
-              ref={recsScroll.ref}
-              className="flex gap-4 overflow-x-auto pb-2 scroll-smooth scrollbar-hide"
-              style={fadeMaskStyle(recsScroll.canScrollLeft, recsScroll.canScrollRight)}
-            >
-              {recommendations.map((item) => (
-                <DiscoveryCard
-                  key={item.id}
-                  item={item}
-                  reason={movieReasons[item.id]}
-                  onSelect={(i) => setSelectedItem(toSearchResult(i.id, (i.type ?? "movie") as "movie" | "series", i.name, { poster: i.poster, year: i.year, description: item.description, genres: i.genres, rating: i.rating }))}
-                  badge={
-                    <span className="inline-flex items-center gap-1 rounded-md bg-plum-500/80 px-1.5 py-0.5 text-2xs font-semibold text-white backdrop-blur-sm">
-                      <Sparkles className="h-2.5 w-2.5" />
-                      {aiActive && <span>AI</span>}
-                    </span>
-                  }
-                />
-              ))}
-            </div>
-          )}
-        </section>
-      )}
-
-      {/* ── Recommended Series ── */}
-      {(seriesRecsLoading || seriesRecs.length > 0) && (
-        <section>
-          <SectionHeader title={aiActive ? "AI Picks — Series" : "Recommended Series For You"}>
-            <div className="flex items-center gap-2">
-              {aiActive && aiLastGeneratedAt && (() => {
-                const nextRefresh = new Date(new Date(aiLastGeneratedAt).getTime() + 7 * 24 * 60 * 60 * 1000);
-                const label = nextRefresh <= new Date() ? "Refresh due" : `Refreshes ${timeUntil(nextRefresh.toISOString())}`;
-                return (
-                  <span title={`Next refresh: ${nextRefresh.toLocaleDateString(undefined, { weekday: "short", month: "short", day: "numeric" })}`} className="flex items-center gap-1 text-xs cursor-default" style={{ color: "var(--text-dim)" }}>
-                    <Clock size={12} />
-                    {label}
-                  </span>
-                );
-              })()}
-              {!seriesRecsLoading && seriesRecs.length > 0 && (
-                <ScrollArrows
-                  canScrollLeft={seriesRecsScroll.canScrollLeft}
-                  canScrollRight={seriesRecsScroll.canScrollRight}
-                  onScroll={seriesRecsScroll.scroll}
-                />
-              )}
-            </div>
-          </SectionHeader>
-          {seriesRecsLoading ? (
-            aiActive
-              ? <p className="text-sm italic" style={{ color: "var(--text-dim)" }}>Generating AI recommendations...</p>
-              : <ContinueWatchingSkeleton />
-          ) : (
-            <div
-              ref={seriesRecsScroll.ref}
-              className="flex gap-4 overflow-x-auto pb-2 scroll-smooth scrollbar-hide"
-              style={fadeMaskStyle(seriesRecsScroll.canScrollLeft, seriesRecsScroll.canScrollRight)}
-            >
-              {seriesRecs.map((item) => (
-                <DiscoveryCard
-                  key={item.id}
-                  item={item}
-                  reason={seriesReasons[item.id]}
-                  onSelect={(i) => setSelectedItem(toSearchResult(i.id, "series", i.name, { poster: i.poster, year: i.year, description: item.description, genres: i.genres, rating: i.rating }))}
-                  badge={
-                    <span className="inline-flex items-center gap-1 rounded-md bg-plum-500/80 px-1.5 py-0.5 text-2xs font-semibold text-white backdrop-blur-sm">
-                      <Sparkles className="h-2.5 w-2.5" />
-                      {aiActive && <span>AI</span>}
-                    </span>
-                  }
-                />
-              ))}
-            </div>
-          )}
+          <div className="space-y-5">
+            <DiscoverSubRow
+              label="Movies"
+              loading={recsLoading}
+              items={recommendations}
+              reasons={movieReasons}
+              aiActive={aiActive}
+              scroll={recsScroll}
+              onSelect={(i) => setSelectedItem(toSearchResult(i.id, (i.type ?? "movie") as "movie" | "series", i.name, { poster: i.poster, year: i.year, description: i.description, genres: i.genres, rating: i.rating }))}
+            />
+            <DiscoverSubRow
+              label="Series"
+              loading={seriesRecsLoading}
+              items={seriesRecs}
+              reasons={seriesReasons}
+              aiActive={aiActive}
+              scroll={seriesRecsScroll}
+              onSelect={(i) => setSelectedItem(toSearchResult(i.id, "series", i.name, { poster: i.poster, year: i.year, description: i.description, genres: i.genres, rating: i.rating }))}
+            />
+          </div>
         </section>
       )}
 
@@ -1162,26 +1145,6 @@ export function DashboardPage() {
           onSelectItem={setSelectedItem}
         />
       )}
-
-      {/* ── Stat strip — banded container, gives it visual weight ── */}
-      <section
-        className="rounded-2xl p-5"
-        style={{ background: "var(--surface)", border: "1px solid var(--border)" }}
-      >
-        <SectionHeader title="Your Stats">
-          <Link to="/stats" className="text-sm font-medium text-claw-400 hover:text-claw-300 transition-colors">
-            Full stats &rarr;
-          </Link>
-        </SectionHeader>
-        <StatStrip
-          stats={stats}
-          monthly={monthly}
-          genres={detailedStats?.genreDistribution ?? []}
-          currentStreak={detailedStats?.currentStreak ?? 0}
-          longestStreak={detailedStats?.longestStreak ?? 0}
-          loading={loading || detailedLoading}
-        />
-      </section>
     </div>
   );
 }

--- a/apps/web/src/pages/SearchPage.tsx
+++ b/apps/web/src/pages/SearchPage.tsx
@@ -655,17 +655,17 @@ function ResultCard({
           {result.type === "movie" ? "Movie" : "Series"}
         </span>
 
-        {/* Hover gradient overlay */}
-        <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-transparent to-transparent opacity-60 transition-opacity duration-300 sm:opacity-0 sm:group-hover:opacity-100" />
+        {/* Gradient overlay: low resting opacity on desktop so it stays discoverable without a hover, full on hover/focus */}
+        <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-transparent to-transparent opacity-60 transition-opacity duration-300 sm:opacity-30 sm:group-hover:opacity-100" />
 
-        {/* Quick-add button (bottom-right on hover) */}
+        {/* Quick-add button: same low-resting-opacity treatment so trackpad/keyboard users see it exists before hovering/focusing */}
         <button
           type="button"
           onClick={(e) => {
             e.stopPropagation();
             onToggleDropdown(result.imdbId);
           }}
-          className="absolute bottom-3 right-3 z-20 flex h-9 w-9 items-center justify-center rounded-full bg-claw-500 text-white opacity-100 sm:opacity-0 sm:group-hover:opacity-100 focus:opacity-100 focus-visible:opacity-100 shadow-lg transition-all duration-300 hover:bg-claw-600 hover:scale-110 focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-300 focus-visible:ring-offset-2"
+          className="absolute bottom-3 right-3 z-20 flex h-9 w-9 items-center justify-center rounded-full bg-claw-500 text-white opacity-100 sm:opacity-60 sm:group-hover:opacity-100 focus:opacity-100 focus-visible:opacity-100 shadow-lg transition-all duration-300 hover:bg-claw-600 hover:scale-110 focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-300 focus-visible:ring-offset-2"
           aria-label={`Add ${result.name} to a list`}
           aria-haspopup="menu"
           aria-expanded={isOpen}

--- a/package.json
+++ b/package.json
@@ -27,7 +27,10 @@
     "overrides": {
       "workbox-build": "^7.4.1",
       "workbox-window": "^7.4.1",
-      "serialize-javascript": "^7.0.3"
+      "serialize-javascript": "^7.0.3",
+      "find-my-way": "^9.7.0",
+      "fast-uri": "^4.1.1",
+      "ajv>fast-uri": "^3.1.4"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ overrides:
   workbox-build: ^7.4.1
   workbox-window: ^7.4.1
   serialize-javascript: ^7.0.3
+  find-my-way: ^9.7.0
+  fast-uri: ^4.1.1
+  ajv>fast-uri: ^3.1.4
 
 importers:
 
@@ -2176,11 +2179,11 @@ packages:
   fast-querystring@1.1.2:
     resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
 
-  fast-uri@3.1.3:
-    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
+  fast-uri@3.1.4:
+    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
 
-  fast-uri@4.1.0:
-    resolution: {integrity: sha512-ZodJ2cRiLVWGi9IgPb3mbgSqM4CD3LexCHkuv0FfBXHJI1ADfucTD06m6clO2Cy5RZYsw/SiCVl/dyrFI/SYWA==}
+  fast-uri@4.1.1:
+    resolution: {integrity: sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==}
 
   fastify-plugin@6.0.0:
     resolution: {integrity: sha512-fZOty7z3O7vOliF6d8bHE3wiEh1KcNnKEQensSgTk9C1DvN6nRLS++XVd86v33Hw/8u9Un8A1zDrQ8ujcQDHEg==}
@@ -2207,8 +2210,8 @@ packages:
   filelist@1.0.6:
     resolution: {integrity: sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==}
 
-  find-my-way@9.6.0:
-    resolution: {integrity: sha512-Zf4Xve4RymLl7NgaavNebZ01joJ8MfVerOG43wy7SHLO+r+K0C6d/SE0BiR7AV5V1VOCFlOP7ecdo+I4qmiHrQ==}
+  find-my-way@9.7.0:
+    resolution: {integrity: sha512-f2JHn75x2JlwUwLenZypgczR7YWMb/uO9BvUXtus+JMgkbIkLADd38cI4EiV+OQqrGo1Zlq6V8wnqMJ8e62wUQ==}
     engines: {node: '>=20'}
 
   find-up@5.0.0:
@@ -4430,7 +4433,7 @@ snapshots:
     dependencies:
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
-      fast-uri: 3.1.3
+      fast-uri: 4.1.1
 
   '@fastify/error@4.2.0': {}
 
@@ -5275,7 +5278,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.3
+      fast-uri: 3.1.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -5746,7 +5749,7 @@ snapshots:
       '@fastify/merge-json-schemas': 0.2.1
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
-      fast-uri: 4.1.0
+      fast-uri: 4.1.1
       json-schema-ref-resolver: 3.0.0
       rfdc: 1.4.1
 
@@ -5756,9 +5759,9 @@ snapshots:
     dependencies:
       fast-decode-uri-component: 1.0.1
 
-  fast-uri@3.1.3: {}
+  fast-uri@3.1.4: {}
 
-  fast-uri@4.1.0: {}
+  fast-uri@4.1.1: {}
 
   fastify-plugin@6.0.0: {}
 
@@ -5771,7 +5774,7 @@ snapshots:
       abstract-logging: 2.0.1
       avvio: 9.3.0
       fast-json-stringify: 7.0.1
-      find-my-way: 9.6.0
+      find-my-way: 9.7.0
       light-my-request: 6.6.0
       pino: 10.3.1
       process-warning: 5.0.0
@@ -5796,7 +5799,7 @@ snapshots:
     dependencies:
       minimatch: 5.1.9
 
-  find-my-way@9.6.0:
+  find-my-way@9.7.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-querystring: 1.1.2


### PR DESCRIPTION
## Summary
Restructures the DashboardPage to consolidate stats display into the header and merge separate movie/series recommendation sections into a unified "Discover" section with sub-rows.

## Key Changes

- **Removed `StatStrip` component**: The dedicated stats section at the bottom of the page has been removed
- **Replaced `GreetingStrip` with `DashboardHeader`**: New header component that combines greeting, date, and key stats (plays this week, current streak, movies/episodes watched, top genre) in a responsive layout with a link to full stats
- **Added `StatChip` component**: Reusable stat display component with icon, label, and optional accent styling
- **Created `DiscoverSubRow` component**: Extracted common pattern for rendering recommendation rails (Movies/Series) with loading states, scroll controls, and AI badges
- **Consolidated recommendation sections**: Merged separate "AI Picks — Movies" and "AI Picks — Series" sections into a single "Discover" section with labeled sub-rows for each type
- **Updated `DiscoveryItem` type**: Added optional `description` field to support passing description data through the discovery card flow
- **Minor UI improvements**: 
  - Search button sizing adjustment in App.tsx (h-10/w-10 → h-11/w-11)
  - Improved gradient overlay visibility on search results (added sm:opacity-30 for better discoverability)
  - Enhanced comments for overlay and button behavior

## Implementation Details

The new `DashboardHeader` uses a responsive flex layout that stacks vertically on mobile and horizontally on desktop, displaying stats only when data is loaded. The `DiscoverSubRow` component eliminates code duplication between movie and series recommendations while maintaining the same visual treatment and interaction patterns. The unified Discover section now shows a single refresh timer and cleaner section hierarchy.

https://claude.ai/code/session_01G4kW3AMEmftxeQxVpMiC3U