### PR TITLE
Fix three security findings: profile PIN bypass, AI SSRF, exposed Postgres port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,12 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - The Stremio addon's mark-watched/scrobble endpoints now require a token derived from the shared API token, instead of relying solely on a spoofable `Origin` header check.
 - TMDB and Trakt API calls now time out after 10s, matching the existing IGDB/Steam client behavior, instead of hanging indefinitely on a slow/unresponsive upstream.
 
+### Security
+
+- Profile PINs are now enforced server-side. Successful PIN verification (`POST /profiles/:id/verify`) issues a short-lived, HMAC-signed profile-access token that `resolveProfile` requires (via the `x-profile-token` header) for any PIN-protected profile. Previously the PIN was only a client-side prompt: anyone holding the shared `API_TOKEN` could read or mutate a "locked" profile's data — including a full `/export` — just by setting the `x-profile-id` header to that profile's UUID. The web app stores and sends the token automatically and re-prompts for the PIN when it expires.
+- The AI-provider config endpoints (`POST /ai/config`, `POST /ai/test`) and the outbound AI request now reject URLs that target the cloud-metadata/link-local range (`169.254.0.0/16`, IPv6 link-local, `0.0.0.0`) or use a non-HTTP scheme, no longer follow redirects, and no longer reflect the upstream response body back to the caller — closing an SSRF-with-reflection vector reachable by an `API_TOKEN` holder. LAN/localhost LLM endpoints (Ollama, LM Studio, etc.) remain allowed.
+- `docker-compose.yml` now binds the Postgres port to `127.0.0.1` instead of `0.0.0.0`, so the database (which stores OAuth tokens) is no longer reachable from the LAN — or the internet, if the host is port-forwarded — bypassing `API_TOKEN`. The api/addon services still reach it over the internal Docker network.
+
 ### Fixed
 
 - `/search` no longer throws an uncaught exception (and a bare 500) when the upstream TMDB request fails.

--- a/apps/api/src/lib/ai.ts
+++ b/apps/api/src/lib/ai.ts
@@ -5,6 +5,7 @@ import { trendingCacheGet, trendingCacheSet, trendingCacheDelete, watchedImdbIds
 import { getTmdb } from "./tmdb-client.js";
 import { getRpdbApiKey, withRpdbPoster } from "./rpdb.js";
 import { upsertMetadata } from "./metadata.js";
+import { validateAiProviderUrl } from "./ssrf.js";
 import type { AiProviderConfig, StremioMetaPreview } from "./types.js";
 
 export const AI_CONFIG_KEY = "ai:config";
@@ -171,6 +172,13 @@ const callAiProvider = async (
   prompt: string,
   minTokens = 0
 ): Promise<string> => {
+  // Defense-in-depth: a config persisted before this validation existed (or by
+  // a future code path that skips the route check) must still not be able to
+  // drive an outbound request at a blocked SSRF target.
+  if (!validateAiProviderUrl(config.url)) {
+    throw new Error("AI provider URL is not an allowed outbound target");
+  }
+
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), 60_000);
 
@@ -195,14 +203,19 @@ const callAiProvider = async (
       headers: { "Content-Type": "application/json", ...config.headers },
       body: JSON.stringify(payload),
       signal: controller.signal,
+      // Do not follow redirects: an allowed host must not be able to bounce the
+      // request (carrying any configured Authorization header) to an internal
+      // address the SSRF validator would otherwise reject.
+      redirect: "error",
     });
   } finally {
     clearTimeout(timeoutId);
   }
 
   if (!response.ok) {
-    const body = await response.text().catch(() => "");
-    throw new Error(`AI provider error (${response.status}): ${body.slice(0, 200)}`);
+    // Deliberately do not echo the upstream response body: reflecting it would
+    // turn this into an SSRF probe that leaks internal responses to the caller.
+    throw new Error(`AI provider error (${response.status})`);
   }
 
   const data = await response.json() as { choices?: Array<{ message?: { content?: string } }> };

