### PR TITLE
Bump the brace-expansion override past the DoS advisory

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,7 @@ overrides:
   find-my-way: ^9.7.0
   fast-uri: ^4.1.1
   ajv>fast-uri: ^3.1.4
-  brace-expansion: ^5.0.8
+  brace-expansion: ^5.0.9
 
 importers:
 
@@ -2094,8 +2094,8 @@ packages:
   bn.js@4.12.3:
     resolution: {integrity: sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   browserslist@4.28.7:
@@ -5894,7 +5894,7 @@ snapshots:
 
   bn.js@4.12.3: {}
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -6895,11 +6895,11 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimist@1.2.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,7 +10,7 @@ overrides:
   find-my-way: "^9.7.0"
   fast-uri: "^4.1.1"
   "ajv>fast-uri": "^3.1.4"
-  brace-expansion: "^5.0.8"
+  brace-expansion: "^5.0.9"
 
 # pnpm does not run a dependency's install scripts unless it is approved here.
 # Prisma downloads its query engine that way, esbuild its platform binary.


### PR DESCRIPTION
The workspace already pinned brace-expansion through an override, but at
^5.0.8 — which is inside the range GHSA-rgw5-rvv9-x895 flags for unbounded
intermediate arrays. Move the floor to ^5.0.9 so every one of the 35 paths
that reach it through eslint/minimatch resolves to the patched release, and
`pnpm audit --audit-level=high` passes again.