### PR TITLE
Centralize typography scale into constants

### DIFF
--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -8,6 +8,7 @@ import { useEscapeKey } from "../hooks/useEscapeKey";
 import { useExitAnimation } from "../hooks/useExitAnimation";
 import { useFocusTrap } from "../hooks/useFocusTrap";
 import { useToast } from "../hooks/useToast";
+import { MICRO_LABEL } from "./typography";
 
 type Action = {
   id: string;
@@ -228,7 +229,7 @@ export function CommandPalette({ open, onClose }: { open: boolean; onClose: () =
 
           {!searching && results.length > 0 && (
             <div className="px-2 pb-2">
-              <p className="px-2 pb-1 text-2xs font-medium uppercase tracking-wider" style={{ color: "var(--text-mute)" }}>
+              <p className={`px-2 pb-1 ${MICRO_LABEL}`} style={{ color: "var(--text-mute)" }}>
                 Titles
               </p>
               {results.map((r, i) => (
@@ -257,7 +258,7 @@ export function CommandPalette({ open, onClose }: { open: boolean; onClose: () =
 
           <div className="px-2">
             {visibleActions.length > 0 && (
-              <p className="px-2 pb-1 pt-1 text-2xs font-medium uppercase tracking-wider" style={{ color: "var(--text-mute)" }}>
+              <p className={`px-2 pb-1 pt-1 ${MICRO_LABEL}`} style={{ color: "var(--text-mute)" }}>
                 Navigate
               </p>
             )}

--- a/apps/web/src/components/ErrorBoundary.tsx
+++ b/apps/web/src/components/ErrorBoundary.tsx
@@ -1,6 +1,7 @@
 import { Component, type ErrorInfo, type ReactNode } from "react";
 import { AlertTriangle } from "lucide-react";
 import { captureException } from "../sentry";
+import { SECTION_TITLE } from "./typography";
 
 type ErrorBoundaryProps = { children: ReactNode };
 type ErrorBoundaryState = { hasError: boolean; error: Error | null };
@@ -32,7 +33,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
             <AlertTriangle className="h-7 w-7" />
           </div>
           <div className="space-y-1">
-            <h1 className="text-lg font-semibold" style={{ color: "var(--text)" }}>
+            <h1 className={SECTION_TITLE} style={{ color: "var(--text)" }}>
               Something went wrong
             </h1>
             <p style={{ color: "var(--text-mute)" }}>An unexpected error occurred. Try again, or reload the page.</p>

--- a/apps/web/src/components/GameDetailPanel.tsx
+++ b/apps/web/src/components/GameDetailPanel.tsx
@@ -6,6 +6,7 @@ import { useScrollLock } from "../hooks/useScrollLock";
 import { useEscapeKey } from "../hooks/useEscapeKey";
 import { useExitAnimation } from "../hooks/useExitAnimation";
 import { formatPlaytime } from "../utils/playtime";
+import { PAGE_TITLE, KICKER } from "./typography";
 
 function formatDate(value: string | null): string | null {
   if (!value) return null;
@@ -44,7 +45,7 @@ function GameStarRating({
 
   return (
     <div>
-      <h3 className="mb-2 flex items-center gap-2 text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--text-mute)" }}>
+      <h3 className={`mb-2 flex items-center gap-2 ${KICKER}`} style={{ color: "var(--text-mute)" }}>
         <Star className="h-3.5 w-3.5" /> Your Rating <span className="font-normal">(1-10)</span>
       </h3>
       <div className="flex flex-wrap items-center gap-1">
@@ -215,7 +216,7 @@ export function GameDetailPanel({
                 </span>
               )}
             </div>
-            <h2 className="mt-3 font-heading text-2xl font-extrabold tracking-tight" style={{ color: "var(--text)" }}>{game.title}</h2>
+            <h2 className={`mt-3 ${PAGE_TITLE}`} style={{ color: "var(--text)" }}>{game.title}</h2>
 
             <div className="mt-2 flex flex-wrap items-center gap-2">
               <span className="inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs" style={{ background: "var(--surface-strong)", color: "var(--text-dim)" }}>
@@ -257,7 +258,7 @@ export function GameDetailPanel({
           </div>
 
           <div>
-            <h3 id="game-notes-heading" className="mb-2 text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--text-mute)" }}>Notes</h3>
+            <h3 id="game-notes-heading" className={`mb-2 ${KICKER}`} style={{ color: "var(--text-mute)" }}>Notes</h3>
             <textarea
               value={notes}
               onChange={(e) => saveNotes(e.target.value)}

--- a/apps/web/src/components/TicketTile.tsx
+++ b/apps/web/src/components/TicketTile.tsx
@@ -1,3 +1,4 @@
+import { MICRO_LABEL } from "./typography";
 export function MiniBarChart({ data, active = true }: { data: number[]; active?: boolean }) {
   const max = Math.max(...data, 1);
   const barW = 10;
@@ -48,7 +49,7 @@ export function TicketTile({
     >
       <div className="flex items-center gap-1.5">
         <Icon className="h-3.5 w-3.5 text-claw-text" />
-        <span className="text-2xs font-medium uppercase tracking-wider" style={{ color: "var(--text-mute)" }}>
+        <span className={MICRO_LABEL} style={{ color: "var(--text-mute)" }}>
           {label}
         </span>
       </div>

--- a/apps/web/src/components/media-detail/CastSection.tsx
+++ b/apps/web/src/components/media-detail/CastSection.tsx
@@ -1,6 +1,7 @@
 import { ChevronLeft, ChevronRight, User } from "lucide-react";
 import { CarouselTrack } from "../CarouselTrack";
 import { useHorizontalScroll } from "../carousel-utils";
+import { KICKER } from "../typography";
 
 export interface CastMember {
   name: string;
@@ -14,7 +15,7 @@ export function CastSection({ cast, loading }: { cast: CastMember[]; loading: bo
   if (loading) {
     return (
       <div>
-        <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--text-mute)" }}>Cast</h3>
+        <h3 className={`mb-2 ${KICKER}`} style={{ color: "var(--text-mute)" }}>Cast</h3>
         <div className="flex gap-3 overflow-hidden">
           {[1, 2, 3, 4].map((i) => (
             <div key={i} className="flex-none w-16 space-y-1">
@@ -32,7 +33,7 @@ export function CastSection({ cast, loading }: { cast: CastMember[]; loading: bo
   return (
     <div>
       <div className="mb-3 flex items-center justify-between">
-        <h3 className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--text-mute)" }}>
+        <h3 className={`flex items-center gap-2 ${KICKER}`} style={{ color: "var(--text-mute)" }}>
           <User className="h-3.5 w-3.5" /> Cast
         </h3>
         {/* Mounted even when the row fits, so the cluster fades with layout

--- a/apps/web/src/components/media-detail/CheckInModal.tsx
+++ b/apps/web/src/components/media-detail/CheckInModal.tsx
@@ -4,6 +4,7 @@ import { useFocusTrap } from "../../hooks/useFocusTrap";
 import { useScrollLock } from "../../hooks/useScrollLock";
 import { useEscapeKey } from "../../hooks/useEscapeKey";
 import { useExitAnimation } from "../../hooks/useExitAnimation";
+import { SECTION_TITLE } from "../typography";
 
 export function CheckInModal({
   seriesName,
@@ -59,7 +60,7 @@ export function CheckInModal({
         <div className="flex items-center justify-between border-b px-5 py-4" style={{ borderColor: "var(--border)" }}>
           <div className="flex items-center gap-2">
             <Radio className="h-4 w-4 text-claw-text" />
-            <h3 id="checkin-modal-title" className="text-base font-bold" style={{ color: "var(--text)" }}>Check In</h3>
+            <h3 id="checkin-modal-title" className={SECTION_TITLE} style={{ color: "var(--text)" }}>Check In</h3>
           </div>
           <button onClick={requestClose} aria-label="Close" className="rounded-lg p-1.5 hover:bg-[var(--surface-strong)]" style={{ color: "var(--text-mute)" }}>
             <X className="h-4 w-4" />

--- a/apps/web/src/components/media-detail/DetailPanel.tsx
+++ b/apps/web/src/components/media-detail/DetailPanel.tsx
@@ -24,6 +24,7 @@ import { useExitAnimation } from "../../hooks/useExitAnimation";
 import type { ShowToast } from "../../hooks/useToast";
 import { relogWatchEvent } from "../../utils/watchEvents";
 import { invalidateDetailBundle, type PanelDetail } from "./useDetailPanel";
+import { PAGE_TITLE, KICKER, MICRO_LABEL } from "../typography";
 
 /* ─── Detail Panel ────────────────────────────────────────── */
 
@@ -372,7 +373,7 @@ export function DetailPanel({
                 </span>
               )}
             </div>
-            <h2 className="mt-3 font-heading text-2xl font-extrabold tracking-tight" style={{ color: "var(--text)" }}>{item.name}</h2>
+            <h2 className={`mt-3 ${PAGE_TITLE}`} style={{ color: "var(--text)" }}>{item.name}</h2>
 
             {/* Meta row: rating, runtime, network, genres */}
             <div className="mt-2 flex flex-wrap items-center gap-2">
@@ -424,7 +425,7 @@ export function DetailPanel({
           {/* Description */}
           {item.description && (
             <div>
-              <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--text-mute)" }}>Overview</h3>
+              <h3 className={`mb-2 ${KICKER}`} style={{ color: "var(--text-mute)" }}>Overview</h3>
               <p className="text-sm leading-relaxed" style={{ color: "var(--text-dim)" }}>{item.description}</p>
             </div>
           )}
@@ -443,7 +444,7 @@ export function DetailPanel({
 
           {/* ─── Your tracking ──────────────────────────────────── */}
           <div className="flex items-center gap-3 pt-1">
-            <span className="text-2xs font-semibold uppercase tracking-wider" style={{ color: "var(--text-mute)" }}>
+            <span className={MICRO_LABEL} style={{ color: "var(--text-mute)" }}>
               Your tracking
             </span>
             <span aria-hidden="true" className="h-px flex-1" style={{ background: "var(--border)" }} />

--- a/apps/web/src/components/media-detail/ProvidersSection.tsx
+++ b/apps/web/src/components/media-detail/ProvidersSection.tsx
@@ -1,5 +1,6 @@
 import { MonitorPlay } from "lucide-react";
 import { WatchProviders } from "../../api";
+import { KICKER } from "../typography";
 
 export function ProvidersSection({ providers, loading }: { providers: WatchProviders | null; loading: boolean }) {
   // Reserve the section's space while the bundle loads — rendering null and
@@ -8,7 +9,7 @@ export function ProvidersSection({ providers, loading }: { providers: WatchProvi
   if (loading) {
     return (
       <div>
-        <h3 className="mb-2 flex items-center gap-2 text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--text-mute)" }}>
+        <h3 className={`mb-2 flex items-center gap-2 ${KICKER}`} style={{ color: "var(--text-mute)" }}>
           <MonitorPlay className="h-3.5 w-3.5" /> Where to Watch
         </h3>
         <div className="flex flex-wrap gap-2">
@@ -32,7 +33,7 @@ export function ProvidersSection({ providers, loading }: { providers: WatchProvi
 
   return (
     <div>
-      <h3 className="mb-2 flex items-center gap-2 text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--text-mute)" }}>
+      <h3 className={`mb-2 flex items-center gap-2 ${KICKER}`} style={{ color: "var(--text-mute)" }}>
         <MonitorPlay className="h-3.5 w-3.5" /> Where to Watch
       </h3>
       <div className="flex flex-wrap gap-2">

--- a/apps/web/src/components/media-detail/RatingsSection.tsx
+++ b/apps/web/src/components/media-detail/RatingsSection.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { ExternalLink, Star } from "lucide-react";
 import { api, ApiError, MediaType } from "../../api";
 import { ImdbLogo, RtLogo, McIcon, TmdbLogo } from "./RatingLogos";
+import { KICKER } from "../typography";
 
 export function ExternalLinks({
   imdbId, tmdbId, type,
@@ -55,7 +56,7 @@ export function ExternalRatings({
     if (!loading) return null;
     return (
       <div>
-        <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--text-mute)" }}>Ratings</h3>
+        <h3 className={`mb-2 ${KICKER}`} style={{ color: "var(--text-mute)" }}>Ratings</h3>
         <div className="flex flex-wrap items-center gap-4">
           {[1, 2, 3].map((i) => (
             <div key={i} className="skeleton h-5 w-16 rounded" />
@@ -66,7 +67,7 @@ export function ExternalRatings({
   }
   return (
     <div>
-      <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--text-mute)" }}>Ratings</h3>
+      <h3 className={`mb-2 ${KICKER}`} style={{ color: "var(--text-mute)" }}>Ratings</h3>
       <div className="flex flex-wrap items-center gap-4">
         {imdbRating != null && (
           <div className="flex items-center gap-1.5">
@@ -162,7 +163,7 @@ export function StarRating({
   const groups: number[][] = [[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]];
   return (
     <div>
-      <h3 className="mb-2 flex items-center gap-2 text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--text-mute)" }}>
+      <h3 className={`mb-2 flex items-center gap-2 ${KICKER}`} style={{ color: "var(--text-mute)" }}>
         <Star className="h-3.5 w-3.5" /> Your Rating <span className="font-normal">(1-10)</span>
       </h3>
       <div className="flex flex-wrap items-center gap-1 sm:gap-1.5">

--- a/apps/web/src/components/media-detail/RecommendationsSection.tsx
+++ b/apps/web/src/components/media-detail/RecommendationsSection.tsx
@@ -3,6 +3,7 @@ import { Poster } from "../Poster";
 import { CarouselTrack } from "../CarouselTrack";
 import { useHorizontalScroll } from "../carousel-utils";
 import type { TrendingMeta } from "../../api";
+import { KICKER } from "../typography";
 
 export function RecommendationsSection({
   items, loading, onSelect,
@@ -16,7 +17,7 @@ export function RecommendationsSection({
   if (loading) {
     return (
       <div>
-        <h3 className="mb-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--text-mute)" }}>
+        <h3 className={`mb-3 flex items-center gap-2 ${KICKER}`} style={{ color: "var(--text-mute)" }}>
           <Sparkles className="h-3.5 w-3.5" /> More Like This
         </h3>
         <div className="flex gap-3 overflow-hidden">
@@ -36,7 +37,7 @@ export function RecommendationsSection({
   return (
     <div>
       <div className="mb-3 flex items-center justify-between">
-        <h3 className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--text-mute)" }}>
+        <h3 className={`flex items-center gap-2 ${KICKER}`} style={{ color: "var(--text-mute)" }}>
           <Sparkles className="h-3.5 w-3.5" /> More Like This
         </h3>
         {/* Mounted even when the row fits, so the cluster fades with layout

--- a/apps/web/src/components/media-detail/SeasonsSection.tsx
+++ b/apps/web/src/components/media-detail/SeasonsSection.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { Check, ChevronDown, ChevronRight, Tv } from "lucide-react";
 import { api, EpisodeInfo } from "../../api";
+import { KICKER } from "../typography";
 
 export interface SeasonInfo {
   seasonNumber: number;
@@ -122,7 +123,7 @@ export function SeasonsSection({
   if (loading) {
     return (
       <div>
-        <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--text-mute)" }}>Seasons</h3>
+        <h3 className={`mb-2 ${KICKER}`} style={{ color: "var(--text-mute)" }}>Seasons</h3>
         <div className="space-y-2">
           {[1, 2, 3].map((i) => <div key={i} className="skeleton h-11 rounded-xl" />)}
         </div>
@@ -134,7 +135,7 @@ export function SeasonsSection({
 
   return (
     <div>
-      <h3 className="mb-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--text-mute)" }}>
+      <h3 className={`mb-3 flex items-center gap-2 ${KICKER}`} style={{ color: "var(--text-mute)" }}>
         <Tv className="h-3.5 w-3.5" /> Seasons
       </h3>
       <div className="space-y-2">

--- a/apps/web/src/components/media-detail/WatchDateModal.tsx
+++ b/apps/web/src/components/media-detail/WatchDateModal.tsx
@@ -5,6 +5,7 @@ import { useFocusTrap } from "../../hooks/useFocusTrap";
 import { useScrollLock } from "../../hooks/useScrollLock";
 import { useEscapeKey } from "../../hooks/useEscapeKey";
 import { useExitAnimation } from "../../hooks/useExitAnimation";
+import { SECTION_TITLE } from "../typography";
 
 export function WatchDateModal({
   target,
@@ -61,8 +62,9 @@ export function WatchDateModal({
         onAnimationEnd={onExitAnimationEnd}
       >
         <div className="mb-5 flex items-center justify-between">
-          <h3 id="watch-date-modal-title" className="text-base font-semibold" style={{ color: "var(--text)" }}>When did you watch this?</h3>
+          <h3 id="watch-date-modal-title" className={SECTION_TITLE} style={{ color: "var(--text)" }}>When did you watch this?</h3>
           <button type="button" onClick={requestClose} aria-label="Close" className="rounded-lg p-1 hover:opacity-80" style={{ color: "var(--text-mute)" }}>
+
             <X className="h-4 w-4" />
           </button>
         </div>

--- a/apps/web/src/components/media-detail/WatchHistorySection.tsx
+++ b/apps/web/src/components/media-detail/WatchHistorySection.tsx
@@ -1,6 +1,7 @@
 import { Calendar, Clock, Film, Trash2, Tv } from "lucide-react";
 import { Poster } from "../Poster";
 import { WatchEvent } from "../../api";
+import { KICKER } from "../typography";
 
 export function WatchHistorySection({
   history,
@@ -16,7 +17,7 @@ export function WatchHistorySection({
   return (
     <div>
       <div className="mb-3 flex items-center justify-between">
-        <h3 className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--text-mute)" }}>
+        <h3 className={`flex items-center gap-2 ${KICKER}`} style={{ color: "var(--text-mute)" }}>
           <Clock className="h-3.5 w-3.5" /> Watch History
         </h3>
         <button

--- a/apps/web/src/components/settings/AddonSettings.tsx
+++ b/apps/web/src/components/settings/AddonSettings.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { api, runtimeConfig } from "../../api";
 import { Loader2, Check, AlertCircle, Copy, ExternalLink, Sparkles } from "lucide-react";
+import { KICKER } from "../typography";
 
 const AI_CATALOGS = new Set(["cataloggy-ai-movie", "cataloggy-ai-series"]);
 
@@ -205,7 +206,7 @@ export function AddonSettings() {
       {/* User lists */}
       {availableLists.length > 0 && (
         <div className="space-y-2">
-          <p className="text-xs font-semibold uppercase tracking-wider pt-1" style={{ color: "var(--text-mute)" }}>My Lists</p>
+          <p className={`pt-1 ${KICKER}`} style={{ color: "var(--text-mute)" }}>My Lists</p>
           <p className="text-xs" style={{ color: "var(--text-mute)" }}>Each list adds separate Movies and Series catalogs to Stremio.</p>
           {availableLists.map((list) => {
             const catalogId = `list:${list.id}`;

--- a/apps/web/src/components/settings/Section.tsx
+++ b/apps/web/src/components/settings/Section.tsx
@@ -1,5 +1,6 @@
 import { ReactNode, useEffect, useId, useRef, useState } from "react";
 import { ChevronDown } from "lucide-react";
+import { SECTION_TITLE } from "../typography";
 
 const STORAGE_PREFIX = "cataloggy:settings-section:";
 
@@ -73,7 +74,7 @@ export function Section({
   const header = (
     <>
       <span className="flex h-9 w-9 items-center justify-center rounded-lg" style={{ background: "var(--surface-strong)", color: "var(--text-mute)" }}>{icon}</span>
-      <span className="flex-1 text-base font-semibold" style={{ color: "var(--text)" }}>{title}</span>
+      <span className={`flex-1 ${SECTION_TITLE}`} style={{ color: "var(--text)" }}>{title}</span>
       {!alwaysOpen && (
         <ChevronDown
           size={18}

--- a/apps/web/src/components/typography.ts
+++ b/apps/web/src/components/typography.ts
@@ -1,0 +1,77 @@
+/**
+ * The app's heading scale, as four class strings.
+ *
+ * These exist for the same reason `BRAND_WORDMARK` does: a heading's type is a
+ * decision about the product, not about the screen it happens to sit on, so it
+ * belongs in one place that every screen reads from. Before this file the same
+ * four roles were spelled eleven different ways — page titles were `text-2xl
+ * font-bold` on six pages but `font-heading text-2xl font-extrabold
+ * tracking-tight` on the hero and the detail panels, section headers were
+ * `font-bold` on the dashboard, `font-semibold` on stats and a size smaller
+ * again in settings, and the uppercase labels drifted across four size/weight
+ * pairs, twice within a single panel.
+ *
+ * Each constant carries size, weight and tracking together, because those three
+ * are what make a tier recognisable — splitting them is how the drift started.
+ * Colour stays with the caller: the same tier is `--text` on a page, `--text-mute`
+ * over a poster and `--accent-text` on a live badge.
+ *
+ * Four tiers, loudest first.
+ */
+
+/**
+ * The loudest thing on a screen: page `h1`s, and the title of whatever a panel
+ * or an empty state has been opened to show.
+ *
+ * The extra weight and the pulled-in tracking are what separate a title from a
+ * merely large label — at `font-bold` and default tracking, "Watch Statistics"
+ * is set the same as a button. Only one of these should be visible at a time;
+ * if a screen wants two, one of them is a `SECTION_TITLE`.
+ */
+export const PAGE_TITLE = "font-heading text-2xl font-extrabold tracking-tight";
+
+/**
+ * The header of a card, a panel, a modal or a run of content under a page title.
+ *
+ * A step down in size from `PAGE_TITLE` and a step down in weight, so the two
+ * never compete, but still on the heading face with tracking in — a section
+ * header is structure, and it should read as the same family of type as the
+ * title above it rather than as bolded body copy.
+ */
+export const SECTION_TITLE = "font-heading text-lg font-bold tracking-tight";
+
+/**
+ * The uppercase label that names a block inside a panel — "Overview", "Cast",
+ * "Now Watching", "Seasons".
+ *
+ * Uppercase and small rather than large and bold, because these appear several
+ * to a panel: at heading size they would out-shout the title they sit under.
+ * The opened-out tracking is not decoration — uppercase text at 12px is hard to
+ * read set solid, and `tracking-wider` is what buys the letterforms back.
+ */
+export const KICKER = "text-xs font-semibold uppercase tracking-wider";
+
+/**
+ * The same idea one notch quieter: form-field labels, table and grid column
+ * headings, the caption on a stat tile, the group headers in the command
+ * palette.
+ *
+ * The distinction from `KICKER` is what it labels, not how loud it is — a
+ * kicker names a section of content, a micro label names a single control or
+ * value. Reach for this when the label sits *inside* a component rather than
+ * above one.
+ */
+export const MICRO_LABEL = "text-2xs font-semibold uppercase tracking-wider";
+
+/*
+ * Two kinds of uppercase text deliberately sit outside this file.
+ *
+ * The filled badges — the "MOVIE"/"SERIES"/"PLAYING" chips on posters and panel
+ * headers — are `uppercase tracking-wide` on a coloured fill. They read as a
+ * shape rather than as type, and a chip's tracking has to stay tighter than a
+ * label's or the pill grows wide enough to cover the artwork underneath.
+ *
+ * The brand tagline in `BrandLockup` runs at `tracking-[0.2em]`, far wider than
+ * `MICRO_LABEL`. That is the lockup's spacing, not the UI's, and it belongs with
+ * the mark it is set under.
+ */

--- a/apps/web/src/pages/CalendarPage.tsx
+++ b/apps/web/src/pages/CalendarPage.tsx
@@ -10,6 +10,7 @@ import { useMediaQuery } from "../hooks/useMediaQuery";
 import { useScrollLock } from "../hooks/useScrollLock";
 import { useToast } from "../hooks/useToast";
 import { useCachedState } from "../hooks/useCachedState";
+import { PAGE_TITLE, SECTION_TITLE, KICKER, MICRO_LABEL } from "../components/typography";
 
 type ViewMode = "agenda" | "month";
 const AGENDA_RANGES = [14, 30, 60, 90] as const;
@@ -130,7 +131,7 @@ function DayEntriesModal({
       >
         <div className="flex items-center justify-between border-b px-5 py-4" style={{ borderColor: "var(--border)" }}>
           <div className="min-w-0">
-            <h2 id="calendar-day-modal-title" className="truncate text-base font-bold" style={{ color: "var(--text)" }}>{heading}</h2>
+            <h2 id="calendar-day-modal-title" className={`truncate ${SECTION_TITLE}`} style={{ color: "var(--text)" }}>{heading}</h2>
             <p className="text-xs" style={{ color: "var(--text-mute)" }}>
               {entries.length} {entries.length === 1 ? "episode" : "episodes"}
             </p>
@@ -284,7 +285,7 @@ export function CalendarPage() {
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="flex items-center gap-2.5">
           <CalendarDays className="h-6 w-6" style={{ color: "var(--text-dim)" }} />
-          <h1 className="text-2xl font-bold" style={{ color: "var(--text)" }}>Calendar</h1>
+          <h1 className={PAGE_TITLE} style={{ color: "var(--text)" }}>Calendar</h1>
         </div>
 
         {!compact && (
@@ -357,7 +358,7 @@ export function CalendarPage() {
             <div className="space-y-6">
               {agendaGroups.map((group) => (
                 <div key={group.label} className="space-y-2">
-                  <h2 className="text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--text-mute)" }}>
+                  <h2 className={KICKER} style={{ color: "var(--text-mute)" }}>
                     {group.label}
                   </h2>
                   {group.entries.map((entry) => (
@@ -402,7 +403,7 @@ export function CalendarPage() {
                 Today
               </button>
             </div>
-            <p className="text-lg font-bold" style={{ color: "var(--text)" }}>
+            <p className={SECTION_TITLE} style={{ color: "var(--text)" }}>
               {monthCursor.toLocaleDateString(undefined, { month: "long", year: "numeric" })}
             </p>
           </div>
@@ -425,7 +426,7 @@ export function CalendarPage() {
             <div className="overflow-hidden rounded-2xl" style={{ border: "1px solid var(--border)" }}>
               <div className="grid grid-cols-7" style={{ borderBottom: "1px solid var(--border)" }}>
                 {WEEKDAY_LABELS.map((label) => (
-                  <div key={label} className="px-2 py-2 text-center text-2xs font-semibold uppercase tracking-wider" style={{ color: "var(--text-mute)" }}>
+                  <div key={label} className={`px-2 py-2 text-center ${MICRO_LABEL}`} style={{ color: "var(--text-mute)" }}>
                     {label}
                   </div>
                 ))}

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -35,6 +35,7 @@ import { useToast } from "../hooks/useToast";
 import { timeAgo, timeUntil } from "../utils/timeAgo";
 import { formatRating, ratingLabel } from "../utils/rating";
 import { useCachedState } from "../hooks/useCachedState";
+import { PAGE_TITLE, SECTION_TITLE, KICKER, MICRO_LABEL } from "../components/typography";
 
 /* ─── Skeleton placeholders ─── */
 
@@ -333,7 +334,7 @@ export function ContinueWatchingHero({
         <Poster src={s.poster} alt={s.name} className="h-full w-full" eager sizes="112px" />
       </div>
       <div className="relative z-10 min-w-0 flex-1">
-        <p className="text-2xs font-bold uppercase tracking-wider text-claw-text">Series &middot; In Progress</p>
+        <p className={`${MICRO_LABEL} text-claw-text`}>Series &middot; In Progress</p>
         <p className="mt-1 truncate font-heading text-xl font-extrabold tracking-tight" style={{ color: "var(--text)" }}>{s.name}</p>
         <p className="mt-0.5 text-sm" style={{ color: "var(--text-dim)" }}>
           S{s.lastSeason}:E{s.lastEpisode}
@@ -437,7 +438,7 @@ function SectionHeader({
   return (
     <div className="mb-4 flex items-center justify-between">
       <div className="flex items-center gap-3">
-        <h2 className="text-lg font-bold" style={{ color: "var(--text)" }}>{title}</h2>
+        <h2 className={SECTION_TITLE} style={{ color: "var(--text)" }}>{title}</h2>
         {count !== undefined && count > 0 && (
           <span
             className="rounded-full px-2.5 py-0.5 text-xs font-medium tabular-nums"
@@ -503,7 +504,7 @@ function DiscoverSubRow({
   return (
     <div>
       <div className="mb-2.5 flex items-center justify-between">
-        <h3 className="text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--text-mute)" }}>{label}</h3>
+        <h3 className={KICKER} style={{ color: "var(--text-mute)" }}>{label}</h3>
         {!loading && !failed && items.length > 0 && (
           <ScrollArrows canScrollLeft={scroll.canScrollLeft} canScrollRight={scroll.canScrollRight} onScroll={scroll.scroll} />
         )}
@@ -1097,9 +1098,9 @@ export function DashboardPage() {
                   <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-claw-400 opacity-75" />
                   <span className="relative inline-flex rounded-full h-2 w-2 bg-claw-500" />
                 </span>
-                <span className="text-xs font-semibold uppercase tracking-wider text-claw-text">Now Watching</span>
+                <span className={`${KICKER} text-claw-text`}>Now Watching</span>
               </div>
-              <p className="mt-1 truncate font-heading text-2xl font-extrabold tracking-tight" style={{ color: "var(--text)" }}>{activeCheckin.name}</p>
+              <p className={`mt-1 truncate ${PAGE_TITLE}`} style={{ color: "var(--text)" }}>{activeCheckin.name}</p>
               {activeCheckin.season != null && activeCheckin.episode != null && (
                 <p className="mt-1 text-sm" style={{ color: "var(--text-dim)" }}>
                   S{String(activeCheckin.season).padStart(2, "0")}:E{String(activeCheckin.episode).padStart(2, "0")}
@@ -1131,7 +1132,7 @@ export function DashboardPage() {
       {/* ── Live: Plex/Jellyfin scrobble sessions ── */}
       {nowPlaying.length > 0 && (
         <section className="space-y-2">
-          <h3 className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--text-mute)" }}>
+          <h3 className={`flex items-center gap-2 ${KICKER}`} style={{ color: "var(--text-mute)" }}>
             <span className="relative flex h-2 w-2">
               <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75" />
               <span className="relative inline-flex rounded-full h-2 w-2 bg-emerald-500" />

--- a/apps/web/src/pages/GamesPage.tsx
+++ b/apps/web/src/pages/GamesPage.tsx
@@ -11,6 +11,7 @@ import { preconnectToGameArtwork } from "../utils/preconnect";
 import { useCachedState } from "../hooks/useCachedState";
 import { formatPlaytime } from "../utils/playtime";
 import { formatRating, ratingLabel, RATING_MAX } from "../utils/rating";
+import { PAGE_TITLE, SECTION_TITLE } from "../components/typography";
 
 const SORT_OPTIONS: { value: GameSort; label: string }[] = [
   { value: "recent", label: "Recently Played" },
@@ -137,7 +138,7 @@ function AddGameModal({
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-center justify-between border-b px-5 py-4" style={{ borderColor: "var(--border)" }}>
-          <h3 id="add-game-modal-title" className="text-lg font-bold" style={{ color: "var(--text)" }}>Add a game</h3>
+          <h3 id="add-game-modal-title" className={SECTION_TITLE} style={{ color: "var(--text)" }}>Add a game</h3>
           <button onClick={onClose} aria-label="Close dialog" className="rounded-lg p-1.5 hover:bg-[var(--surface)] hover:text-[var(--text)]" style={{ color: "var(--text-mute)" }}>
             <X className="h-5 w-5" />
           </button>
@@ -384,7 +385,7 @@ export function GamesPage() {
   return (
     <div>
       <div className="mb-6 flex flex-wrap items-center justify-between gap-4">
-        <h1 className="text-2xl font-bold" style={{ color: "var(--text)" }}>Games</h1>
+        <h1 className={PAGE_TITLE} style={{ color: "var(--text)" }}>Games</h1>
         <button
           type="button"
           onClick={() => setShowAddModal(true)}

--- a/apps/web/src/pages/HistoryPage.tsx
+++ b/apps/web/src/pages/HistoryPage.tsx
@@ -6,6 +6,7 @@ import { DetailPanel, useDetailPanel } from "../components/MediaDetailPanel";
 import { useToast } from "../hooks/useToast";
 import { useCachedState } from "../hooks/useCachedState";
 import { relogWatchEvent } from "../utils/watchEvents";
+import { PAGE_TITLE, SECTION_TITLE, KICKER } from "../components/typography";
 
 const PAGE_SIZE = 25;
 
@@ -184,7 +185,7 @@ export function HistoryPage() {
   return (
     <div className="mx-auto max-w-3xl space-y-6">
       <div className="flex flex-wrap items-center justify-between gap-3">
-        <h1 className="text-2xl font-bold" style={{ color: "var(--text)" }}>Watch History</h1>
+        <h1 className={PAGE_TITLE} style={{ color: "var(--text)" }}>Watch History</h1>
 
         <div className="relative inline-flex rounded-full p-0.5" style={{ background: "var(--surface-strong)", border: "1px solid var(--border)" }}>
           {(["all", "movie", "episode"] as const).map((opt) => (
@@ -221,7 +222,7 @@ export function HistoryPage() {
       ) : error && events.length === 0 ? (
         <div className="mx-auto max-w-lg rounded-2xl p-8 text-center" style={{ border: "1px solid rgba(244,63,94,0.2)", background: "rgba(244,63,94,0.05)" }}>
           <AlertCircle className="mx-auto h-12 w-12 text-rose-500" />
-          <p className="mt-3 text-lg font-semibold text-rose-500">{error}</p>
+          <p className={`mt-3 ${SECTION_TITLE} text-rose-500`}>{error}</p>
         </div>
       ) : events.length === 0 ? (
         <div className="glass-panel rounded-2xl p-8 text-center" style={{ border: "1px solid var(--border)", background: "var(--bg-1)" }}>
@@ -244,7 +245,7 @@ export function HistoryPage() {
         <div className="space-y-6">
           {groups.map((group) => (
             <div key={`${group.label}-${group.events[0].id}`} className="space-y-2">
-              <h2 className="text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--text-mute)" }}>
+              <h2 className={KICKER} style={{ color: "var(--text-mute)" }}>
                 {group.label}
               </h2>
               {group.events.map((event) => (

--- a/apps/web/src/pages/ListsPage.tsx
+++ b/apps/web/src/pages/ListsPage.tsx
@@ -10,6 +10,7 @@ import { useCachedState } from "../hooks/useCachedState";
 import { useScrollLock } from "../hooks/useScrollLock";
 import { useEscapeKey } from "../hooks/useEscapeKey";
 import { mergeByRelevance } from "../utils/mergeSearchResults";
+import { PAGE_TITLE, SECTION_TITLE } from "../components/typography";
 
 type SortOption = "added" | "name" | "year" | "rating";
 
@@ -191,7 +192,7 @@ function AddItemModal({
       >
         {/* Header */}
         <div className="flex items-center justify-between border-b px-5 py-4" style={{ borderColor: "var(--border)" }}>
-          <h3 id="add-item-modal-title" className="text-lg font-bold" style={{ color: "var(--text)" }}>Add to {listName}</h3>
+          <h3 id="add-item-modal-title" className={SECTION_TITLE} style={{ color: "var(--text)" }}>Add to {listName}</h3>
           <button onClick={onClose} aria-label="Close dialog" className="rounded-lg p-1.5 hover:bg-[var(--surface)] hover:text-[var(--text)]" style={{ color: "var(--text-mute)" }}>
             <X className="h-5 w-5" />
           </button>
@@ -661,7 +662,7 @@ export function ListsPage() {
             <div className="flex h-20 w-20 items-center justify-center rounded-full ring-1" style={{ backgroundColor: "var(--surface)", "--tw-ring-color": "var(--border)" } as React.CSSProperties}>
               <FolderOpen className="h-10 w-10" style={{ color: "var(--text-mute)" }} />
             </div>
-            <p className="mt-4 text-lg font-semibold" style={{ color: "var(--text-dim)" }}>
+            <p className={`mt-4 ${SECTION_TITLE}`} style={{ color: "var(--text-dim)" }}>
               {listNotFound ? "That list no longer exists" : "No list selected"}
             </p>
             <p className="mt-1 text-sm" style={{ color: "var(--text-mute)" }}>
@@ -690,7 +691,7 @@ export function ListsPage() {
                       onBlur={cancelRename}
                       onKeyDown={(e) => { if (e.key === "Escape") cancelRename(); }}
                       aria-label={`Rename list ${selectedList.name}`}
-                      className="min-w-0 flex-1 rounded-lg border px-3 py-1.5 text-2xl font-bold focus:border-claw-500 focus:outline-none focus:ring-2 focus:ring-claw-500/15"
+                      className={`min-w-0 flex-1 rounded-lg border px-3 py-1.5 ${PAGE_TITLE} focus:border-claw-500 focus:outline-none focus:ring-2 focus:ring-claw-500/15`}
                       style={{ borderColor: "var(--border)", color: "var(--text)", background: "var(--bg-1)" }}
                     />
                     <button
@@ -706,7 +707,7 @@ export function ListsPage() {
                   </form>
                 ) : (
                   <div className="flex items-center gap-2">
-                    <h2 className="truncate text-2xl font-bold" style={{ color: "var(--text)" }}>{selectedList.name}</h2>
+                    <h2 className={`truncate ${PAGE_TITLE}`} style={{ color: "var(--text)" }}>{selectedList.name}</h2>
                     <button
                       type="button"
                       onClick={() => { setRenamingListId(selectedList.id); setRenameValue(selectedList.name); }}
@@ -786,7 +787,7 @@ export function ListsPage() {
                 <div className="flex h-20 w-20 items-center justify-center rounded-full ring-1" style={{ backgroundColor: "var(--surface)", "--tw-ring-color": "var(--border)" } as React.CSSProperties}>
                   <FolderOpen className="h-10 w-10" style={{ color: "var(--text-mute)" }} />
                 </div>
-                <p className="mt-4 text-lg font-semibold" style={{ color: "var(--text-dim)" }}>This list is empty</p>
+                <p className={`mt-4 ${SECTION_TITLE}`} style={{ color: "var(--text-dim)" }}>This list is empty</p>
                 <p className="mt-1 text-sm" style={{ color: "var(--text-mute)" }}>
                   Click <span className="font-semibold text-claw-text">+ Add</span> to search and add titles.
                 </p>
@@ -796,7 +797,7 @@ export function ListsPage() {
                 <div className="flex h-20 w-20 items-center justify-center rounded-full ring-1" style={{ backgroundColor: "var(--surface)", "--tw-ring-color": "var(--border)" } as React.CSSProperties}>
                   <Search className="h-10 w-10" style={{ color: "var(--text-mute)" }} />
                 </div>
-                <p className="mt-4 text-lg font-semibold" style={{ color: "var(--text-dim)" }}>No matches</p>
+                <p className={`mt-4 ${SECTION_TITLE}`} style={{ color: "var(--text-dim)" }}>No matches</p>
                 <p className="mt-1 text-sm" style={{ color: "var(--text-mute)" }}>Try a different search term.</p>
               </div>
             ) : (

--- a/apps/web/src/pages/NotFoundPage.tsx
+++ b/apps/web/src/pages/NotFoundPage.tsx
@@ -1,11 +1,12 @@
 import { Link } from "react-router";
 import { Clapperboard } from "lucide-react";
+import { PAGE_TITLE } from "../components/typography";
 
 export function NotFoundPage() {
   return (
     <div className="flex flex-col items-center justify-center py-24 text-center">
       <Clapperboard className="h-12 w-12" style={{ color: "var(--text-mute)" }} />
-      <h1 className="mt-4 text-2xl font-bold" style={{ color: "var(--text)" }}>
+      <h1 className={`mt-4 ${PAGE_TITLE}`} style={{ color: "var(--text)" }}>
         Page not found
       </h1>
       <p className="mt-2 text-sm" style={{ color: "var(--text-dim)" }}>

--- a/apps/web/src/pages/ProfileSwitcher.tsx
+++ b/apps/web/src/pages/ProfileSwitcher.tsx
@@ -5,6 +5,7 @@ import { BRAND_WORDMARK, BrandLockup, BrandMark } from "../components/BrandMark"
 import { useEscapeKey } from "../hooks/useEscapeKey";
 import { useFocusTrap } from "../hooks/useFocusTrap";
 import { useScrollLock } from "../hooks/useScrollLock";
+import { SECTION_TITLE } from "../components/typography";
 
 // Standing in for the switcher's own title. As a full page (first run) it is the
 // document's h1; opened as a modal over the app, the page behind already owns the
@@ -106,7 +107,7 @@ function CreateProfileForm({
   return (
     <form onSubmit={submit} className="space-y-4">
       <div>
-        <Heading className="text-lg font-semibold" style={{ color: "var(--text)" }}>{title}</Heading>
+        <Heading className={SECTION_TITLE} style={{ color: "var(--text)" }}>{title}</Heading>
         <p className="mt-1 text-sm leading-relaxed" style={{ color: "var(--text-mute)" }}>{subtitle}</p>
       </div>
       <input
@@ -193,7 +194,7 @@ function PinPrompt({
   return (
     <form onSubmit={submit} className="space-y-4">
       <div>
-        <Heading className="text-lg font-semibold" style={{ color: "var(--text)" }}>Enter PIN for {profile.name}</Heading>
+        <Heading className={SECTION_TITLE} style={{ color: "var(--text)" }}>Enter PIN for {profile.name}</Heading>
         <p className="mt-1 text-sm leading-relaxed" style={{ color: "var(--text-mute)" }}>This profile is PIN-protected.</p>
       </div>
       <input
@@ -257,7 +258,7 @@ function ProfilePicker({
   return (
     <div className="space-y-4">
       <div>
-        <Heading className="text-lg font-semibold" style={{ color: "var(--text)" }}>Who's watching?</Heading>
+        <Heading className={SECTION_TITLE} style={{ color: "var(--text)" }}>Who's watching?</Heading>
         <p className="mt-1 text-sm leading-relaxed" style={{ color: "var(--text-mute)" }}>Choose a profile to continue.</p>
       </div>
       <div className="space-y-2">

--- a/apps/web/src/pages/SearchPage.tsx
+++ b/apps/web/src/pages/SearchPage.tsx
@@ -14,6 +14,7 @@ import {
   GENRE_OPTIONS,
   SORT_LABELS,
 } from "../hooks/useSearchFilters";
+import { PAGE_TITLE, SECTION_TITLE, MICRO_LABEL } from "../components/typography";
 
 /* ─── Helpers ─── */
 
@@ -411,7 +412,7 @@ export function SearchPage() {
 
             {/* Year range */}
             <div className="flex flex-col gap-1">
-              <label className="text-2xs font-medium uppercase tracking-wider" style={{ color: "var(--text-mute)" }}>Year</label>
+              <label className={MICRO_LABEL} style={{ color: "var(--text-mute)" }}>Year</label>
               <div className="flex gap-1.5">
                 <input
                   type="number"
@@ -470,7 +471,7 @@ export function SearchPage() {
           <div className="flex h-28 w-28 items-center justify-center rounded-full ring-1" style={{ backgroundColor: "var(--surface)", "--tw-ring-color": "var(--border-strong)" } as React.CSSProperties}>
             <Search className="h-14 w-14" style={{ color: "var(--text-mute)" }} />
           </div>
-          <p className="mt-6 text-2xl font-bold" style={{ color: "var(--text)" }}>Discover your next favorite</p>
+          <p className={`mt-6 ${PAGE_TITLE}`} style={{ color: "var(--text)" }}>Discover your next favorite</p>
           <p className="mt-2 max-w-sm" style={{ color: "var(--text-mute)" }}>
             Search for movies and series to add them to your lists and track what you watch.
           </p>
@@ -483,7 +484,7 @@ export function SearchPage() {
           <div className="flex h-24 w-24 items-center justify-center rounded-full ring-1" style={{ backgroundColor: "var(--surface)", "--tw-ring-color": "var(--border-strong)" } as React.CSSProperties}>
             <Filter className="h-12 w-12" style={{ color: "var(--text-mute)" }} />
           </div>
-          <p className="mt-5 text-lg font-semibold" style={{ color: "var(--text-dim)" }}>
+          <p className={`mt-5 ${SECTION_TITLE}`} style={{ color: "var(--text-dim)" }}>
             {needsTmdb ? "Search needs a TMDB API key" : "No results found"}
           </p>
           <p className="mt-1 text-sm" style={{ color: "var(--text-mute)" }}>
@@ -603,7 +604,7 @@ function FilterSelect({
   const id = useId();
   return (
     <div className="flex flex-col gap-1">
-      <label htmlFor={id} className="text-2xs font-medium uppercase tracking-wider" style={{ color: "var(--text-mute)" }}>{label}</label>
+      <label htmlFor={id} className={MICRO_LABEL} style={{ color: "var(--text-mute)" }}>{label}</label>
       <div className="relative">
         <select
           id={id}
@@ -836,7 +837,7 @@ function ResultCard({
             className="absolute left-0 right-0 overflow-hidden rounded-xl shadow-lg"
             style={{ background: "var(--bg-0)", borderWidth: 1, borderStyle: "solid", borderColor: "var(--border)" }}
           >
-            <p className="px-3 py-2.5 text-2xs font-semibold uppercase tracking-wider" style={{ borderBottomWidth: 1, borderBottomStyle: "solid", borderBottomColor: "var(--border)", color: "var(--text-mute)" }}>
+            <p className={`px-3 py-2.5 ${MICRO_LABEL}`} style={{ borderBottomWidth: 1, borderBottomStyle: "solid", borderBottomColor: "var(--border)", color: "var(--text-mute)" }}>
               Add to list
             </p>
             {lists.length === 0 && !creating && (

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -15,6 +15,7 @@ import { PreferencesSettings } from "../components/settings/PreferencesSettings"
 import { PushSettings } from "../components/settings/PushSettings";
 import { ProfileSettings } from "../components/settings/ProfileSettings";
 import { JobStatusSettings } from "../components/settings/JobStatusSettings";
+import { PAGE_TITLE } from "../components/typography";
 
 declare const __APP_VERSION__: string;
 const APP_VERSION = typeof __APP_VERSION__ !== "undefined" ? __APP_VERSION__ : "unknown";
@@ -203,7 +204,7 @@ export function SettingsPage() {
 
   return (
     <div className="mx-auto max-w-2xl space-y-4">
-      <h1 className="text-2xl font-bold">Settings</h1>
+      <h1 className={PAGE_TITLE}>Settings</h1>
 
       <div className="relative">
         <Search size={16} className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2" style={{ color: "var(--text-mute)" }} />

--- a/apps/web/src/pages/SetupWizard.tsx
+++ b/apps/web/src/pages/SetupWizard.tsx
@@ -4,6 +4,7 @@ import { api, ApiError, runtimeConfig } from "../api";
 import { BrandLockup } from "../components/BrandMark";
 import { StatusBadge } from "../components/settings/StatusBadge";
 import { TraktSettings } from "../components/settings/TraktSettings";
+import { SECTION_TITLE } from "../components/typography";
 
 type Step = "token" | "tmdb" | "trakt" | "done";
 
@@ -113,7 +114,7 @@ function TokenStep({ onVerified }: { onVerified: (tmdbConfigured: boolean) => vo
       <div>
         {/* Not "Welcome to Cataloggy": the lockup above already says the name,
             and a step's heading is better spent saying what the step wants. */}
-        <h1 className="text-lg font-semibold">Connect your server</h1>
+        <h1 className={SECTION_TITLE}>Connect your server</h1>
         <p className="mt-1 text-sm leading-relaxed" style={{ color: "var(--text-mute)" }}>
           Paste the API token your server was configured with to get started.
         </p>
@@ -155,7 +156,7 @@ function TmdbStep({ configured, onContinue, onBack }: { configured: boolean; onC
   return (
     <div className="space-y-4">
       <div>
-        <h1 className="text-lg font-semibold">TMDB Metadata</h1>
+        <h1 className={SECTION_TITLE}>TMDB Metadata</h1>
         <p className="mt-1 text-sm leading-relaxed" style={{ color: "var(--text-mute)" }}>
           Cataloggy uses TMDB to fetch posters, ratings, and details for movies and shows.
         </p>
@@ -189,7 +190,7 @@ function TraktStep({ onContinue, onBack }: { onContinue: () => void; onBack: () 
   return (
     <div className="space-y-4">
       <div>
-        <h1 className="text-lg font-semibold">Connect Trakt (optional)</h1>
+        <h1 className={SECTION_TITLE}>Connect Trakt (optional)</h1>
         <p className="mt-1 text-sm leading-relaxed" style={{ color: "var(--text-mute)" }}>
           Sync your watch history and watchlist from Trakt. You can also do this later in Settings.
         </p>
@@ -217,7 +218,7 @@ function DoneStep({ onFinish, onBack }: { onFinish: () => void; onBack: () => vo
         <Check className="h-7 w-7 text-emerald-600" />
       </div>
       <div>
-        <h1 className="text-lg font-semibold">You're all set</h1>
+        <h1 className={SECTION_TITLE}>You're all set</h1>
         <p className="mt-1 text-sm leading-relaxed" style={{ color: "var(--text-mute)" }}>
           Start searching for movies and shows to build your catalog.
         </p>

--- a/apps/web/src/pages/StatsPage.tsx
+++ b/apps/web/src/pages/StatsPage.tsx
@@ -5,6 +5,7 @@ import { TicketTile } from "../components/TicketTile";
 import { buildTmdbSrcSet, POSTER_GRID_SIZES } from "../components/Poster";
 import { useCachedState } from "../hooks/useCachedState";
 import { formatRating, ratingLabel } from "../utils/rating";
+import { PAGE_TITLE, SECTION_TITLE, KICKER } from "../components/typography";
 
 const MONTH_NAMES = [
   "January", "February", "March", "April", "May", "June",
@@ -79,10 +80,10 @@ export function StatsPage() {
   if (error) {
     return (
       <div className="mx-auto max-w-4xl space-y-6">
-        <h1 className="text-2xl font-bold" style={{ color: "var(--text)" }}>Watch Statistics</h1>
+        <h1 className={PAGE_TITLE} style={{ color: "var(--text)" }}>Watch Statistics</h1>
         <div className="mx-auto max-w-lg rounded-2xl p-8 text-center" style={{ border: "1px solid rgba(244,63,94,0.2)", background: "rgba(244,63,94,0.05)" }}>
           <AlertCircle className="mx-auto h-12 w-12 text-rose-500" />
-          <p className="mt-3 text-lg font-semibold text-rose-500">{error}</p>
+          <p className={`mt-3 ${SECTION_TITLE} text-rose-500`}>{error}</p>
         </div>
       </div>
     );
@@ -91,7 +92,7 @@ export function StatsPage() {
   if (loading) {
     return (
       <div className="mx-auto max-w-4xl space-y-6">
-        <h1 className="text-2xl font-bold" style={{ color: "var(--text)" }}>Watch Statistics</h1>
+        <h1 className={PAGE_TITLE} style={{ color: "var(--text)" }}>Watch Statistics</h1>
         <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
           {Array.from({ length: 4 }).map((_, i) => (
             <div key={i} className="skeleton h-28 rounded-2xl" />
@@ -121,7 +122,7 @@ export function StatsPage() {
 
   return (
     <div className="mx-auto max-w-4xl space-y-8">
-      <h1 className="text-2xl font-bold" style={{ color: "var(--text)" }}>Watch Statistics</h1>
+      <h1 className={PAGE_TITLE} style={{ color: "var(--text)" }}>Watch Statistics</h1>
 
       {/* Summary tiles */}
       {stats && (
@@ -146,7 +147,7 @@ export function StatsPage() {
       {detailed && detailed.monthly.length > 0 && (
         <section className="glass-panel rounded-2xl p-5" style={{ border: "1px solid var(--border)", background: "var(--bg-1)" }}>
           <div className="mb-4 flex items-center justify-between gap-3">
-            <h2 className="text-lg font-semibold" style={{ color: "var(--text)" }}>Monthly Activity</h2>
+            <h2 className={SECTION_TITLE} style={{ color: "var(--text)" }}>Monthly Activity</h2>
             {momComparison && (
               <span
                 className={`flex items-center gap-1 text-xs font-medium ${
@@ -252,7 +253,7 @@ export function StatsPage() {
       {/* Genre distribution */}
       {detailed && detailed.genreDistribution.length > 0 && (
         <section className="glass-panel rounded-2xl p-5" style={{ border: "1px solid var(--border)", background: "var(--bg-1)" }}>
-          <h2 className="mb-4 text-lg font-semibold" style={{ color: "var(--text)" }}>Top Genres</h2>
+          <h2 className={`mb-4 ${SECTION_TITLE}`} style={{ color: "var(--text)" }}>Top Genres</h2>
           <div className="space-y-2.5">
             {detailed.genreDistribution.map((g) => (
               <div key={g.genre} className="flex items-center gap-3">
@@ -277,7 +278,7 @@ export function StatsPage() {
       {/* Top rated watched content */}
       {detailed && detailed.topRated.length > 0 && (
         <section className="glass-panel rounded-2xl p-5" style={{ border: "1px solid var(--border)", background: "var(--bg-1)" }}>
-          <h2 className="mb-4 flex items-center gap-2 text-lg font-semibold" style={{ color: "var(--text)" }}>
+          <h2 className={`mb-4 flex items-center gap-2 ${SECTION_TITLE}`} style={{ color: "var(--text)" }}>
             <Star className="h-5 w-5 text-amber-400" /> Top Rated Watched
           </h2>
           <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-5">
@@ -319,7 +320,7 @@ export function StatsPage() {
       {/* Year in Review */}
       <section className="glass-panel rounded-2xl p-5" style={{ border: "1px solid var(--border)", background: "var(--bg-1)" }}>
         <div className="mb-4 flex items-center justify-between gap-3">
-          <h2 className="text-lg font-semibold" style={{ color: "var(--text)" }}>Year in Review</h2>
+          <h2 className={SECTION_TITLE} style={{ color: "var(--text)" }}>Year in Review</h2>
           <select
             aria-label="Year in review: year"
             value={year}
@@ -346,7 +347,7 @@ export function StatsPage() {
 
             {yearReview.topGenres.length > 0 && (
               <div>
-                <h3 className="mb-2 text-sm font-semibold" style={{ color: "var(--text-dim)" }}>Top Genres</h3>
+                <h3 className={`mb-2 ${KICKER}`} style={{ color: "var(--text-dim)" }}>Top Genres</h3>
                 <div className="flex flex-wrap gap-2">
                   {yearReview.topGenres.map((g) => (
                     <span
@@ -363,7 +364,7 @@ export function StatsPage() {
 
             {yearReview.topRated.length > 0 && (
               <div>
-                <h3 className="mb-2 flex items-center gap-2 text-sm font-semibold" style={{ color: "var(--text-dim)" }}>
+                <h3 className={`mb-2 flex items-center gap-2 ${KICKER}`} style={{ color: "var(--text-dim)" }}>
                   <Star className="h-4 w-4 text-amber-400" /> Top Rated Picks
                 </h3>
                 <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-5">
@@ -427,7 +428,7 @@ function MilestoneBadges({
 
   return (
     <section className="glass-panel rounded-2xl p-5" style={{ border: "1px solid var(--border)", background: "var(--bg-1)" }}>
-      <h2 className="mb-4 flex items-center gap-2 text-lg font-semibold" style={{ color: "var(--text)" }}>
+      <h2 className={`mb-4 flex items-center gap-2 ${SECTION_TITLE}`} style={{ color: "var(--text)" }}>
         <Award className="h-5 w-5 text-amber-400" /> Achievements
       </h2>
       {earned.length > 0 ? (


### PR DESCRIPTION
Consolidates the app's heading and label typography into a single source of truth, eliminating inconsistent styling across pages and components.

## Summary

Before this change, typography styles were scattered throughout the codebase with the same semantic roles spelled multiple different ways. For example, page titles used `text-2xl font-bold` on some pages but `font-heading text-2xl font-extrabold tracking-tight` on others. This PR creates a new `typography.ts` module that defines four typography tiers as reusable constants, ensuring consistent visual hierarchy across the entire app.

## Changes

- **New file**: `apps/web/src/components/typography.ts`
  - `PAGE_TITLE`: The loudest tier for page `h1`s and panel titles
  - `SECTION_TITLE`: Headers for cards, panels, and content sections
  - `KICKER`: Uppercase labels for content blocks (e.g., "Overview", "Cast")
  - `MICRO_LABEL`: Smaller uppercase labels for form fields and column headings
  - Comprehensive documentation explaining the rationale for each tier and why they're kept together

- **Updated pages and components**: Applied the new constants across:
  - Pages: `StatsPage`, `DashboardPage`, `ListsPage`, `CalendarPage`, `SearchPage`, `SetupWizard`, `HistoryPage`, `ProfileSwitcher`, `GamesPage`, `NotFoundPage`, `SettingsPage`
  - Components: `GameDetailPanel`, `DetailPanel`, `RatingsSection`, `CommandPalette`, `CastSection`, `ProvidersSection`, `RecommendationsSection`, `SeasonsSection`, `WatchDateModal`, `ErrorBoundary`, `TicketTile`, `CheckInModal`, `WatchHistorySection`, `AddonSettings`, `Section`

## Implementation Details

- Each constant bundles size, weight, and tracking together since these three properties define a tier's recognizability
- Color remains with the caller, allowing the same tier to use different colors (`--text`, `--text-mute`, `--accent-text`) depending on context
- The constants use Tailwind classes for consistency with the existing codebase
- Documentation notes two intentional exceptions: filled badges and the brand tagline, which have their own spacing requirements

https://claude.ai/code/session_014ZkdUjJX9ZH58qmrQbW7bY