### PR TITLE
Smooth carousel and image loading transitions

### DIFF
--- a/apps/web/src/components/CarouselTrack.test.tsx
+++ b/apps/web/src/components/CarouselTrack.test.tsx
@@ -10,32 +10,52 @@ const renderTrack = (canScrollLeft: boolean, canScrollRight: boolean) =>
   );
 
 const fades = (container: HTMLElement) => container.querySelectorAll("[data-carousel-fade]");
+const fade = (container: HTMLElement, side: "left" | "right") =>
+  container.querySelector(`[data-carousel-fade="${side}"]`) as HTMLElement;
+const isVisible = (el: HTMLElement) => !el.className.includes("opacity-0");
 const track = (container: HTMLElement) => container.querySelector(".overflow-x-auto") as HTMLElement;
 
 describe("CarouselTrack", () => {
-  it("renders no edge fade when the row fits entirely on screen", () => {
+  it("hides both edge fades when the row fits entirely on screen", () => {
     const { container } = renderTrack(false, false);
-    expect(fades(container)).toHaveLength(0);
+    expect(isVisible(fade(container, "left"))).toBe(false);
+    expect(isVisible(fade(container, "right"))).toBe(false);
   });
 
-  it("fades only the right edge at the start of a scrollable row", () => {
+  it("keeps both fades mounted with an opacity transition, so they ease in and out rather than pop", () => {
+    const { container } = renderTrack(false, false);
+    const found = fades(container);
+    expect(found).toHaveLength(2);
+    for (const el of found) expect(el.className).toContain("transition-opacity");
+  });
+
+  it("shows only the right fade at the start of a scrollable row", () => {
     const { container } = renderTrack(false, true);
-    const found = fades(container);
-    expect(found).toHaveLength(1);
-    expect(found[0].getAttribute("data-carousel-fade")).toBe("right");
-    expect(found[0]).toHaveStyle({ background: "linear-gradient(to left, var(--bg-0), transparent)" });
+    expect(isVisible(fade(container, "left"))).toBe(false);
+    expect(isVisible(fade(container, "right"))).toBe(true);
+    expect(fade(container, "right")).toHaveStyle({ background: "linear-gradient(to left, var(--bg-0), transparent)" });
   });
 
-  it("fades only the left edge at the end of a scrollable row", () => {
+  it("shows only the left fade at the end of a scrollable row", () => {
     const { container } = renderTrack(true, false);
-    const found = fades(container);
-    expect(found).toHaveLength(1);
-    expect(found[0].getAttribute("data-carousel-fade")).toBe("left");
+    expect(isVisible(fade(container, "left"))).toBe(true);
+    expect(isVisible(fade(container, "right"))).toBe(false);
   });
 
-  it("fades both edges mid-scroll", () => {
+  it("shows both fades mid-scroll", () => {
     const { container } = renderTrack(true, true);
-    expect([...fades(container)].map((el) => el.getAttribute("data-carousel-fade"))).toEqual(["left", "right"]);
+    expect(isVisible(fade(container, "left"))).toBe(true);
+    expect(isVisible(fade(container, "right"))).toBe(true);
+  });
+
+  it("snaps flicks to card boundaries without hijacking mid-row scrolling", () => {
+    const { container } = renderTrack(true, true);
+    const el = track(container);
+    // proximity, not mandatory: only a flick that ends near a boundary settles
+    // on it. snap-start rides on the children, where snap alignment must live.
+    expect(el.className).toContain("snap-x");
+    expect(el.className).toContain("snap-proximity");
+    expect(el.className).toContain("[&>*]:snap-start");
   });
 
   it("keeps the fades out of the accessibility tree and out of the way of clicks", () => {

--- a/apps/web/src/components/CarouselTrack.tsx
+++ b/apps/web/src/components/CarouselTrack.tsx
@@ -21,6 +21,16 @@ import type { ReactNode } from "react";
  *    `overflow-x: auto` clips vertically as well as horizontally. 8px covers
  *    every decoration in play — the 4px `card-lift` translate, the ~2px a
  *    `scale-[1.03]` poster gains, and a 2px ring at a 2px offset.
+ *
+ * Both fades stay mounted and toggle opacity instead of mounting on demand —
+ * reaching an end of the row eases the fade out over 300ms rather than
+ * blinking it away on the frame the scroll position crosses the threshold.
+ *
+ * The track snaps with `snap-proximity` (via `snap-start` on each child):
+ * a flick that ends near a card boundary settles on it instead of stopping
+ * mid-card, while `proximity` — unlike `mandatory` — leaves free scrolling
+ * through the middle of a long row alone. `scroll-px-8` doubles as the snap
+ * padding, so a snapped card lands clear of the fade.
  */
 export function CarouselTrack({
   scrollRef,
@@ -43,22 +53,22 @@ export function CarouselTrack({
     <div className="relative -m-2">
       <div
         ref={scrollRef}
-        className={`flex overflow-x-auto scroll-smooth scroll-px-8 scrollbar-hide p-2 ${className}`}
+        className={`flex overflow-x-auto scroll-smooth scroll-px-8 snap-x snap-proximity [&>*]:snap-start scrollbar-hide p-2 ${className}`}
       >
         {children}
       </div>
-      {canScrollLeft && <EdgeFade side="left" color={fadeColor} />}
-      {canScrollRight && <EdgeFade side="right" color={fadeColor} />}
+      <EdgeFade side="left" color={fadeColor} visible={canScrollLeft} />
+      <EdgeFade side="right" color={fadeColor} visible={canScrollRight} />
     </div>
   );
 }
 
-function EdgeFade({ side, color }: { side: "left" | "right"; color: string }) {
+function EdgeFade({ side, color, visible }: { side: "left" | "right"; color: string; visible: boolean }) {
   return (
     <span
       aria-hidden="true"
       data-carousel-fade={side}
-      className={`pointer-events-none absolute inset-y-0 w-8 ${side === "left" ? "left-0" : "right-0"}`}
+      className={`pointer-events-none absolute inset-y-0 w-8 transition-opacity duration-300 ${side === "left" ? "left-0" : "right-0"} ${visible ? "opacity-100" : "opacity-0"}`}
       style={{ background: `linear-gradient(to ${side === "left" ? "right" : "left"}, ${color}, transparent)` }}
     />
   );

--- a/apps/web/src/components/Poster.tsx
+++ b/apps/web/src/components/Poster.tsx
@@ -41,8 +41,12 @@ export function Poster({
   sizes?: string;
 }) {
   const [loadFailed, setLoadFailed] = useState(false);
+  const [loaded, setLoaded] = useState(false);
 
-  useEffect(() => { setLoadFailed(false); }, [src]);
+  useEffect(() => {
+    setLoadFailed(false);
+    setLoaded(false);
+  }, [src]);
 
   if (!src || loadFailed) {
     return (
@@ -56,20 +60,34 @@ export function Poster({
 
   const srcSet = buildTmdbSrcSet(src);
 
+  // The wrapper carries the slot: a shimmer while bytes are in flight (the
+  // cards behind these images are transparent, so without it each poster pops
+  // out of nothing), settling to a plain surface once the image starts its
+  // fade so nothing animates behind an opaque picture.
   return (
-    <img
-      src={src}
-      srcSet={srcSet}
-      sizes={srcSet ? sizes : undefined}
-      alt={alt ?? "Poster"}
-      className={`object-cover ${className}`}
-      loading={eager ? "eager" : "lazy"}
-      decoding={eager ? "sync" : "async"}
-      // Above-fold artwork is what the page looks like — it should outrank the
-      // lazy posters further down the row that the browser would otherwise treat
-      // as equals. `low` on the rest keeps them behind the data requests.
-      fetchPriority={eager ? "high" : "low"}
-      onError={() => setLoadFailed(true)}
-    />
+    <div className={`${loaded ? "bg-[var(--surface-strong)]" : "skeleton"} ${className}`}>
+      <img
+        src={src}
+        srcSet={srcSet}
+        sizes={srcSet ? sizes : undefined}
+        alt={alt ?? "Poster"}
+        className={`h-full w-full object-cover transition-opacity duration-300 ${loaded ? "opacity-100" : "opacity-0"}`}
+        loading={eager ? "eager" : "lazy"}
+        decoding={eager ? "sync" : "async"}
+        // Above-fold artwork is what the page looks like — it should outrank the
+        // lazy posters further down the row that the browser would otherwise treat
+        // as equals. `low` on the rest keeps them behind the data requests.
+        fetchPriority={eager ? "high" : "low"}
+        // A memory-cached image can be `complete` in the same commit that sets
+        // `src` — marking it loaded here paints it opaque on the first frame,
+        // so re-renders and back-navigations skip the fade instead of making
+        // an already-seen poster blink.
+        ref={(el) => {
+          if (el?.complete && el.naturalWidth > 0) setLoaded(true);
+        }}
+        onLoad={() => setLoaded(true)}
+        onError={() => setLoadFailed(true)}
+      />
+    </div>
   );
 }

--- a/apps/web/src/components/media-detail/CastSection.tsx
+++ b/apps/web/src/components/media-detail/CastSection.tsx
@@ -35,30 +35,33 @@ export function CastSection({ cast, loading }: { cast: CastMember[]; loading: bo
         <h3 className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--text-mute)" }}>
           <User className="h-3.5 w-3.5" /> Cast
         </h3>
-        {(canScrollLeft || canScrollRight) && (
-          <div className="flex items-center gap-1">
-            <button
-              type="button"
-              onClick={() => scroll("left")}
-              disabled={!canScrollLeft}
-              className="flex h-6 w-6 items-center justify-center rounded-full transition-all disabled:opacity-30 disabled:cursor-default active:scale-95"
-              style={{ border: "1px solid var(--border-strong)", background: "var(--bg-1)", color: "var(--text-dim)" }}
-              aria-label="Scroll cast left"
-            >
-              <ChevronLeft className="h-3.5 w-3.5" />
-            </button>
-            <button
-              type="button"
-              onClick={() => scroll("right")}
-              disabled={!canScrollRight}
-              className="flex h-6 w-6 items-center justify-center rounded-full transition-all disabled:opacity-30 disabled:cursor-default active:scale-95"
-              style={{ border: "1px solid var(--border-strong)", background: "var(--bg-1)", color: "var(--text-dim)" }}
-              aria-label="Scroll cast right"
-            >
-              <ChevronRight className="h-3.5 w-3.5" />
-            </button>
-          </div>
-        )}
+        {/* Mounted even when the row fits, so the cluster fades with layout
+            changes instead of blinking; disabled buttons keep it untabbable. */}
+        <div
+          className={`flex items-center gap-1 transition-opacity duration-300 ${canScrollLeft || canScrollRight ? "" : "pointer-events-none opacity-0"}`}
+          aria-hidden={!canScrollLeft && !canScrollRight}
+        >
+          <button
+            type="button"
+            onClick={() => scroll("left")}
+            disabled={!canScrollLeft}
+            className="flex h-6 w-6 items-center justify-center rounded-full transition-all disabled:opacity-30 disabled:cursor-default active:scale-95"
+            style={{ border: "1px solid var(--border-strong)", background: "var(--bg-1)", color: "var(--text-dim)" }}
+            aria-label="Scroll cast left"
+          >
+            <ChevronLeft className="h-3.5 w-3.5" />
+          </button>
+          <button
+            type="button"
+            onClick={() => scroll("right")}
+            disabled={!canScrollRight}
+            className="flex h-6 w-6 items-center justify-center rounded-full transition-all disabled:opacity-30 disabled:cursor-default active:scale-95"
+            style={{ border: "1px solid var(--border-strong)", background: "var(--bg-1)", color: "var(--text-dim)" }}
+            aria-label="Scroll cast right"
+          >
+            <ChevronRight className="h-3.5 w-3.5" />
+          </button>
+        </div>
       </div>
       <CarouselTrack
         scrollRef={ref}

--- a/apps/web/src/components/media-detail/RecommendationsSection.tsx
+++ b/apps/web/src/components/media-detail/RecommendationsSection.tsx
@@ -39,30 +39,33 @@ export function RecommendationsSection({
         <h3 className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--text-mute)" }}>
           <Sparkles className="h-3.5 w-3.5" /> More Like This
         </h3>
-        {(canScrollLeft || canScrollRight) && (
-          <div className="flex items-center gap-1">
-            <button
-              type="button"
-              onClick={() => scroll("left")}
-              disabled={!canScrollLeft}
-              className="flex h-6 w-6 items-center justify-center rounded-full transition-all disabled:opacity-30 disabled:cursor-default active:scale-95"
-              style={{ border: "1px solid var(--border-strong)", background: "var(--bg-1)", color: "var(--text-dim)" }}
-              aria-label="Scroll recommendations left"
-            >
-              <ChevronLeft className="h-3.5 w-3.5" />
-            </button>
-            <button
-              type="button"
-              onClick={() => scroll("right")}
-              disabled={!canScrollRight}
-              className="flex h-6 w-6 items-center justify-center rounded-full transition-all disabled:opacity-30 disabled:cursor-default active:scale-95"
-              style={{ border: "1px solid var(--border-strong)", background: "var(--bg-1)", color: "var(--text-dim)" }}
-              aria-label="Scroll recommendations right"
-            >
-              <ChevronRight className="h-3.5 w-3.5" />
-            </button>
-          </div>
-        )}
+        {/* Mounted even when the row fits, so the cluster fades with layout
+            changes instead of blinking; disabled buttons keep it untabbable. */}
+        <div
+          className={`flex items-center gap-1 transition-opacity duration-300 ${canScrollLeft || canScrollRight ? "" : "pointer-events-none opacity-0"}`}
+          aria-hidden={!canScrollLeft && !canScrollRight}
+        >
+          <button
+            type="button"
+            onClick={() => scroll("left")}
+            disabled={!canScrollLeft}
+            className="flex h-6 w-6 items-center justify-center rounded-full transition-all disabled:opacity-30 disabled:cursor-default active:scale-95"
+            style={{ border: "1px solid var(--border-strong)", background: "var(--bg-1)", color: "var(--text-dim)" }}
+            aria-label="Scroll recommendations left"
+          >
+            <ChevronLeft className="h-3.5 w-3.5" />
+          </button>
+          <button
+            type="button"
+            onClick={() => scroll("right")}
+            disabled={!canScrollRight}
+            className="flex h-6 w-6 items-center justify-center rounded-full transition-all disabled:opacity-30 disabled:cursor-default active:scale-95"
+            style={{ border: "1px solid var(--border-strong)", background: "var(--bg-1)", color: "var(--text-dim)" }}
+            aria-label="Scroll recommendations right"
+          >
+            <ChevronRight className="h-3.5 w-3.5" />
+          </button>
+        </div>
       </div>
       <CarouselTrack
         scrollRef={ref}

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -391,9 +391,14 @@ function ScrollArrows({
   canScrollRight: boolean;
   onScroll: (dir: "left" | "right") => void;
 }) {
-  if (!canScrollLeft && !canScrollRight) return null;
+  const scrollable = canScrollLeft || canScrollRight;
   return (
-    <div className="flex items-center gap-1.5">
+    // Stays mounted when the row fits on screen so a resize fades the cluster
+    // out instead of blinking it away; disabled buttons keep it untabbable.
+    <div
+      className={`flex items-center gap-1.5 transition-opacity duration-300 ${scrollable ? "" : "pointer-events-none opacity-0"}`}
+      aria-hidden={!scrollable}
+    >
       <button
         type="button"
         onClick={() => onScroll("left")}


### PR DESCRIPTION
## Summary
Refactors carousel navigation controls and image loading to use opacity transitions instead of conditional mounting, creating smoother visual feedback during layout changes and image loads.

## Key Changes

- **Carousel scroll buttons** (CastSection, RecommendationsSection, DashboardPage):
  - Always mount the button cluster but toggle visibility with opacity and `pointer-events-none`
  - Buttons fade in/out over 300ms when scrollability changes, instead of blinking in/out
  - Disabled state prevents keyboard access when hidden

- **Carousel edge fades** (CarouselTrack):
  - Both left and right fades stay mounted and transition opacity based on scroll position
  - Fades ease in/out over 300ms rather than mounting/unmounting abruptly
  - Added `snap-x snap-proximity [&>*]:snap-start` for card-boundary snapping on flicks

- **Poster image loading** (Poster):
  - Wrapper div shows shimmer skeleton while image loads, then transitions to solid surface
  - Image fades in over 300ms once loaded via `opacity-0` → `opacity-100`
  - Handles memory-cached images correctly by checking `complete` and `naturalWidth` on mount
  - Prevents blink on re-renders and back-navigations for already-seen images

- **Tests** (CarouselTrack.test.tsx):
  - Updated to verify opacity visibility instead of DOM presence
  - Added test for snap scroll behavior
  - Confirms transitions are applied to fades

## Implementation Details

All transitions use `transition-opacity duration-300` for consistency. Hidden elements use `pointer-events-none opacity-0` to remain in the DOM but be invisible and non-interactive. The `aria-hidden` attribute is applied conditionally to keep hidden controls out of the accessibility tree.

https://claude.ai/code/session_012b4cmh5tzdq45XmjARaiBp