--- a/apps/api/src/lib/cors.ts
+++ b/apps/api/src/lib/cors.ts
@@ -8,7 +8,7 @@ const CATALOGGY_ALLOWED_ORIGINS = (process.env.CATALOGGY_ALLOWED_ORIGINS ?? "")
 export const ALLOWED_ORIGINS = IS_DEVELOPMENT ? ["*"] : Array.from(new Set(CATALOGGY_ALLOWED_ORIGINS));
 
 const CORS_METHODS = "GET,POST,DELETE,PATCH,OPTIONS";
-const CORS_HEADERS = "Authorization,Content-Type,X-Profile-Id";
+const CORS_HEADERS = "Authorization,Content-Type,X-Profile-Id,X-Profile-Token";
 
 export const isAllowedOrigin = (origin: string | undefined): boolean => {
   if (IS_DEVELOPMENT) return true;

--- a/apps/api/src/lib/profile-token.test.ts
+++ b/apps/api/src/lib/profile-token.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mintProfileToken, verifyProfileToken } from "./profile-token.js";
+
+const PROFILE_A = "11111111-1111-4111-8111-111111111111";
+const PROFILE_B = "22222222-2222-4222-8222-222222222222";
+
+describe("profile-token", () => {
+  beforeEach(() => {
+    process.env.API_TOKEN = "test-signing-secret";
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("verifies a freshly minted token for the same profile", () => {
+    const token = mintProfileToken(PROFILE_A);
+    expect(verifyProfileToken(token, PROFILE_A)).toBe(true);
+  });
+
+  it("rejects a token minted for a different profile", () => {
+    const token = mintProfileToken(PROFILE_A);
+    expect(verifyProfileToken(token, PROFILE_B)).toBe(false);
+  });
+
+  it("rejects a missing or malformed token", () => {
+    expect(verifyProfileToken(undefined, PROFILE_A)).toBe(false);
+    expect(verifyProfileToken("", PROFILE_A)).toBe(false);
+    expect(verifyProfileToken("garbage", PROFILE_A)).toBe(false);
+    expect(verifyProfileToken("v1.notanumber.sig", PROFILE_A)).toBe(false);
+  });
+
+  it("rejects a tampered signature", () => {
+    const token = mintProfileToken(PROFILE_A);
+    const tampered = `${token.slice(0, -1)}${token.slice(-1) === "a" ? "b" : "a"}`;
+    expect(verifyProfileToken(tampered, PROFILE_A)).toBe(false);
+  });
+
+  it("rejects an expired token", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    const token = mintProfileToken(PROFILE_A);
+    // Advance beyond the 12h TTL.
+    vi.setSystemTime(new Date("2026-01-01T13:00:00Z"));
+    expect(verifyProfileToken(token, PROFILE_A)).toBe(false);
+  });
+
+  it("rejects a token signed under a different API_TOKEN (rotation invalidates)", () => {
+    const token = mintProfileToken(PROFILE_A);
+    process.env.API_TOKEN = "rotated-secret";
+    expect(verifyProfileToken(token, PROFILE_A)).toBe(false);
+  });
+});

--- a/apps/api/src/lib/profile-token.ts
+++ b/apps/api/src/lib/profile-token.ts
@@ -1,0 +1,46 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+// A profile-access token is a stateless, signed capability proving the holder
+// passed PIN verification for a specific profile. `resolveProfile` requires a
+// valid one for any PIN-protected profile, so holding the shared API_TOKEN
+// alone is no longer enough to read or mutate a locked profile's data by simply
+// setting the `x-profile-id` header.
+//
+// The signing key is derived from API_TOKEN, which is always present in a
+// running deployment (the production startup guard refuses to boot without it).
+// Rotating API_TOKEN therefore invalidates every outstanding profile token —
+// the desired behavior: a credential change forces re-verification.
+
+const PROFILE_TOKEN_TTL_MS = 12 * 60 * 60 * 1000; // 12 hours
+const TOKEN_VERSION = "v1";
+
+const signingKey = () => process.env.API_TOKEN ?? "";
+
+const sign = (profileId: string, expiresAt: number): string =>
+  createHmac("sha256", signingKey()).update(`${TOKEN_VERSION}:${profileId}:${expiresAt}`).digest("base64url");
+
+export const mintProfileToken = (profileId: string): string => {
+  const expiresAt = Date.now() + PROFILE_TOKEN_TTL_MS;
+  return `${TOKEN_VERSION}.${expiresAt}.${sign(profileId, expiresAt)}`;
+};
+
+export const verifyProfileToken = (token: string | undefined, profileId: string): boolean => {
+  if (!token) return false;
+
+  const parts = token.split(".");
+  if (parts.length !== 3) return false;
+  const [version, expiresRaw, providedSig] = parts;
+  if (version !== TOKEN_VERSION) return false;
+
+  const expiresAt = Number(expiresRaw);
+  if (!Number.isFinite(expiresAt) || expiresAt <= Date.now()) return false;
+
+  // Recompute the signature over the caller-supplied profileId, so a token
+  // minted for profile A can never authorize profile B.
+  const expectedSig = sign(profileId, expiresAt);
+  const providedBuf = Buffer.from(providedSig);
+  const expectedBuf = Buffer.from(expectedSig);
+  // Length pre-check: timingSafeEqual throws on unequal-length buffers.
+  if (providedBuf.length !== expectedBuf.length) return false;
+  return timingSafeEqual(providedBuf, expectedBuf);
+};

--- a/apps/api/src/lib/profile.ts
+++ b/apps/api/src/lib/profile.ts
@@ -1,5 +1,6 @@
 import type { FastifyReply, FastifyRequest } from "fastify";
 import { prisma } from "./prisma.js";
+import { verifyProfileToken } from "./profile-token.js";
 import { UUID_V4_PATTERN } from "./types.js";
 
 declare module "fastify" {
@@ -9,6 +10,7 @@ declare module "fastify" {
 }
 
 const PROFILE_HEADER = "x-profile-id";
+const PROFILE_TOKEN_HEADER = "x-profile-token";
 
 /**
  * Resolves the active profile for a request from the `x-profile-id` header.
@@ -30,6 +32,21 @@ export const getDefaultProfileId = async (): Promise<string> => {
   return created.id;
 };
 
+// A PIN-protected profile requires a valid, unexpired profile-access token
+// (minted by POST /profiles/:id/verify on correct PIN). This is what makes the
+// PIN a real server-side boundary rather than a client-side prompt: a token
+// holder can't reach a locked profile's data just by naming its UUID.
+const hasValidProfileToken = (request: FastifyRequest, profileId: string): boolean => {
+  const headerValue = request.headers[PROFILE_TOKEN_HEADER];
+  const token = Array.isArray(headerValue) ? headerValue[0] : headerValue;
+  return verifyProfileToken(token, profileId);
+};
+
+const PROFILE_LOCKED_RESPONSE = {
+  error: "Profile PIN verification required",
+  code: "profile_verification_required",
+} as const;
+
 export const resolveProfile = async (request: FastifyRequest, reply: FastifyReply) => {
   const headerValue = request.headers[PROFILE_HEADER];
   const rawProfileId = Array.isArray(headerValue) ? headerValue[0] : headerValue;
@@ -42,13 +59,20 @@ export const resolveProfile = async (request: FastifyRequest, reply: FastifyRepl
     if (!profile) {
       return reply.code(404).send({ error: "Profile not found" });
     }
+    if (profile.pinHash && !hasValidProfileToken(request, profile.id)) {
+      return reply.code(401).send(PROFILE_LOCKED_RESPONSE);
+    }
     request.profileId = rawProfileId;
     return;
   }
 
-  const profiles = await prisma.profile.findMany({ select: { id: true }, take: 2 });
+  const profiles = await prisma.profile.findMany({ select: { id: true, pinHash: true }, take: 2 });
   if (profiles.length === 1) {
-    request.profileId = profiles[0].id;
+    const [only] = profiles;
+    if (only.pinHash && !hasValidProfileToken(request, only.id)) {
+      return reply.code(401).send(PROFILE_LOCKED_RESPONSE);
+    }
+    request.profileId = only.id;
     return;
   }
 

--- a/apps/api/src/lib/ssrf.test.ts
+++ b/apps/api/src/lib/ssrf.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { validateAiProviderUrl } from "./ssrf.js";
+
+describe("validateAiProviderUrl", () => {
+  it("allows public and LAN/localhost LLM endpoints", () => {
+    // Local models (Ollama, LM Studio, self-hosted) are legitimate targets.
+    expect(validateAiProviderUrl("https://api.openai.com/v1/chat/completions")).not.toBeNull();
+    expect(validateAiProviderUrl("http://localhost:11434/v1/chat/completions")).not.toBeNull();
+    expect(validateAiProviderUrl("http://192.168.1.50:1234/v1")).not.toBeNull();
+    expect(validateAiProviderUrl("http://127.0.0.1:8080/")).not.toBeNull();
+  });
+
+  it("rejects non-HTTP schemes and unparseable URLs", () => {
+    expect(validateAiProviderUrl("file:///etc/passwd")).toBeNull();
+    expect(validateAiProviderUrl("gopher://x/")).toBeNull();
+    expect(validateAiProviderUrl("not a url")).toBeNull();
+  });
+
+  it("blocks the cloud-metadata / link-local range and unspecified address", () => {
+    expect(validateAiProviderUrl("http://169.254.169.254/latest/meta-data/")).toBeNull();
+    expect(validateAiProviderUrl("http://0.0.0.0/")).toBeNull();
+    expect(validateAiProviderUrl("http://[fe80::1]/")).toBeNull();
+    expect(validateAiProviderUrl("http://[fd00:ec2::254]/")).toBeNull();
+    expect(validateAiProviderUrl("http://[::]/")).toBeNull();
+  });
+
+  it("blocks the metadata address expressed as an IPv4-mapped IPv6 literal", () => {
+    // Node normalizes these to "::ffff:a9fe:a9fe", which must still be blocked.
+    expect(validateAiProviderUrl("http://[::ffff:169.254.169.254]/latest/meta-data/")).toBeNull();
+    expect(validateAiProviderUrl("http://[::ffff:a9fe:a9fe]/")).toBeNull();
+  });
+});

--- a/apps/api/src/lib/ssrf.ts
+++ b/apps/api/src/lib/ssrf.ts
@@ -11,9 +11,22 @@
 // turning the AI feature into a metadata-service / internal-probe proxy while
 // preserving local-model setups.
 
-const isBlockedAiHostname = (hostname: string): boolean => {
-  // URL.hostname keeps IPv6 in bracket-free form already; normalize just in case.
+// Canonicalize an IPv4-mapped IPv6 literal (e.g. "::ffff:a9fe:a9fe", the form
+// Node normalizes "[::ffff:169.254.169.254]" into) to its dotted-quad IPv4
+// address, so the IPv4 blocklist rules below can't be bypassed by expressing a
+// blocked address in IPv6 mapped notation.
+const normalizeHostname = (hostname: string): string => {
   const host = hostname.toLowerCase().replace(/^\[/, "").replace(/\]$/, "");
+  const mapped = host.match(/^::ffff:(?:0:)?([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+  if (!mapped) return host;
+
+  const high = Number.parseInt(mapped[1], 16);
+  const low = Number.parseInt(mapped[2], 16);
+  return [high >> 8, high & 0xff, low >> 8, low & 0xff].join(".");
+};
+
+const isBlockedAiHostname = (hostname: string): boolean => {
+  const host = normalizeHostname(hostname);
   return (
     host === "0.0.0.0" ||
     host === "::" ||

--- a/apps/api/src/lib/ssrf.ts
+++ b/apps/api/src/lib/ssrf.ts
@@ -1,0 +1,40 @@
+// Guards for outbound fetches whose target URL is user-configurable.
+//
+// The AI provider endpoint is deliberately allowed to point at a LAN or
+// localhost LLM server (Ollama, LM Studio, a self-hosted vLLM, etc.), so —
+// unlike the web-push endpoint, which only ever talks to public browser push
+// services and blocks all private ranges — we cannot simply reject private
+// IPs here. Instead we block what is *never* a legitimate LLM host but *is* a
+// classic SSRF target: non-HTTP schemes, the cloud-metadata / link-local
+// range, and the unspecified address. Combined with disabling redirect
+// following at the fetch call sites, this stops a stolen API token from
+// turning the AI feature into a metadata-service / internal-probe proxy while
+// preserving local-model setups.
+
+const isBlockedAiHostname = (hostname: string): boolean => {
+  // URL.hostname keeps IPv6 in bracket-free form already; normalize just in case.
+  const host = hostname.toLowerCase().replace(/^\[/, "").replace(/\]$/, "");
+  return (
+    host === "0.0.0.0" ||
+    host === "::" ||
+    /^169\.254\./.test(host) || // IPv4 link-local, incl. 169.254.169.254 (cloud metadata)
+    /^fe80:/.test(host) || // IPv6 link-local
+    host === "fd00:ec2::254" // AWS IMDS over IPv6
+  );
+};
+
+/**
+ * Validates a user-supplied AI-provider URL. Returns the parsed URL when it is
+ * an acceptable outbound target, or null when it must be rejected.
+ */
+export const validateAiProviderUrl = (raw: string): URL | null => {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+  if (isBlockedAiHostname(url.hostname)) return null;
+  return url;
+};

--- a/apps/api/src/routes/ai.ts
+++ b/apps/api/src/routes/ai.ts
@@ -15,6 +15,7 @@ import {
   getAiRecommendations,
 } from "../lib/ai.js";
 import { resolveProfile } from "../lib/profile.js";
+import { validateAiProviderUrl } from "../lib/ssrf.js";
 import { getMetadataType } from "../lib/types.js";
 import type { StremioMetaPreview, StremioMetaType } from "../lib/types.js";
 
@@ -369,9 +370,10 @@ const aiRoutes: FastifyPluginAsync = async (app) => {
     const body = request.body as { config?: unknown } | null;
     const cfg = body?.config as Record<string, unknown> | undefined;
 
-    if (!cfg || typeof cfg.url !== "string" || !cfg.url.startsWith("http")) {
+    if (!cfg || typeof cfg.url !== "string" || !validateAiProviderUrl(cfg.url)) {
       return reply.code(400).send({
-        error: "config.url must be a non-empty string starting with http",
+        error:
+          "config.url must be an http(s) URL and must not target the cloud-metadata/link-local range",
       });
     }
     if (!cfg.headers || typeof cfg.headers !== "object" || Array.isArray(cfg.headers)) {
@@ -430,7 +432,7 @@ const aiRoutes: FastifyPluginAsync = async (app) => {
     if (
       !cfg ||
       typeof cfg.url !== "string" ||
-      !cfg.url.startsWith("http") ||
+      !validateAiProviderUrl(cfg.url) ||
       !cfg.headers ||
       typeof cfg.headers !== "object" ||
       Array.isArray(cfg.headers) ||
@@ -439,7 +441,11 @@ const aiRoutes: FastifyPluginAsync = async (app) => {
       Array.isArray(cfg.payload) ||
       typeof (cfg.payload as Record<string, unknown>).model !== "string"
     ) {
-      return { success: false, error: "Invalid config: url, headers, and payload.model are required" };
+      return {
+        success: false,
+        error:
+          "Invalid config: url (an http(s) URL not targeting the cloud-metadata/link-local range), headers, and payload.model are required",
+      };
     }
 
     const testConfig = {
@@ -463,14 +469,18 @@ const aiRoutes: FastifyPluginAsync = async (app) => {
           headers: { "Content-Type": "application/json", ...testConfig.headers },
           body: JSON.stringify(testConfig.payload),
           signal: controller.signal,
+          // Don't follow redirects — an allowed host must not be able to bounce
+          // this request to an internal address the validator would reject.
+          redirect: "error",
         });
       } finally {
         clearTimeout(timeoutId);
       }
 
       if (!response.ok) {
-        const errBody = await response.text().catch(() => "");
-        return { success: false, error: `HTTP ${response.status}: ${errBody.slice(0, 200)}` };
+        // Don't echo the upstream body back to the caller: reflecting it would
+        // leak internal responses and turn this into an SSRF probe.
+        return { success: false, error: `HTTP ${response.status}` };
       }
 
       const data = await response.json() as {

--- a/apps/api/src/routes/profiles.ts
+++ b/apps/api/src/routes/profiles.ts
@@ -1,6 +1,7 @@
 import { createHash, timingSafeEqual } from "node:crypto";
 import type { FastifyPluginAsync } from "fastify";
 import { prisma } from "../lib/prisma.js";
+import { mintProfileToken } from "../lib/profile-token.js";
 import { UUID_V4_PATTERN } from "../lib/types.js";
 
 const toSha256Digest = (value: string) => createHash("sha256").update(value).digest();
@@ -129,7 +130,9 @@ const profilesRoutes: FastifyPluginAsync = async (app) => {
       if (!profile) return reply.code(404).send({ error: "Profile not found" });
 
       if (!profile.pinHash) {
-        return reply.code(200).send({ id: profile.id, name: profile.name });
+        return reply
+          .code(200)
+          .send({ id: profile.id, name: profile.name, profileToken: mintProfileToken(profile.id) });
       }
 
       const lockout = await getPinLockout(profile.id);
@@ -147,7 +150,9 @@ const profilesRoutes: FastifyPluginAsync = async (app) => {
       }
 
       await clearPinAttempts(profile.id);
-      return reply.code(200).send({ id: profile.id, name: profile.name });
+      return reply
+        .code(200)
+        .send({ id: profile.id, name: profile.name, profileToken: mintProfileToken(profile.id) });
     },
   );
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -48,6 +48,14 @@ export function App() {
     return () => window.removeEventListener("cataloggy:unauthorized", handleUnauthorized);
   }, []);
 
+  useEffect(() => {
+    // A PIN-protected profile's access token expired or was cleared — send the
+    // user back to the profile picker to re-verify.
+    const handleProfileLocked = () => setNeedsProfile(true);
+    window.addEventListener("cataloggy:profile-locked", handleProfileLocked);
+    return () => window.removeEventListener("cataloggy:profile-locked", handleProfileLocked);
+  }, []);
+
   if (needsSetup) {
     return (
       <SetupWizard

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -26,6 +26,7 @@ const ADDON_BASE_DEFAULT = stripTrailingSlash(
 const API_BASE_OVERRIDE_KEY = "cataloggy_api_base_override";
 const TOKEN_KEY = "cataloggy_token";
 const PROFILE_ID_KEY = "cataloggy_profile_id";
+const PROFILE_TOKEN_KEY = "cataloggy_profile_token";
 
 export const runtimeConfig = {
   apiBaseDefault: API_BASE_DEFAULT,
@@ -77,6 +78,24 @@ export const runtimeConfig = {
   },
   clearProfileId() {
     window.localStorage.removeItem(PROFILE_ID_KEY);
+    window.localStorage.removeItem(PROFILE_TOKEN_KEY);
+  },
+  // Signed capability returned by POST /profiles/:id/verify. Sent as the
+  // x-profile-token header so PIN-protected profiles pass the server-side gate.
+  getProfileToken() {
+    return window.localStorage.getItem(PROFILE_TOKEN_KEY) ?? "";
+  },
+  setProfileToken(value: string) {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      window.localStorage.removeItem(PROFILE_TOKEN_KEY);
+      return;
+    }
+
+    window.localStorage.setItem(PROFILE_TOKEN_KEY, trimmed);
+  },
+  clearProfileToken() {
+    window.localStorage.removeItem(PROFILE_TOKEN_KEY);
   }
 };
 
@@ -399,6 +418,10 @@ const authHeaders = (hasBody: boolean) => {
   if (profileId) {
     headers["x-profile-id"] = profileId;
   }
+  const profileToken = runtimeConfig.getProfileToken();
+  if (profileToken) {
+    headers["x-profile-token"] = profileToken;
+  }
   return headers;
 };
 
@@ -469,15 +492,26 @@ async function request<T>(path: string, init?: RequestInit & { timeoutMs?: numbe
     // Fall back to the raw body if it isn't (or isn't valid JSON) so nothing
     // is ever silently swallowed.
     let message = body;
+    let errorCode: string | undefined;
     if (body) {
       try {
-        const parsed = JSON.parse(body) as { error?: unknown };
+        const parsed = JSON.parse(body) as { error?: unknown; code?: unknown };
         if (typeof parsed.error === "string" && parsed.error.trim()) {
           message = parsed.error;
+        }
+        if (typeof parsed.code === "string") {
+          errorCode = parsed.code;
         }
       } catch {
         // not JSON — use the raw body as-is
       }
+    }
+    // A PIN-protected profile's access token is missing or expired. Drop the
+    // stale profile selection and prompt the user to re-verify, rather than
+    // leaving every page stuck on a 401.
+    if (response.status === 401 && errorCode === "profile_verification_required") {
+      runtimeConfig.clearProfileId();
+      window.dispatchEvent(new Event("cataloggy:profile-locked"));
     }
     // A 401 with a WWW-Authenticate header (RFC 6750) comes from the bearer-token
     // auth middleware itself, meaning the stored token is missing/invalid/rotated —
@@ -826,11 +860,18 @@ export const api = {
       body: JSON.stringify(payload),
     });
   },
-  verifyProfile(profileId: string, pin?: string) {
-    return request<{ id: string; name: string }>(`/profiles/${encodeURIComponent(profileId)}/verify`, {
-      method: "POST",
-      body: JSON.stringify(pin ? { pin } : {}),
-    });
+  async verifyProfile(profileId: string, pin?: string) {
+    const result = await request<{ id: string; name: string; profileToken?: string }>(
+      `/profiles/${encodeURIComponent(profileId)}/verify`,
+      {
+        method: "POST",
+        body: JSON.stringify(pin ? { pin } : {}),
+      }
+    );
+    // Persist the signed capability so subsequent requests for this profile
+    // clear the server-side PIN gate.
+    runtimeConfig.setProfileToken(result.profileToken ?? "");
+    return result;
   },
   updateProfile(profileId: string, payload: { name?: string; pin?: string | null; currentPin?: string }) {
     return request<{ profile: Profile }>(`/profiles/${encodeURIComponent(profileId)}`, {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,15 @@ services:
       POSTGRES_DB: ${POSTGRES_DB:-cataloggy}
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in a .env file next to docker-compose.yml — see README.md}
+    # Bind Postgres to loopback only. The api/addon services reach it over the
+    # internal "cataloggy" Docker network (host db:5432), so no host mapping is
+    # needed for the app to work. Publishing on 0.0.0.0 would expose the
+    # database — including stored OAuth tokens — to the whole LAN (and the
+    # internet if the host is port-forwarded), bypassing API_TOKEN entirely.
+    # Loopback keeps host-side psql/backups working without that exposure.
+    # Remove this block entirely if you never need host-side DB access.
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
     restart: unless-stopped


### PR DESCRIPTION
- Enforce profile PINs server-side. POST /profiles/:id/verify now issues a
  short-lived HMAC-signed profile-access token that resolveProfile requires
  (x-profile-token header) for any PIN-protected profile. Previously the PIN
  was a client-side prompt only: any API_TOKEN holder could read/mutate a
  locked profile's data (incl. full /export) by setting x-profile-id to its
  UUID. Web client stores/sends the token and re-prompts on expiry.

- Harden the AI-provider config against SSRF. POST /ai/config, POST /ai/test,
  and the outbound AI call reject cloud-metadata/link-local targets and
  non-HTTP schemes, stop following redirects, and no longer reflect the
  upstream response body. LAN/localhost LLM endpoints stay allowed.

- Bind the Postgres container port to 127.0.0.1 instead of 0.0.0.0 so the
  database is no longer reachable from the LAN/internet, bypassing API_TOKEN.