### PR TITLE
Replace the route loading spinner with a Pac-Man ghost

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,8 +1,9 @@
 import { lazy, Suspense, useEffect, useRef, useState } from "react";
 import { Link, Route, Routes, useLocation } from "react-router";
-import { Clapperboard, Loader2, Search, User } from "lucide-react";
+import { Clapperboard, Search, User } from "lucide-react";
 import { api, Profile, runtimeConfig } from "./api";
 import { useCommandPalette } from "./hooks/useCommandPalette";
+import { GhostLoader } from "./components/GhostLoader";
 import { InstallButton } from "./components/InstallButton";
 import { MobileTabBar } from "./components/MobileTabBar";
 import { OfflineBanner } from "./components/OfflineBanner";
@@ -52,15 +53,7 @@ const SettingsPage = lazy(() => loadSettingsPage().then((m) => ({ default: m.Set
 const StatsPage = lazy(() => loadStatsPage().then((m) => ({ default: m.StatsPage })));
 
 const LoadingFallback = ({ label = "Loading…" }: { label?: string }) => (
-  <div
-    role="status"
-    aria-live="polite"
-    className="flex items-center justify-center py-24"
-    style={{ color: "var(--text-dim)" }}
-  >
-    <Loader2 size={24} className="animate-spin" aria-hidden="true" />
-    <span className="sr-only">{label}</span>
-  </div>
+  <GhostLoader label={label} className="items-center py-24" />
 );
 
 // The switcher is a full-screen modal, so suspending it to nothing would blank the

--- a/apps/web/src/components/GhostLoader.test.tsx
+++ b/apps/web/src/components/GhostLoader.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { GhostLoader } from "./GhostLoader";
+
+describe("GhostLoader", () => {
+  it("announces itself as a live status with a default label", () => {
+    render(<GhostLoader />);
+
+    expect(screen.getByRole("status")).toHaveTextContent("Loading…");
+  });
+
+  it("takes a caller-supplied label, so the wait can say what it is waiting on", () => {
+    render(<GhostLoader label="Loading profiles…" />);
+
+    expect(screen.getByRole("status")).toHaveTextContent("Loading profiles…");
+  });
+
+  it("hides the drawing from assistive tech, leaving only the label to read", () => {
+    const { container } = render(<GhostLoader label="Loading…" />);
+
+    expect(container.querySelector(".cg-ghost")).toHaveAttribute("aria-hidden", "true");
+  });
+
+  it("leaves the scale variable unset by default, so the stylesheet's 0.8 stands", () => {
+    const { container } = render(<GhostLoader />);
+
+    expect(container.querySelector<HTMLElement>(".cg-ghost")!.style.getPropertyValue("--cg-ghost-scale")).toBe("");
+  });
+
+  it("passes an explicit scale through as the CSS variable the stylesheet reads", () => {
+    const { container } = render(<GhostLoader scale={0.5} />);
+
+    expect(container.querySelector<HTMLElement>(".cg-ghost")!.style.getPropertyValue("--cg-ghost-scale")).toBe("0.5");
+  });
+
+  it("places every cell the grid template names, and no cell it does not", () => {
+    const { container } = render(<GhostLoader />);
+    const placed = [...container.querySelectorAll<HTMLElement>(".cg-ghost__cell")]
+      .map((cell) => cell.style.gridArea);
+
+    // an5 and an14 are named by the template but deliberately left empty —
+    // they are the gaps between the ghost's trailing wisps.
+    expect(new Set(placed).size).toBe(placed.length);
+    expect(placed).toHaveLength(27);
+    expect(placed).not.toContain("an5");
+    expect(placed).not.toContain("an14");
+  });
+});

--- a/apps/web/src/components/GhostLoader.test.tsx
+++ b/apps/web/src/components/GhostLoader.test.tsx
@@ -2,6 +2,21 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { GhostLoader } from "./GhostLoader";
 
+/**
+ * Every area the 14x14 template in index.css names and expects to be filled.
+ * Transcribed from the stylesheet rather than imported from the component, so
+ * that renaming an area in one place without the other fails here.
+ *
+ * an5 and an14 are named by the template but deliberately left empty — they
+ * are the gaps between the ghost's trailing wisps — so they are absent below.
+ */
+const EXPECTED_AREAS = [
+  "top0", "top1", "top2", "top3", "top4",
+  "st0", "st1", "st2", "st3", "st4", "st5",
+  "an1", "an2", "an3", "an4", "an6", "an7", "an8", "an9",
+  "an10", "an11", "an12", "an13", "an15", "an16", "an17", "an18",
+];
+
 describe("GhostLoader", () => {
   it("announces itself as a live status with a default label", () => {
     render(<GhostLoader />);
@@ -38,8 +53,12 @@ describe("GhostLoader", () => {
     const placed = [...container.querySelectorAll<HTMLElement>(".cg-ghost__cell")]
       .map((cell) => cell.style.gridArea);
 
-    // an5 and an14 are named by the template but deliberately left empty —
-    // they are the gaps between the ghost's trailing wisps.
+    // Spelled out rather than counted. A cell whose area name is misspelled is
+    // placed nowhere and paints nothing, but it still leaves 27 unique values
+    // that are neither an5 nor an14 — so the count and the gap checks below
+    // pass while a chunk of the ghost is missing. Only naming the set catches
+    // that.
+    expect([...placed].sort()).toEqual([...EXPECTED_AREAS].sort());
     expect(new Set(placed).size).toBe(placed.length);
     expect(placed).toHaveLength(27);
     expect(placed).not.toContain("an5");

--- a/apps/web/src/components/GhostLoader.tsx
+++ b/apps/web/src/components/GhostLoader.tsx
@@ -1,0 +1,72 @@
+/**
+ * Pac-Man ghost loading indicator. The shape is 27 coloured blocks placed on
+ * the 14x14 grid defined by `.cg-ghost__body` in index.css, plus two eyes that
+ * track side to side. All of the paint comes from the active theme's accent —
+ * see the block comment beside `.cg-ghost` for the colour reasoning.
+ *
+ * Cells carry their `grid-area` inline rather than through a class each: the
+ * name is the only thing that varies between them, so a rule per cell would be
+ * 27 lines of stylesheet expressing what these three arrays already say.
+ */
+
+/** Always painted: the dome and the fringe's fixed teeth. */
+const SOLID_AREAS = [
+  "top0", "top1", "top2", "top3", "top4",
+  "st0", "st1", "st2", "st3", "st4", "st5",
+];
+
+/** Fringe cells lit for the first half of the cycle. */
+const FLICKER_A_AREAS = ["an1", "an6", "an7", "an8", "an11", "an12", "an13", "an18"];
+
+/** Fringe cells lit for the second half — the antiphase of the set above. */
+const FLICKER_B_AREAS = ["an2", "an3", "an4", "an9", "an10", "an15", "an16", "an17"];
+
+type GhostLoaderProps = {
+  /** Announced to screen readers; the ghost itself is decorative. */
+  label?: string;
+  /**
+   * Painted size as a multiple of 140px. The element reserves 140px square
+   * whatever this is, so values far from 1 leave slack around the ghost.
+   */
+  scale?: number;
+  /** Applied to the wrapper, for positioning the loader in its container. */
+  className?: string;
+};
+
+export function GhostLoader({ label = "Loading…", scale, className = "" }: GhostLoaderProps) {
+  return (
+    <div role="status" aria-live="polite" className={`flex justify-center ${className}`}>
+      <div
+        className="cg-ghost"
+        aria-hidden="true"
+        style={scale === undefined ? undefined : { "--cg-ghost-scale": scale } as React.CSSProperties}
+      >
+        <div className="cg-ghost__body">
+          {SOLID_AREAS.map((area) => (
+            <div key={area} className="cg-ghost__cell" style={{ gridArea: area }} />
+          ))}
+          {FLICKER_A_AREAS.map((area) => (
+            <div
+              key={area}
+              className="cg-ghost__cell cg-ghost__cell--flicker-a"
+              style={{ gridArea: area }}
+            />
+          ))}
+          {FLICKER_B_AREAS.map((area) => (
+            <div
+              key={area}
+              className="cg-ghost__cell cg-ghost__cell--flicker-b"
+              style={{ gridArea: area }}
+            />
+          ))}
+          <div className="cg-ghost__eye" />
+          <div className="cg-ghost__eye cg-ghost__eye--right" />
+          <div className="cg-ghost__pupil" />
+          <div className="cg-ghost__pupil cg-ghost__pupil--right" />
+        </div>
+        <div className="cg-ghost__shadow" />
+      </div>
+      <span className="sr-only">{label}</span>
+    </div>
+  );
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -491,3 +491,203 @@ body {
   transform: translateY(-4px);
   box-shadow: 0 8px 20px rgba(28, 24, 20, 0.08);
 }
+
+/*
+ * Ghost loader — a Pac-Man ghost painted as a 14x14 grid of blocks, with the
+ * bottom two rows flickering between two phases so the fringe appears to
+ * ripple. Adapted from a Uiverse.io design onto the theme tokens.
+ *
+ * Body, fringe and pupils are all --accent, so the ghost picks up whichever
+ * theme is live. The sclera is the one fixed colour: --on-accent is the
+ * token that guarantees contrast on an accent fill, but it resolves to
+ * near-black on four of the five themes, which turns the eyes into hollow
+ * sockets and costs the shape its read as a Pac-Man ghost. White holds that
+ * read everywhere, at 2.4:1 (dark, the weakest accent) to 4.0:1 (midnight)
+ * against the body — under the text threshold, but this is a 40px decorative
+ * block with the accessible name carried by GhostLoader's sr-only label, not
+ * something anyone reads.
+ *
+ * The drop shadow is the accent at low alpha rather than black, which would
+ * vanish against the four dark themes' backgrounds.
+ *
+ * Individual cells get their `grid-area` inline from GhostLoader.tsx; putting
+ * the 27 single-property rules here instead would triple the size of this
+ * block for nothing. Only paint and flicker phase live in CSS.
+ */
+.cg-ghost {
+  position: relative;
+  width: 140px;
+  height: 140px;
+  /* The layout box stays 140px square — this only changes the painted size. */
+  transform: scale(var(--cg-ghost-scale, 0.8));
+}
+
+.cg-ghost__body {
+  position: relative;
+  width: 140px;
+  height: 140px;
+  display: grid;
+  grid-template-columns: repeat(14, 1fr);
+  grid-template-rows: repeat(14, 1fr);
+  animation: ghost-bob 0.5s infinite;
+  grid-template-areas:
+    "a1  a2  a3  a4  a5  top0  top0  top0  top0  a10 a11 a12 a13 a14"
+    "b1  b2  b3  top1 top1 top1 top1 top1 top1 top1 top1 b12 b13 b14"
+    "c1 c2 top2 top2 top2 top2 top2 top2 top2 top2 top2 top2 c13 c14"
+    "d1 top3 top3 top3 top3 top3 top3 top3 top3 top3 top3 top3 top3 d14"
+    "e1 top3 top3 top3 top3 top3 top3 top3 top3 top3 top3 top3 top3 e14"
+    "f1 top3 top3 top3 top3 top3 top3 top3 top3 top3 top3 top3 top3 f14"
+    "top4 top4 top4 top4 top4 top4 top4 top4 top4 top4 top4 top4 top4 top4"
+    "top4 top4 top4 top4 top4 top4 top4 top4 top4 top4 top4 top4 top4 top4"
+    "top4 top4 top4 top4 top4 top4 top4 top4 top4 top4 top4 top4 top4 top4"
+    "top4 top4 top4 top4 top4 top4 top4 top4 top4 top4 top4 top4 top4 top4"
+    "top4 top4 top4 top4 top4 top4 top4 top4 top4 top4 top4 top4 top4 top4"
+    "top4 top4 top4 top4 top4 top4 top4 top4 top4 top4 top4 top4 top4 top4"
+    "st0 st0 an4 st1 an7 st2 an10 an10 st3 an13 st4 an16 st5 st5"
+    "an1 an2 an3 an5 an6 an8 an9 an9 an11 an12 an14 an15 an17 an18";
+}
+
+.cg-ghost__cell {
+  background-color: var(--accent);
+}
+
+/* The two fringe phases run in antiphase, so the notches appear to slide. */
+.cg-ghost__cell--flicker-a {
+  animation: ghost-flicker-a 0.5s infinite;
+}
+
+.cg-ghost__cell--flicker-b {
+  animation: ghost-flicker-b 0.5s infinite;
+}
+
+.cg-ghost__eye {
+  position: absolute;
+  top: 30px;
+  left: 10px;
+  width: 40px;
+  height: 50px;
+}
+
+.cg-ghost__eye--right {
+  left: auto;
+  right: 30px;
+}
+
+/* A plus-shaped sclera: a tall bar crossed by a wide one. */
+.cg-ghost__eye::before,
+.cg-ghost__eye::after {
+  content: "";
+  display: block;
+  position: absolute;
+  background-color: #fff;
+}
+
+.cg-ghost__eye::before {
+  width: 20px;
+  height: 50px;
+  transform: translateX(10px);
+}
+
+.cg-ghost__eye::after {
+  width: 40px;
+  height: 30px;
+  transform: translateY(10px);
+}
+
+.cg-ghost__pupil {
+  position: absolute;
+  top: 50px;
+  left: 10px;
+  z-index: 1;
+  width: 20px;
+  height: 20px;
+  background-color: var(--accent);
+  animation: ghost-look 3s infinite;
+}
+
+.cg-ghost__pupil--right {
+  left: auto;
+  right: 50px;
+}
+
+.cg-ghost__shadow {
+  position: absolute;
+  top: 80%;
+  width: 140px;
+  height: 140px;
+  border-radius: 50%;
+  background-color: rgb(var(--accent-rgb) / 0.35);
+  transform: rotateX(80deg);
+  filter: blur(20px);
+  animation: ghost-shadow 0.5s infinite;
+}
+
+@keyframes ghost-bob {
+  0%, 49% {
+    transform: translateY(0);
+  }
+  50%, 100% {
+    transform: translateY(-10px);
+  }
+}
+
+@keyframes ghost-flicker-a {
+  0%, 49% {
+    background-color: var(--accent);
+  }
+  50%, 100% {
+    background-color: transparent;
+  }
+}
+
+@keyframes ghost-flicker-b {
+  0%, 49% {
+    background-color: transparent;
+  }
+  50%, 100% {
+    background-color: var(--accent);
+  }
+}
+
+@keyframes ghost-look {
+  0%, 49% {
+    transform: translateX(0);
+  }
+  50%, 99% {
+    transform: translateX(10px);
+  }
+  100% {
+    transform: translateX(0);
+  }
+}
+
+@keyframes ghost-shadow {
+  0%, 49% {
+    opacity: 0.5;
+  }
+  50%, 100% {
+    opacity: 0.2;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  /*
+   * The global reduce block above collapses every animation to 0.001ms and one
+   * iteration, which would leave the ghost mid-flicker: the phase-b cells hold
+   * their 100% keyframe (painted) while the phase-a cells hold theirs
+   * (transparent), tearing a bite out of one half of the fringe. Drop the
+   * animations outright and paint the whole fringe instead, so what's left is
+   * a still ghost rather than a broken one.
+   */
+  .cg-ghost__body,
+  .cg-ghost__pupil,
+  .cg-ghost__shadow {
+    animation: none;
+  }
+
+  .cg-ghost__cell--flicker-a,
+  .cg-ghost__cell--flicker-b {
+    animation: none;
+    background-color: var(--accent);
+  }
+}


### PR DESCRIPTION
The suspense fallback between routes was a 24px spinner, which is the same
thing every button in settings shows while it saves — nothing about it said
"the page is coming". A ghost is unmistakably a page-level wait, and it suits
a media catalogue better than a generic spinner does.

The shape is 27 blocks placed on a 14x14 grid, with the bottom two rows
flickering between two phases so the fringe ripples. Adapted from a Uiverse.io
design, with three changes it needed to live here:

- Colours run off the theme tokens rather than a hard-coded red, so the ghost
  follows whichever of the five themes is active. The sclera stays white; the
  token that guarantees contrast on an accent fill resolves to near-black on
  four of the five, which reads as hollow sockets rather than eyes.
- IDs became classes. A loader can appear more than once on a page, and the
  original selectors would have collided the moment it did.
- Reduced motion gets its own block. The global reduce rule collapses every
  animation to one 0.001ms iteration, which would have frozen the two flicker
  phases on opposite keyframes and bitten a chunk out of half the fringe.
  The ghost now falls back to a still one with the fringe fully painted.

Cells carry grid-area inline from the component instead of through 27
single-property rules in the stylesheet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Pac-Man-style ghost loading indicator with customizable status text, size, and styling.
  * Added animated ghost visuals, including eyes, fringe flicker, bobbing, and shadow effects.
  * Added reduced-motion support for a static, accessible loading experience.

* **Bug Fixes**
  * Updated loading states to use the shared ghost loader for a more consistent presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->