### PR TITLE
Consolidate button and status styles into reusable components

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -151,7 +151,10 @@
         height: 32px;
         border-radius: 50%;
         border: 3px solid rgba(150, 150, 150, 0.25);
-        border-top-color: #d6502a;
+        /* theme-init.js sets --loader-accent from the live theme's --accent
+           before this paints. The fallback is the light theme's accent, for
+           the case where that script did not run at all. */
+        border-top-color: var(--loader-accent, #d97742);
         animation: initial-loader-spin 0.8s linear infinite;
       }
       @keyframes initial-loader-spin {

--- a/apps/web/public/theme-init.js
+++ b/apps/web/public/theme-init.js
@@ -8,6 +8,19 @@
     letterboxd: "#14181c",
   };
 
+  // Each theme's --accent, for the pre-hydration spinner in index.html. That
+  // spinner paints before the app's CSS exists, so it cannot read --accent and
+  // used to be a hard-coded orange — which is the wrong brand colour on the
+  // blue and red themes, on the one frame a visitor sees first. Keep in sync
+  // with the --accent declarations in apps/web/src/index.css.
+  var themeAccent = {
+    light: "#d97742",
+    dark: "#e89163",
+    glass: "#0a84ff",
+    midnight: "#e02f44",
+    letterboxd: "#ff8000",
+  };
+
   var stored = null;
   try {
     stored = localStorage.getItem("cataloggy:theme");
@@ -23,6 +36,7 @@
   document.documentElement.setAttribute("data-theme", theme);
   document.documentElement.style.colorScheme = theme === "light" ? "light" : "dark";
   document.documentElement.style.backgroundColor = themeBg[theme];
+  document.documentElement.style.setProperty("--loader-accent", themeAccent[theme]);
 
   var meta = document.querySelector('meta[name="theme-color"]');
   if (meta) meta.setAttribute("content", themeBg[theme]);

--- a/apps/web/src/components/ErrorBoundary.tsx
+++ b/apps/web/src/components/ErrorBoundary.tsx
@@ -42,14 +42,14 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
             <button
               type="button"
               onClick={this.resetErrorBoundary}
-              className="rounded-lg border border-claw-500 px-4 py-2 text-claw-text"
+              className="btn-secondary"
             >
               Try Again
             </button>
             <button
               type="button"
               onClick={() => window.location.reload()}
-              className="rounded-lg bg-claw-500 px-4 py-2 text-claw-on"
+              className="btn-primary"
             >
               Reload
             </button>

--- a/apps/web/src/components/GameDetailPanel.tsx
+++ b/apps/web/src/components/GameDetailPanel.tsx
@@ -209,8 +209,10 @@ export function GameDetailPanel({
         <button
           type="button"
           onClick={requestClose}
-          className="absolute right-4 top-4 z-30 flex h-9 w-9 items-center justify-center rounded-full shadow-e2 backdrop-blur transition-colors hover:text-white"
-          style={{ background: "color-mix(in srgb, var(--bg-0) 80%, transparent)", color: "var(--bg-2)" }}
+          // See the matching close button in media-detail/DetailPanel.tsx: white
+          // on hover is invisible against the light theme's cream circle.
+          className="absolute right-4 top-4 z-30 flex h-9 w-9 items-center justify-center rounded-full shadow-e2 backdrop-blur transition-colors hover:text-[var(--text)]"
+          style={{ background: "color-mix(in srgb, var(--bg-0) 80%, transparent)", color: "var(--text-dim)" }}
           aria-label="Close detail panel"
         >
           <X className="h-4 w-4" />
@@ -301,15 +303,14 @@ export function GameDetailPanel({
                   type="button"
                   disabled={deleting}
                   onClick={() => void handleDelete()}
-                  className="rounded-lg bg-rose-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-rose-700 disabled:opacity-50"
+                  className="btn-danger btn-sm"
                 >
                   {deleting ? "Removing..." : "Confirm remove"}
                 </button>
                 <button
                   type="button"
                   onClick={() => setConfirmDelete(false)}
-                  className="rounded-lg px-3 py-1.5 text-xs font-semibold"
-                  style={{ color: "var(--text-mute)" }}
+                  className="btn-secondary btn-sm"
                 >
                   Cancel
                 </button>

--- a/apps/web/src/components/OfflineBanner.tsx
+++ b/apps/web/src/components/OfflineBanner.tsx
@@ -20,7 +20,7 @@ export function OfflineBanner() {
     <div
       role="status"
       aria-live="polite"
-      className="overlay-dialog sticky top-[76px] z-20 mb-5 flex items-center gap-2.5 rounded-xl px-3.5 py-2.5 text-sm shadow-e2"
+      className="glass-surface overlay-dialog sticky top-[76px] z-20 mb-5 flex items-center gap-2.5 rounded-xl px-3.5 py-2.5 text-sm shadow-e2"
       style={{
         background: "var(--surface-strong)",
         border: "1px solid var(--border-strong)",

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -252,7 +252,7 @@ export function Sidebar({
           <button
             type="button"
             onClick={dismissHint}
-            className="mt-2 rounded-md bg-claw-500 px-2.5 py-1 text-2xs font-semibold text-claw-on transition-colors hover:bg-claw-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-400"
+            className="btn-primary btn-xs mt-2"
           >
             Got it
           </button>

--- a/apps/web/src/components/ThemeToggle.tsx
+++ b/apps/web/src/components/ThemeToggle.tsx
@@ -78,7 +78,12 @@ export function ThemeToggle({ theme, onChange }: { theme: Theme; onChange: (next
             openMenu();
           }
         }}
-        className="flex h-10 w-10 flex-none items-center justify-center rounded-full transition-colors active:scale-95 sm:h-9 sm:w-9"
+        // `transition-colors` here meant the active:scale-95 press had no
+        // transition to run on, so the button snapped down and back instead of
+        // pressing. The property list stays explicit rather than becoming
+        // `transition-all`, which would also animate layout — see the base-layer
+        // note in index.css.
+        className="flex h-10 w-10 flex-none items-center justify-center rounded-full transition-[color,background-color,border-color,transform] duration-200 ease-in-out active:scale-95 sm:h-9 sm:w-9"
         style={{ border: "1px solid var(--border-strong)", background: "var(--surface)", color: "var(--text)" }}
       >
         <Palette className="h-4 w-4" />

--- a/apps/web/src/components/UpdatePrompt.tsx
+++ b/apps/web/src/components/UpdatePrompt.tsx
@@ -40,7 +40,7 @@ export function UpdatePrompt() {
       // -translate-x-1/2, and a running keyframe on `transform` would replace
       // that translate for its duration, lurching the banner sideways. Opacity
       // doesn't collide.
-      className={`overlay-fade fixed bottom-6 left-1/2 z-[110] flex max-w-[calc(100vw-2rem)] -translate-x-1/2 flex-wrap items-center justify-center gap-3 rounded-xl border px-5 py-3.5 shadow-e2 max-sm:bottom-[calc(5rem+env(safe-area-inset-bottom))] ${exiting ? "overlay-exit" : ""}`}
+      className={`glass-surface overlay-fade fixed bottom-6 left-1/2 z-[110] flex max-w-[calc(100vw-2rem)] -translate-x-1/2 flex-wrap items-center justify-center gap-3 rounded-xl border px-5 py-3.5 shadow-e2 max-sm:bottom-[calc(5rem+env(safe-area-inset-bottom))] ${exiting ? "overlay-exit" : ""}`}
       style={{ borderLeftWidth: "4px", borderColor: "var(--border)", background: "var(--bg-1)" }}
       onAnimationEnd={onExitAnimationEnd}
     >
@@ -51,7 +51,7 @@ export function UpdatePrompt() {
       <button
         type="button"
         onClick={() => updateSW?.(true)}
-        className="flex-none rounded-md bg-claw-500 px-3 py-1.5 text-sm font-medium text-claw-on hover:bg-claw-600"
+        className="btn-primary btn-sm flex-none"
       >
         Reload
       </button>

--- a/apps/web/src/components/media-detail/CheckInBlock.tsx
+++ b/apps/web/src/components/media-detail/CheckInBlock.tsx
@@ -38,15 +38,14 @@ export function CheckInBlock({
           <button
             type="button"
             onClick={() => onCheckout(false)}
-            className="flex-1 rounded-xl border px-3 py-2 text-xs font-semibold transition-colors hover:bg-[var(--surface-strong)]"
-            style={{ borderColor: "var(--border-strong)", background: "var(--surface)", color: "var(--text-dim)" }}
+            className="btn-secondary btn-sm flex-1"
           >
             Check Out
           </button>
           <button
             type="button"
             onClick={() => onCheckout(true)}
-            className="flex-1 rounded-xl bg-claw-500 px-3 py-2 text-xs font-semibold text-claw-on hover:bg-claw-600 transition-colors"
+            className="btn-primary btn-sm flex-1"
           >
             Finished &amp; Log
           </button>
@@ -65,8 +64,7 @@ export function CheckInBlock({
           onStartCheckin();
         }
       }}
-      className="flex w-full items-center justify-center gap-2 rounded-xl border px-4 py-2.5 text-sm font-semibold text-[var(--text-dim)] transition-colors hover:border-claw-500/40 hover:bg-claw-500/5 hover:text-claw-text"
-      style={{ borderColor: "var(--border-strong)", background: "var(--surface)" }}
+      className="btn-secondary w-full"
     >
       <Radio className="h-4 w-4" /> Check In
     </button>

--- a/apps/web/src/components/media-detail/CheckInModal.tsx
+++ b/apps/web/src/components/media-detail/CheckInModal.tsx
@@ -52,7 +52,7 @@ export function CheckInModal({
         aria-modal="true"
         aria-labelledby="checkin-modal-title"
         tabIndex={-1}
-        className={`overlay-dialog w-full max-w-sm rounded-3xl border shadow-e3 ${exiting ? "overlay-exit" : ""}`}
+        className={`glass-surface overlay-dialog w-full max-w-sm rounded-3xl border shadow-e3 ${exiting ? "overlay-exit" : ""}`}
         style={{ borderColor: "var(--border)", background: "var(--bg-0)" }}
         onClick={(e) => e.stopPropagation()}
         onAnimationEnd={onExitAnimationEnd}
@@ -94,14 +94,13 @@ export function CheckInModal({
           <div className="flex gap-3 pt-1">
             <button
               type="button" onClick={requestClose}
-              className="flex-1 rounded-xl px-4 py-2.5 text-sm font-medium transition-colors hover:bg-[var(--surface-strong)]"
-              style={{ background: "var(--surface)", color: "var(--text-dim)" }}
+              className="btn-secondary flex-1"
             >
               Cancel
             </button>
             <button
               type="button" disabled={saving} onClick={() => void submit()}
-              className="flex-1 flex items-center justify-center gap-2 rounded-xl bg-claw-500 px-4 py-2.5 text-sm font-semibold text-claw-on hover:bg-claw-600 disabled:opacity-50 transition-colors"
+              className="btn-primary flex-1"
             >
               <Radio className="h-3.5 w-3.5" />
               {saving ? "Checking in…" : "Check In"}

--- a/apps/web/src/components/media-detail/DetailPanel.tsx
+++ b/apps/web/src/components/media-detail/DetailPanel.tsx
@@ -309,8 +309,11 @@ export function DetailPanel({
           {/* Close */}
           <button
             type="button" onClick={requestClose}
-            className="absolute right-4 top-4 z-30 flex h-9 w-9 items-center justify-center rounded-full shadow-e2 backdrop-blur transition-colors hover:text-white"
-            style={{ background: "color-mix(in srgb, var(--bg-0) 80%, transparent)", color: "var(--bg-2)" }}
+            // Hovers to --text, not white: the light theme's circle is a
+            // translucent cream, and white-on-cream made the X disappear under
+            // the pointer on the one theme where it mattered most.
+            className="absolute right-4 top-4 z-30 flex h-9 w-9 items-center justify-center rounded-full shadow-e2 backdrop-blur transition-colors hover:text-[var(--text)]"
+            style={{ background: "color-mix(in srgb, var(--bg-0) 80%, transparent)", color: "var(--text-dim)" }}
             aria-label="Close detail panel"
           >
             <X className="h-4 w-4" />
@@ -367,8 +370,11 @@ export function DetailPanel({
                   {item.certification}
                 </span>
               )}
+              {/* No `ring-1` on the chip: .status-chip draws its own hairline
+                  from the same token as its text, and a utility ring would
+                  outrank it. */}
               {item.status && (
-                <span className={`rounded-full px-2.5 py-0.5 text-xs font-semibold ring-1 ${statusColor(item.status)}`}>
+                <span className={`rounded-full px-2.5 py-0.5 text-xs font-semibold ${statusColor(item.status)}`}>
                   {item.status}
                 </span>
               )}

--- a/apps/web/src/components/media-detail/ListsSection.tsx
+++ b/apps/web/src/components/media-detail/ListsSection.tsx
@@ -214,7 +214,7 @@ export function ListsSection({
                   type="button"
                   disabled={!newListName.trim() || savingNewList}
                   onClick={() => void createAndAdd()}
-                  className="flex-none rounded-md bg-claw-500 px-2.5 py-1 text-2xs font-semibold text-claw-on transition-colors hover:bg-claw-600 disabled:opacity-50"
+                  className="btn-primary btn-xs flex-none"
                 >
                   {savingNewList ? "…" : "Add"}
                 </button>

--- a/apps/web/src/components/media-detail/SeasonsSection.tsx
+++ b/apps/web/src/components/media-detail/SeasonsSection.tsx
@@ -181,7 +181,7 @@ export function SeasonsSection({
                   type="button"
                   onClick={() => void markSeasonWatched(s)}
                   disabled={pendingSeason[s.seasonNumber]}
-                  className="flex-none rounded-full bg-claw-500/10 px-2.5 py-1 text-2xs font-semibold text-claw-text ring-1 ring-claw-500/20 transition-colors hover:bg-claw-500/20 disabled:opacity-50"
+                  className="btn-tonal btn-xs flex-none"
                 >
                   Mark watched
                 </button>

--- a/apps/web/src/components/media-detail/WatchDateModal.tsx
+++ b/apps/web/src/components/media-detail/WatchDateModal.tsx
@@ -56,7 +56,7 @@ export function WatchDateModal({
         aria-modal="true"
         aria-labelledby="watch-date-modal-title"
         tabIndex={-1}
-        className={`overlay-dialog w-full max-w-sm rounded-3xl border p-6 shadow-e3 ${exiting ? "overlay-exit" : ""}`}
+        className={`glass-surface overlay-dialog w-full max-w-sm rounded-3xl border p-6 shadow-e3 ${exiting ? "overlay-exit" : ""}`}
         style={{ borderColor: "var(--border)", background: "var(--bg-0)" }}
         onClick={(e) => e.stopPropagation()}
         onAnimationEnd={onExitAnimationEnd}
@@ -105,7 +105,7 @@ export function WatchDateModal({
               type="button"
               disabled={saving}
               onClick={() => void submit(new Date().toISOString())}
-              className="rounded-xl bg-plum-500 px-4 py-3 text-sm font-semibold text-white hover:bg-plum-600 disabled:opacity-50 transition-colors"
+              className="btn-primary py-3"
             >
               Just finished
             </button>
@@ -117,8 +117,7 @@ export function WatchDateModal({
                   const [y, m, d] = releaseDate.split("-").map(Number);
                   void submit(new Date(Date.UTC(y, m - 1, d, 12)).toISOString());
                 }}
-                className="rounded-xl px-4 py-3 text-sm font-semibold transition-colors hover:bg-[var(--surface-strong)] disabled:opacity-50"
-                style={{ background: "var(--surface)", color: "var(--text)" }}
+                className="btn-secondary py-3"
               >
                 Release date
               </button>
@@ -128,8 +127,7 @@ export function WatchDateModal({
               disabled={saving}
               onClick={() => void submit(new Date().toISOString(), true)}
               title="Logs this watch without a specific date"
-              className="flex flex-col items-start gap-0.5 rounded-xl px-4 py-3 text-left transition-colors hover:bg-[var(--surface-strong)] disabled:opacity-50"
-              style={{ background: "var(--surface)", color: "var(--text)" }}
+              className="btn-secondary flex-col items-start justify-center gap-0.5 py-3 text-left"
             >
               <span className="text-sm font-semibold">Unknown date</span>
               <span className="text-2xs" style={{ color: "var(--text-mute)" }}>Logs without a specific date</span>
@@ -137,8 +135,7 @@ export function WatchDateModal({
             <button
               type="button"
               onClick={() => setMode("custom")}
-              className="rounded-xl px-4 py-3 text-sm font-semibold transition-colors hover:bg-[var(--surface-strong)]"
-              style={{ background: "var(--surface)", color: "var(--text)" }}
+              className="btn-secondary py-3"
             >
               Other date
             </button>
@@ -158,8 +155,7 @@ export function WatchDateModal({
               <button
                 type="button"
                 onClick={() => setMode("quick")}
-                className="flex-1 rounded-xl px-4 py-2.5 text-sm font-medium transition-colors hover:bg-[var(--surface-strong)]"
-                style={{ background: "var(--surface)", color: "var(--text-dim)" }}
+                className="btn-secondary flex-1"
               >
                 Back
               </button>
@@ -170,7 +166,7 @@ export function WatchDateModal({
                   const [y, m, d] = customDate.split("-").map(Number);
                   void submit(new Date(Date.UTC(y, m - 1, d, 12)).toISOString());
                 }}
-                className="flex-1 rounded-xl bg-claw-500 px-4 py-2.5 text-sm font-semibold text-claw-on hover:bg-claw-600 disabled:opacity-50 transition-colors"
+                className="btn-primary flex-1"
               >
                 {saving ? "Saving…" : "Log Watch"}
               </button>

--- a/apps/web/src/components/media-detail/WatchHistorySection.tsx
+++ b/apps/web/src/components/media-detail/WatchHistorySection.tsx
@@ -23,7 +23,7 @@ export function WatchHistorySection({
         <button
           type="button"
           onClick={onLogWatch}
-          className="inline-flex items-center gap-1.5 rounded-lg bg-claw-500/10 px-2.5 py-1 text-xs font-semibold text-claw-text ring-1 ring-claw-500/20 hover:bg-claw-500/20 transition-colors"
+          className="btn-tonal btn-sm"
         >
           <Calendar className="h-3 w-3" /> Log a Watch
         </button>

--- a/apps/web/src/components/media-detail/detailPanelUtils.test.ts
+++ b/apps/web/src/components/media-detail/detailPanelUtils.test.ts
@@ -20,20 +20,29 @@ describe("formatRuntime", () => {
 });
 
 describe("statusColor", () => {
-  it("marks running shows green", () => {
-    expect(statusColor("Returning Series")).toContain("text-green-400");
-    expect(statusColor("Ongoing")).toContain("text-green-400");
+  it("always returns a themed chip rather than a raw tint", () => {
+    for (const status of ["Returning Series", "Ended", "Planned", "Released", ""]) {
+      expect(statusColor(status)).toContain("status-chip");
+      // A hard-coded -400/-500 tint is what made these unreadable on the light
+      // theme; every status has to come from a --status-* token now.
+      expect(statusColor(status)).not.toMatch(/-\d00\b/);
+    }
   });
 
-  it("marks finished shows rose", () => {
-    expect(statusColor("Ended")).toContain("text-rose-400");
-    expect(statusColor("Canceled")).toContain("text-rose-400");
-    expect(statusColor("Cancelled")).toContain("text-rose-400");
+  it("marks running shows as ok", () => {
+    expect(statusColor("Returning Series")).toContain("status-chip--ok");
+    expect(statusColor("Ongoing")).toContain("status-chip--ok");
   });
 
-  it("marks upcoming titles amber", () => {
-    expect(statusColor("In Production")).toContain("text-amber-400");
-    expect(statusColor("Planned")).toContain("text-amber-400");
+  it("marks finished shows as bad", () => {
+    expect(statusColor("Ended")).toContain("status-chip--bad");
+    expect(statusColor("Canceled")).toContain("status-chip--bad");
+    expect(statusColor("Cancelled")).toContain("status-chip--bad");
+  });
+
+  it("marks upcoming titles as warn", () => {
+    expect(statusColor("In Production")).toContain("status-chip--warn");
+    expect(statusColor("Planned")).toContain("status-chip--warn");
   });
 
   it("is case-insensitive", () => {
@@ -41,8 +50,8 @@ describe("statusColor", () => {
     expect(statusColor("returning series")).toBe(statusColor("Returning Series"));
   });
 
-  it("falls back to slate for anything unrecognised", () => {
-    expect(statusColor("Released")).toContain("text-slate-400");
-    expect(statusColor("")).toContain("text-slate-400");
+  it("falls back to the neutral chip for anything unrecognised", () => {
+    expect(statusColor("Released")).toBe("status-chip");
+    expect(statusColor("")).toBe("status-chip");
   });
 });

--- a/apps/web/src/components/media-detail/detailPanelUtils.ts
+++ b/apps/web/src/components/media-detail/detailPanelUtils.ts
@@ -5,12 +5,22 @@ export function formatRuntime(minutes: number): string {
   return m > 0 ? `${h}h ${m}m` : `${h}h`;
 }
 
+/**
+ * Paint classes for a series' status badge.
+ *
+ * These used to be raw `-400` tints (green/rose/amber/slate), all picked
+ * against a dark background — on the light theme's cream they sat at roughly
+ * 2:1 and the badge was a smudge. `.status-chip` in index.css derives text,
+ * fill and ring from one per-theme token instead, so each status stays legible
+ * on all five themes; the unmatched case falls through to the chip's default,
+ * which is --text-mute.
+ */
 export function statusColor(status: string): string {
   const s = status.toLowerCase();
-  if (s.includes("return") || s.includes("ongoing")) return "text-green-400 bg-green-500/10 ring-green-500/20";
-  if (s.includes("ended") || s.includes("cancel")) return "text-rose-400 bg-rose-500/10 ring-rose-500/20";
-  if (s.includes("production") || s.includes("planned")) return "text-amber-400 bg-amber-500/10 ring-amber-500/20";
-  return "text-slate-400 bg-slate-500/10 ring-slate-500/20";
+  if (s.includes("return") || s.includes("ongoing")) return "status-chip status-chip--ok";
+  if (s.includes("ended") || s.includes("cancel")) return "status-chip status-chip--bad";
+  if (s.includes("production") || s.includes("planned")) return "status-chip status-chip--warn";
+  return "status-chip";
 }
 
 export type WatchLogTarget =

--- a/apps/web/src/components/settings/AddonSettings.tsx
+++ b/apps/web/src/components/settings/AddonSettings.tsx
@@ -232,11 +232,7 @@ export function AddonSettings() {
         type="button"
         onClick={save}
         disabled={saving}
-        className={`inline-flex items-center gap-2 rounded-xl px-5 py-2.5 text-sm font-semibold transition-all duration-base ${
-          saved
-            ? "bg-emerald-500/15 text-emerald-600 ring-1 ring-emerald-500/20"
-            : "bg-claw-500 text-claw-on hover:bg-claw-600"
-        }`}
+        className={`btn-primary ${saved ? "btn-saved" : ""}`}
       >
         {saved ? <><Check size={16} /> Saved</> : saving ? <><Loader2 size={16} className="animate-spin" /> Saving...</> : "Save Configuration"}
       </button>

--- a/apps/web/src/components/settings/ApiTokenSettings.tsx
+++ b/apps/web/src/components/settings/ApiTokenSettings.tsx
@@ -46,11 +46,7 @@ export function ApiTokenSettings() {
       <p className="text-xs text-amber-600">Only use this on trusted devices.</p>
       <button
         type="submit"
-        className={`inline-flex items-center gap-2 rounded-xl px-5 py-2.5 text-sm font-semibold transition-all duration-base ${
-          saved
-            ? "bg-emerald-500/15 text-emerald-400 ring-1 ring-emerald-500/20"
-            : "bg-claw-500 text-claw-on hover:bg-claw-600 shadow-glow"
-        }`}
+        className={`btn-primary ${saved ? "btn-saved" : ""}`}
       >
         {saved ? <><Check size={16} /> Saved</> : "Save token"}
       </button>

--- a/apps/web/src/components/settings/DataSettings.tsx
+++ b/apps/web/src/components/settings/DataSettings.tsx
@@ -116,7 +116,7 @@ export function DataSettings() {
           type="button"
           onClick={refreshAll}
           disabled={syncing}
-          className="inline-flex items-center gap-2 rounded-xl bg-claw-500 px-5 py-2.5 text-sm font-semibold text-claw-on transition-colors hover:bg-claw-600 disabled:opacity-60"
+          className="btn-primary"
         >
           {syncing ? <><Loader2 size={16} className="animate-spin" /> Syncing...</> : "Sync all metadata"}
         </button>
@@ -133,8 +133,7 @@ export function DataSettings() {
           type="button"
           onClick={handleExport}
           disabled={exporting}
-          className="inline-flex items-center gap-2 rounded-xl px-5 py-2.5 text-sm font-semibold transition-colors hover:bg-[var(--surface)] disabled:opacity-60"
-          style={{ background: "var(--surface-strong)", border: "1px solid var(--border)", color: "var(--text-dim)" }}
+          className="btn-secondary"
         >
           {exporting ? <><Loader2 size={16} className="animate-spin" /> Exporting...</> : <><Download size={16} /> Download export</>}
         </button>
@@ -163,8 +162,7 @@ export function DataSettings() {
             type="button"
             onClick={() => jsonFileInputRef.current?.click()}
             disabled={importingJson}
-            className="inline-flex items-center gap-2 rounded-xl px-5 py-2.5 text-sm font-semibold transition-colors hover:bg-[var(--surface)] disabled:opacity-60"
-            style={{ background: "var(--surface-strong)", border: "1px solid var(--border)", color: "var(--text-dim)" }}
+            className="btn-secondary"
           >
             {importingJson ? <><Loader2 size={16} className="animate-spin" /> Importing...</> : <><Upload size={16} /> Import JSON export</>}
           </button>
@@ -184,8 +182,7 @@ export function DataSettings() {
             type="button"
             onClick={() => csvFileInputRef.current?.click()}
             disabled={importingCsv}
-            className="inline-flex items-center gap-2 rounded-xl px-5 py-2.5 text-sm font-semibold transition-colors hover:bg-[var(--surface)] disabled:opacity-60"
-            style={{ background: "var(--surface-strong)", border: "1px solid var(--border)", color: "var(--text-dim)" }}
+            className="btn-secondary"
           >
             {importingCsv ? <><Loader2 size={16} className="animate-spin" /> Importing...</> : <><Upload size={16} /> Import CSV history</>}
           </button>
@@ -229,8 +226,7 @@ export function DataSettings() {
             type="button"
             onClick={() => externalFileInputRef.current?.click()}
             disabled={importingExternal}
-            className="inline-flex items-center gap-2 rounded-xl px-5 py-2.5 text-sm font-semibold transition-colors hover:bg-[var(--surface)] disabled:opacity-60"
-            style={{ background: "var(--surface-strong)", border: "1px solid var(--border)", color: "var(--text-dim)" }}
+            className="btn-secondary"
           >
             {importingExternal ? <><Loader2 size={16} className="animate-spin" /> Importing...</> : <><Upload size={16} /> Import CSV</>}
           </button>

--- a/apps/web/src/components/settings/OmdbSettings.tsx
+++ b/apps/web/src/components/settings/OmdbSettings.tsx
@@ -80,7 +80,7 @@ export function OmdbSettings() {
           <button
             type="button"
             onClick={disconnect}
-            className="inline-flex items-center gap-2 rounded-xl border border-[var(--border)] bg-[var(--bg-0)] px-4 py-2.5 text-sm font-semibold text-[var(--text-dim)] transition-colors hover:bg-rose-600 hover:text-white"
+            className="btn-secondary hover:bg-rose-600 hover:text-white"
           >
             <Unplug size={16} /> Remove Key
           </button>
@@ -110,11 +110,7 @@ export function OmdbSettings() {
           <button
             type="submit"
             disabled={saving || !apiKey.trim()}
-            className={`inline-flex items-center gap-2 rounded-xl px-5 py-2.5 text-sm font-semibold transition-all duration-base ${
-              saved
-                ? "bg-emerald-500/15 text-emerald-600 ring-1 ring-emerald-500/20"
-                : "bg-claw-500 text-claw-on hover:bg-claw-600 disabled:opacity-50"
-            }`}
+            className={`btn-primary ${saved ? "btn-saved" : ""}`}
           >
             {saved ? <><Check size={16} /> Saved</> : saving ? <><Loader2 size={16} className="animate-spin" /> Saving...</> : "Save OMDB Key"}
           </button>

--- a/apps/web/src/components/settings/PlayDetectionSettings.tsx
+++ b/apps/web/src/components/settings/PlayDetectionSettings.tsx
@@ -88,8 +88,7 @@ export function PlayDetectionSettings() {
             <button
               type="button"
               onClick={fetchSignals}
-              className="inline-flex items-center gap-2 rounded-xl px-4 py-2.5 text-sm font-semibold transition-colors hover:bg-[var(--surface-strong)] border border-[var(--border-strong)]"
-              style={{ color: "var(--text-dim)", background: "var(--bg-1)" }}
+              className="btn-secondary"
             >
               <RefreshCw size={16} /> Refresh
             </button>
@@ -146,8 +145,7 @@ export function PlayDetectionSettings() {
           <button
             type="button"
             onClick={fetchSignals}
-            className="inline-flex items-center gap-2 rounded-xl px-4 py-2.5 text-sm font-semibold transition-colors hover:bg-[var(--surface-strong)] border border-[var(--border-strong)]"
-            style={{ color: "var(--text-dim)", background: "var(--bg-1)" }}
+            className="btn-secondary"
           >
             <RefreshCw size={16} /> Retry
           </button>

--- a/apps/web/src/components/settings/PreferencesSettings.tsx
+++ b/apps/web/src/components/settings/PreferencesSettings.tsx
@@ -155,11 +155,7 @@ export function PreferencesSettings() {
         type="button"
         onClick={save}
         disabled={saving}
-        className={`inline-flex items-center gap-2 rounded-xl px-5 py-2.5 text-sm font-semibold transition-all duration-base ${
-          saved
-            ? "bg-emerald-500/15 text-emerald-400 ring-1 ring-emerald-500/20"
-            : "bg-claw-500 text-claw-on hover:bg-claw-600 shadow-glow"
-        }`}
+        className={`btn-primary ${saved ? "btn-saved" : ""}`}
       >
         {saved ? <><Check size={16} /> Saved</> : saving ? <><Loader2 size={16} className="animate-spin" /> Saving...</> : "Save Preferences"}
       </button>

--- a/apps/web/src/components/settings/ProfileSettings.tsx
+++ b/apps/web/src/components/settings/ProfileSettings.tsx
@@ -424,8 +424,7 @@ export function ProfileSettings() {
       <button
         type="button"
         onClick={openSwitcher}
-        className="inline-flex items-center gap-2 rounded-xl border px-5 py-2.5 text-sm font-semibold transition-colors hover:bg-[var(--surface-strong)] focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-400 focus-ring-offset"
-        style={{ background: "var(--surface)", borderColor: "var(--border-strong)", color: "var(--text-dim)" }}
+        className="btn-secondary"
       >
         <Users size={16} /> Switch Profile
       </button>

--- a/apps/web/src/components/settings/PushSettings.tsx
+++ b/apps/web/src/components/settings/PushSettings.tsx
@@ -82,12 +82,9 @@ export function PushSettings() {
         type="button"
         onClick={subscribed ? disable : enable}
         disabled={busy}
-        className={`inline-flex items-center gap-2 rounded-xl px-5 py-2.5 text-sm font-semibold transition-all duration-base disabled:opacity-50 ${
-          subscribed
-            ? "border hover:bg-rose-600 hover:text-white"
-            : "bg-claw-500 text-claw-on hover:bg-claw-600 shadow-glow"
-        }`}
-        style={subscribed ? { backgroundColor: "var(--surface)", borderColor: "var(--border)", color: "var(--text-dim)" } : undefined}
+        // Utilities outrank the .btn-secondary hover, so the destructive hover
+        // lands without needing !important.
+        className={subscribed ? "btn-secondary hover:bg-rose-600 hover:text-white" : "btn-primary"}
       >
         {busy ? (
           <><Loader2 size={16} className="animate-spin" /> {subscribed ? "Disabling..." : "Enabling..."}</>

--- a/apps/web/src/components/settings/RpdbSettings.tsx
+++ b/apps/web/src/components/settings/RpdbSettings.tsx
@@ -82,8 +82,7 @@ export function RpdbSettings() {
           <button
             type="button"
             onClick={disconnect}
-            className="inline-flex items-center gap-2 rounded-xl px-4 py-2.5 text-sm font-semibold transition-colors hover:bg-rose-600 hover:text-white border"
-            style={{ color: "var(--text-dim)", borderColor: "var(--border)", background: "var(--bg-1)" }}
+            className="btn-secondary hover:bg-rose-600 hover:text-white"
           >
             <Unplug size={16} /> Remove Key
           </button>
@@ -113,11 +112,7 @@ export function RpdbSettings() {
           <button
             type="submit"
             disabled={saving || !apiKey.trim()}
-            className={`inline-flex items-center gap-2 rounded-xl px-5 py-2.5 text-sm font-semibold transition-all duration-base ${
-              saved
-                ? "bg-emerald-500/15 text-emerald-600 ring-1 ring-emerald-500/20"
-                : "bg-claw-500 text-claw-on hover:bg-claw-600 disabled:opacity-50"
-            }`}
+            className={`btn-primary ${saved ? "btn-saved" : ""}`}
           >
             {saved ? <><Check size={16} /> Saved</> : saving ? <><Loader2 size={16} className="animate-spin" /> Saving...</> : "Save RPDB Key"}
           </button>

--- a/apps/web/src/components/settings/StremioSyncSettings.tsx
+++ b/apps/web/src/components/settings/StremioSyncSettings.tsx
@@ -139,7 +139,7 @@ export function StremioSyncSettings() {
           <button
             type="submit"
             disabled={busy === "connect" || !email.trim() || !password}
-            className="inline-flex items-center gap-2 rounded-xl bg-plum-500 px-4 py-2.5 text-sm font-semibold transition-colors hover:bg-plum-600 disabled:opacity-50 disabled:cursor-not-allowed"
+            className="btn-primary"
           >
             {busy === "connect" ? (
               <>
@@ -163,7 +163,7 @@ export function StremioSyncSettings() {
               type="button"
               onClick={() => run("import")}
               disabled={busy !== null}
-              className="inline-flex items-center gap-2 rounded-xl bg-claw-500 px-4 py-2.5 text-sm font-semibold text-claw-on transition-colors hover:bg-claw-600 disabled:opacity-60 shadow-glow"
+              className="btn-primary"
             >
               {busy === "import" ? (
                 <>
@@ -177,8 +177,7 @@ export function StremioSyncSettings() {
               type="button"
               onClick={() => run("sync")}
               disabled={busy !== null}
-              className="inline-flex items-center gap-2 rounded-xl px-4 py-2.5 text-sm font-semibold transition-colors hover:bg-[var(--surface-strong)] border border-[var(--border-strong)] disabled:opacity-60"
-              style={{ color: "var(--text-dim)", background: "var(--bg-1)" }}
+              className="btn-secondary"
             >
               {busy === "sync" ? (
                 <>
@@ -194,8 +193,7 @@ export function StremioSyncSettings() {
               type="button"
               onClick={disconnect}
               disabled={busy !== null}
-              className="inline-flex items-center gap-2 rounded-xl px-4 py-2.5 text-sm font-semibold transition-colors hover:bg-rose-600 hover:text-white border border-[var(--border-strong)] disabled:opacity-60"
-              style={{ color: "var(--text-dim)", background: "var(--bg-1)" }}
+              className="btn-secondary hover:bg-rose-600 hover:text-white"
             >
               <Unplug size={16} /> Disconnect
             </button>

--- a/apps/web/src/components/settings/TraktSettings.tsx
+++ b/apps/web/src/components/settings/TraktSettings.tsx
@@ -92,7 +92,7 @@ export function TraktSettings() {
             type="button"
             onClick={connect}
             disabled={!status?.configured}
-            className="inline-flex items-center gap-2 rounded-xl bg-plum-500 px-4 py-2.5 text-sm font-semibold transition-colors hover:bg-plum-600 disabled:opacity-50 disabled:cursor-not-allowed"
+            className="btn-primary"
           >
             <Link size={16} /> Connect Trakt
           </button>
@@ -103,23 +103,21 @@ export function TraktSettings() {
               type="button"
               onClick={runImport}
               disabled={importing}
-              className="inline-flex items-center gap-2 rounded-xl bg-claw-500 px-4 py-2.5 text-sm font-semibold text-claw-on transition-colors hover:bg-claw-600 disabled:opacity-60 shadow-glow"
+              className="btn-primary"
             >
               {importing ? <><Loader2 size={16} className="animate-spin" /> Importing...</> : "Run Import"}
             </button>
             <button
               type="button"
               onClick={disconnect}
-              className="inline-flex items-center gap-2 rounded-xl px-4 py-2.5 text-sm font-semibold transition-colors hover:bg-rose-600 hover:text-white border border-[var(--border-strong)]"
-              style={{ color: "var(--text-dim)", background: "var(--bg-1)" }}
+              className="btn-secondary hover:bg-rose-600 hover:text-white"
             >
               <Unplug size={16} /> Disconnect
             </button>
             <button
               type="button"
               onClick={fetchStatus}
-              className="rounded-xl px-4 py-2.5 text-sm font-semibold transition-colors hover:bg-[var(--surface-strong)] border border-[var(--border-strong)]"
-              style={{ color: "var(--text-dim)", background: "var(--bg-1)" }}
+              className="btn-secondary"
             >
               Refresh
             </button>

--- a/apps/web/src/hooks/useToast.tsx
+++ b/apps/web/src/hooks/useToast.tsx
@@ -95,7 +95,7 @@ function ToastContainer({
           onAnimationEnd={toast.exiting ? () => onExited(toast.id) : undefined}
           // `pointer-events-none` while fading: a toast on its way out must not
           // take a second Undo click during the animation.
-          className={`${toast.exiting ? "toast-exit pointer-events-none" : "toast-enter"} flex items-center gap-3 rounded-xl border px-5 py-3.5 shadow-e2 ${
+          className={`glass-surface ${toast.exiting ? "toast-exit pointer-events-none" : "toast-enter"} flex items-center gap-3 rounded-xl border px-5 py-3.5 shadow-e2 ${
             toast.type === "success"
               ? "border-emerald-500/30"
               : toast.type === "error"

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -238,6 +238,37 @@
 }
 
 /*
+ * Status colours — "returning", "cancelled", "saved", and friends.
+ *
+ * Split light/dark for the same reason the elevations above are: these were
+ * spelled as raw Tailwind tints at each call site (text-green-400,
+ * text-rose-400, text-amber-400, text-emerald-600), all of them picked against
+ * a dark background. On the light theme's cream those sit at roughly 2:1, so a
+ * series status was legible on four themes and a smudge on the fifth — and the
+ * same "saved" confirmation shipped as emerald-400 in two settings panels and
+ * emerald-600 in three others.
+ *
+ * Only the text colour is a token. Fills and hairlines are mixed out of it
+ * (see .status-chip), so a fill can never drift away from the text it sits
+ * behind. Every value clears 4.5:1 against its themes' --bg-0 and --bg-1.
+ */
+:root,
+[data-theme="light"] {
+  --status-ok: #047857;
+  --status-bad: #be123c;
+  --status-warn: #b45309;
+}
+
+[data-theme="dark"],
+[data-theme="glass"],
+[data-theme="midnight"],
+[data-theme="letterboxd"] {
+  --status-ok: #34d399;
+  --status-bad: #fb7185;
+  --status-warn: #fbbf24;
+}
+
+/*
  * Selection. The UA default is a fixed blue that belongs to none of the five
  * themes — over the Letterboxd charcoal or the Midnight navy it reads as a
  * rendering fault rather than a selection. Accent tint with the accent's own
@@ -356,8 +387,13 @@ body {
  * not alike.
  *
  * .glass-surface — the floating chrome: header, sidebar, command palette,
- *   detail panels, sheets. At most two are on screen at once, they sit over
- *   whatever is scrolling underneath, and they carry the full blur.
+ *   detail panels, sheets, modal dialogs, toasts and the offline/update
+ *   banners. All of it sits over whatever is scrolling underneath, only a
+ *   couple are ever on screen at once (toasts cap at three, and they are small
+ *   boxes), and it carries the full blur. The dialogs and toasts were the
+ *   glaring omission: the glass theme's whole point is an ambient glow behind
+ *   frosted surfaces, and without them the two things that most obviously
+ *   float over the page were opaque slabs.
  *
  * .glass-panel — the in-flow panels that tile a page: dashboard cards, stats
  *   and settings sections, calendar and history cards. A dashboard can stack a
@@ -547,9 +583,144 @@ body {
     opacity: 0.5;
     cursor: default;
   }
+
+  /*
+   * Buttons.
+   *
+   * The same semantic button used to be rebuilt from utilities at every call
+   * site, which is why the primary action shipped as rounded-md, -lg, -xl and
+   * -full on different screens, with the shadow, the press scale, the disabled
+   * opacity and the focus ring each present on roughly half of them. A variant
+   * class is the whole button: `className="btn-primary"` is complete, and call
+   * sites add only layout (`w-full`, `flex-1`) and a size (`btn-sm`).
+   *
+   * Everything shared lives on the selector list below, so a variant can never
+   * drift on shape, motion, focus or the disabled state — only on paint.
+   *
+   * A button is a control rather than a surface, so it sits outside the radius
+   * ranks above: rounded-xl at every size but btn-sm/btn-xs, which shrink with
+   * the box so the corner stays proportional.
+   *
+   * The transition names its properties instead of using `transition-all`: the
+   * base-layer rule deliberately stops buttons easing their own size and
+   * position, and `transform` is added because `active:scale` without it snaps
+   * rather than presses. `transition-colors` at a call site would erase the
+   * transform half of that (utilities outrank components), so migrated buttons
+   * carry neither it nor `transition-all`.
+   *
+   * --tw-ring-offset-color is set here for the same reason .focus-ring-offset
+   * exists — see the comment on it — so a button never needs to be paired with
+   * that class to get a themed offset.
+   */
+  .btn-primary,
+  .btn-secondary,
+  .btn-tonal,
+  .btn-danger {
+    @apply inline-flex items-center justify-center gap-2 rounded-xl px-4 py-2.5 text-sm font-semibold;
+    @apply transition-[color,background-color,border-color,box-shadow,transform] duration-base ease-in-out;
+    @apply active:scale-[0.98];
+    @apply focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-400 focus-visible:ring-offset-2;
+    @apply disabled:opacity-50 disabled:cursor-not-allowed disabled:active:scale-100;
+    --tw-ring-offset-color: var(--bg-0);
+  }
+
+  /*
+   * --elevation-glow is the accent halo this token was named for. It is fed
+   * through Tailwind's --tw-shadow rather than declared as a box-shadow of its
+   * own, because `focus-visible:ring-2` paints its ring *as* a box-shadow — a
+   * plain declaration here would either lose to the ring (halo vanishes on
+   * focus) or, at equal specificity, beat it and swap a focused button's ring
+   * for a glow. Composed this way both draw.
+   *
+   * The resting halo is the glow at a third of its spread; .btn-lg takes the
+   * token at full strength, since a hero CTA is what it was measured for.
+   */
+  .btn-primary {
+    @apply bg-claw-500 text-claw-on hover:bg-claw-600;
+    --tw-shadow: 0 2px 8px rgb(var(--accent-rgb) / 0.22);
+    box-shadow: var(--tw-shadow);
+  }
+
+  .btn-secondary {
+    border: 1px solid var(--border-strong);
+    background: var(--surface);
+    color: var(--text-dim);
+  }
+
+  .btn-secondary:hover {
+    background: var(--surface-strong);
+    color: var(--text);
+  }
+
+  /* Accent-tinted, for the in-panel actions that are the accent action of their
+     section but not of the screen — "Log a Watch", "Mark watched". */
+  .btn-tonal {
+    @apply bg-claw-500/10 text-claw-text ring-1 ring-claw-500/20 hover:bg-claw-500/20;
+  }
+
+  /* Confirmed destructive actions — the second step of a delete, never the
+     first. Rose is fixed rather than themed: a delete has to read as a delete
+     on all five themes, and it is white-on-rose either way. Its focus ring
+     matches, so the ring doesn't say "accent" on a button that means danger. */
+  .btn-danger {
+    @apply bg-rose-600 text-white hover:bg-rose-700;
+    @apply focus-visible:ring-rose-400;
+  }
+
+  /* The settled state of a save button, not a rank of its own: the settings
+     panels swap a .btn-primary to this for a beat after a successful save. */
+  .btn-primary.btn-saved {
+    background: color-mix(in srgb, var(--status-ok) 15%, transparent);
+    color: var(--status-ok);
+    --tw-shadow: inset 0 0 0 1px color-mix(in srgb, var(--status-ok) 30%, transparent);
+  }
+
+  .btn-primary.btn-saved:hover {
+    background: color-mix(in srgb, var(--status-ok) 15%, transparent);
+  }
+
+  /* Size variants. Declared after the variants above so their padding and
+     radius win at equal specificity. */
+  .btn-sm {
+    @apply gap-1.5 rounded-lg px-3 py-1.5 text-xs;
+  }
+
+  .btn-xs {
+    @apply gap-1 rounded-md px-2.5 py-1 text-2xs;
+  }
+
+  /* The full-width hero CTAs — setup wizard, empty-state calls to action. */
+  .btn-lg {
+    @apply rounded-xl px-5 py-3;
+  }
+
+  .btn-primary.btn-lg {
+    --tw-shadow: var(--elevation-glow);
+  }
+
+  /* Status chips — a series' status, and anything else that reads as a state
+     rather than an action. Paint only; the caller sets shape and size. Text,
+     fill and hairline all come from one --status-* token, so they cannot drift
+     apart, and an unmatched status falls through to --text-mute. */
+  .status-chip {
+    color: var(--status-color, var(--text-mute));
+    background: color-mix(in srgb, var(--status-color, var(--text-mute)) 12%, transparent);
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--status-color, var(--text-mute)) 25%, transparent);
+  }
+
+  .status-chip--ok { --status-color: var(--status-ok); }
+  .status-chip--bad { --status-color: var(--status-bad); }
+  .status-chip--warn { --status-color: var(--status-warn); }
 }
 
-/* Custom Scrollbar */
+/*
+ * Custom scrollbar.
+ *
+ * The thumb was a hard-coded warm grey — the dark theme's --text-mute, shipped
+ * to all five themes, so it read as a brown smear down the edge of the two cool
+ * navy ones. Mixing it out of --text-mute instead keeps it the same relationship
+ * to the text on every theme, warm or cool, light or dark.
+ */
 ::-webkit-scrollbar {
   width: 8px;
   height: 8px;
@@ -558,17 +729,22 @@ body {
   background: transparent;
 }
 ::-webkit-scrollbar-thumb {
-  background: rgba(143, 132, 117, 0.35);
+  /* Opaque --text-mute first, for anything without color-mix(): a thumb one
+     step too solid still reads as a scrollbar, an invalid value is no thumb. */
+  background: var(--text-mute);
+  background: color-mix(in srgb, var(--text-mute) 45%, transparent);
   border-radius: 4px;
 }
 ::-webkit-scrollbar-thumb:hover {
-  background: rgba(181, 171, 154, 0.5);
+  background: var(--text-mute);
+  background: color-mix(in srgb, var(--text-mute) 70%, transparent);
 }
 
 /* Firefox scrollbar */
 * {
   scrollbar-width: thin;
-  scrollbar-color: rgba(143, 132, 117, 0.35) transparent;
+  scrollbar-color: var(--text-mute) transparent;
+  scrollbar-color: color-mix(in srgb, var(--text-mute) 45%, transparent) transparent;
 }
 
 /* Hide scrollbar for carousels */

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -355,7 +355,7 @@ export function ContinueWatchingHero({
             disabled={isMarking || isDone}
             onClick={onMarkNext}
             aria-label={isMarking ? "Marking" : isDone ? "Marked" : `Mark S${s.nextSeason}:E${s.nextEpisode}`}
-            className="flex items-center gap-1.5 rounded-xl bg-claw-500 px-4 py-2.5 text-sm font-semibold text-claw-on transition-all duration-base active:scale-[0.98] hover:bg-claw-600 disabled:opacity-60"
+            className="btn-primary"
           >
             {isDone ? (
               <><Check className="h-4 w-4" /> Marked</>
@@ -368,8 +368,7 @@ export function ContinueWatchingHero({
           <button
             type="button"
             onClick={onSelect}
-            className="rounded-xl px-4 py-2.5 text-sm font-semibold transition-all duration-base active:scale-[0.98]"
-            style={{ border: "1px solid var(--border-strong)", background: "var(--bg-1)", color: "var(--text-dim)" }}
+            className="btn-secondary"
           >
             Details
           </button>
@@ -1015,14 +1014,13 @@ export function DashboardPage() {
             <button
               type="button"
               onClick={() => window.location.reload()}
-              className="rounded-lg bg-claw-500 px-5 py-2.5 text-sm font-semibold text-claw-on hover:bg-claw-600 transition-colors active:scale-[0.98] focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-400"
+              className="btn-primary"
             >
               Reload
             </button>
             <Link
               to="/settings"
-              className="rounded-lg px-5 py-2.5 text-sm font-medium transition-colors focus:outline-none"
-              style={{ border: "1px solid var(--border-strong)", color: "var(--text-dim)" }}
+              className="btn-secondary"
             >
               Settings
             </Link>
@@ -1109,15 +1107,14 @@ export function DashboardPage() {
               <button
                 type="button"
                 onClick={() => void handleCheckout(true)}
-                className="flex items-center gap-1.5 rounded-xl bg-claw-500 px-4 py-2.5 text-sm font-semibold text-claw-on hover:bg-claw-600 active:scale-[0.98] transition-all duration-base"
+                className="btn-primary"
               >
                 <Check className="h-4 w-4" /> Finished
               </button>
               <button
                 type="button"
                 onClick={() => void handleCheckout(false)}
-                className="flex h-10 w-10 items-center justify-center rounded-xl transition-all duration-base active:scale-95"
-                style={{ border: "1px solid var(--border-strong)", background: "var(--bg-1)", color: "var(--text-dim)" }}
+                className="btn-secondary h-10 w-10 p-0"
                 aria-label="Check out without logging"
               >
                 <X className="h-4 w-4" />

--- a/apps/web/src/pages/GamesPage.tsx
+++ b/apps/web/src/pages/GamesPage.tsx
@@ -210,7 +210,12 @@ function GameCard({ game, onSelect }: { game: Game; onSelect: (game: Game) => vo
       <div
         role="button"
         tabIndex={0}
-        className="card-lift relative cursor-pointer overflow-hidden rounded-xl ring-1 ring-black/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-400 focus-ring-offset"
+        // `ring-black/5` was invisible on the four dark themes, so cards of the
+        // same rank carried two different edge treatments — this one and the
+        // Dashboard's themed hairline. --border matches the Dashboard. It stays
+        // a ring rather than an inline inset shadow so .card-lift's hover
+        // shadow can still replace it; an inline style would outrank that.
+        className="card-lift relative cursor-pointer overflow-hidden rounded-xl ring-1 ring-[var(--border)] focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-400 focus-ring-offset"
         style={{ aspectRatio: "var(--poster-ratio)" }}
         onClick={() => onSelect(game)}
         onKeyDown={(e) => {
@@ -389,7 +394,7 @@ export function GamesPage() {
         <button
           type="button"
           onClick={() => setShowAddModal(true)}
-          className="flex items-center gap-1.5 rounded-lg bg-claw-500 px-3.5 py-2 text-sm font-semibold text-claw-on transition-colors hover:bg-claw-600"
+          className="btn-primary btn-sm"
         >
           <Plus className="h-4 w-4" /> Add game
         </button>

--- a/apps/web/src/pages/ListsPage.tsx
+++ b/apps/web/src/pages/ListsPage.tsx
@@ -571,15 +571,14 @@ export function ListsPage() {
                       type="button"
                       disabled={deletingListId === list.id}
                       onClick={() => void handleDeleteList(list.id)}
-                      className="flex-1 rounded-lg bg-rose-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-rose-500 disabled:opacity-60 transition-colors"
+                      className="btn-danger btn-sm flex-1"
                     >
                       {deletingListId === list.id ? "Deleting…" : "Delete"}
                     </button>
                     <button
                       type="button"
                       onClick={() => setConfirmDeleteId(null)}
-                      className="flex-1 rounded-lg border px-3 py-1.5 text-xs font-semibold hover:bg-[var(--surface)] transition-colors"
-                      style={{ borderColor: "var(--border)", color: "var(--text-dim)", background: "var(--bg-1)" }}
+                      className="btn-secondary btn-sm flex-1"
                     >
                       Cancel
                     </button>
@@ -642,7 +641,7 @@ export function ListsPage() {
           />
           <button
             type="submit"
-            className="rounded-xl bg-claw-500 px-4 py-2.5 text-sm font-semibold text-claw-on hover:bg-claw-600 transition-colors"
+            className="btn-primary"
           >
             Create
           </button>
@@ -726,7 +725,7 @@ export function ListsPage() {
               <button
                 type="button"
                 onClick={() => setShowAddModal(true)}
-                className="ml-3 flex flex-none items-center gap-2 rounded-xl bg-claw-500 px-4 py-2.5 text-sm font-semibold text-claw-on hover:bg-claw-600 transition-colors"
+                className="btn-primary ml-3 flex-none"
               >
                 <Plus className="h-4 w-4" />
                 Add

--- a/apps/web/src/pages/NotFoundPage.tsx
+++ b/apps/web/src/pages/NotFoundPage.tsx
@@ -14,7 +14,7 @@ export function NotFoundPage() {
       </p>
       <Link
         to="/"
-        className="mt-6 rounded-full bg-claw-500 px-5 py-2.5 text-sm font-semibold text-claw-on transition-colors hover:bg-claw-600"
+        className="btn-primary mt-6"
       >
         Back to Dashboard
       </Link>

--- a/apps/web/src/pages/ProfileSwitcher.tsx
+++ b/apps/web/src/pages/ProfileSwitcher.tsx
@@ -36,7 +36,7 @@ function Shell({ children, onClose }: { children: React.ReactNode; onClose?: () 
             <span className={`text-2xl ${BRAND_WORDMARK}`} style={{ color: "var(--text)" }}>Cataloggy</span>
           </div>
 
-          <div className="relative rounded-3xl border p-6 shadow-e3" style={{ borderColor: "var(--border)", background: "var(--bg-1)" }}>
+          <div className="glass-surface relative rounded-3xl border p-6 shadow-e3" style={{ borderColor: "var(--border)", background: "var(--bg-1)" }}>
             <button
               type="button"
               onClick={onClose}
@@ -140,8 +140,7 @@ function CreateProfileForm({
           <button
             type="button"
             onClick={onCancel}
-            className="flex-1 rounded-xl border px-5 py-3 text-sm font-semibold transition-colors hover:bg-[var(--surface-strong)]"
-            style={{ borderColor: "var(--border)", color: "var(--text-dim)", background: "var(--bg-1)" }}
+            className="btn-secondary btn-lg flex-1"
           >
             Cancel
           </button>
@@ -149,7 +148,7 @@ function CreateProfileForm({
         <button
           type="submit"
           disabled={creating || !name.trim()}
-          className="flex flex-1 items-center justify-center gap-2 rounded-xl bg-claw-500 px-5 py-3 text-sm font-semibold text-claw-on transition-all duration-base hover:bg-claw-600 disabled:opacity-50"
+          className="btn-primary btn-lg flex-1"
         >
           {creating ? <><Loader2 size={16} className="animate-spin" /> Creating...</> : <>Create <ArrowRight size={16} /></>}
         </button>
@@ -215,15 +214,14 @@ function PinPrompt({
         <button
           type="button"
           onClick={onBack}
-          className="flex-1 rounded-xl border px-5 py-3 text-sm font-semibold transition-colors hover:bg-[var(--surface-strong)]"
-          style={{ borderColor: "var(--border)", color: "var(--text-dim)", background: "var(--bg-1)" }}
+          className="btn-secondary btn-lg flex-1"
         >
           Back
         </button>
         <button
           type="submit"
           disabled={verifying || !pin.trim()}
-          className="flex flex-1 items-center justify-center gap-2 rounded-xl bg-claw-500 px-5 py-3 text-sm font-semibold text-claw-on transition-all duration-base hover:bg-claw-600 disabled:opacity-50"
+          className="btn-primary btn-lg flex-1"
         >
           {verifying ? <Loader2 size={16} className="animate-spin" /> : <>Unlock <ArrowRight size={16} /></>}
         </button>
@@ -284,8 +282,7 @@ function ProfilePicker({
       <button
         type="button"
         onClick={onCreateNew}
-        className="flex w-full items-center justify-center gap-2 rounded-xl border px-5 py-3 text-sm font-semibold transition-colors hover:bg-[var(--surface-strong)]"
-        style={{ borderColor: "var(--border)", color: "var(--text-dim)", background: "var(--bg-1)" }}
+        className="btn-secondary btn-lg w-full"
       >
         <Plus size={16} /> New Profile
       </button>

--- a/apps/web/src/pages/SearchPage.tsx
+++ b/apps/web/src/pages/SearchPage.tsx
@@ -739,7 +739,12 @@ function ResultCard({
       <div
         role="button"
         tabIndex={0}
-        className="card-lift relative cursor-pointer overflow-hidden rounded-xl ring-1 ring-black/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-400 focus-ring-offset"
+        // `ring-black/5` was invisible on the four dark themes, so cards of the
+        // same rank carried two different edge treatments — this one and the
+        // Dashboard's themed hairline. --border matches the Dashboard. It stays
+        // a ring rather than an inline inset shadow so .card-lift's hover
+        // shadow can still replace it; an inline style would outrank that.
+        className="card-lift relative cursor-pointer overflow-hidden rounded-xl ring-1 ring-[var(--border)] focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-400 focus-ring-offset"
         style={{ aspectRatio: "var(--poster-ratio)" }}
         onClick={() => onSelect(result)}
         onKeyDown={(e) => {
@@ -899,7 +904,7 @@ function ResultCard({
                   type="button"
                   disabled={!newListName.trim() || savingNewList}
                   onClick={(e) => { e.stopPropagation(); void submitNewList(); }}
-                  className="flex-none rounded-md bg-claw-500 px-2.5 py-1 text-2xs font-semibold text-claw-on transition-colors hover:bg-claw-600 disabled:opacity-50"
+                  className="btn-primary btn-xs flex-none"
                 >
                   {savingNewList ? "…" : "Add"}
                 </button>

--- a/apps/web/src/pages/SetupWizard.tsx
+++ b/apps/web/src/pages/SetupWizard.tsx
@@ -21,8 +21,7 @@ function BackButton({ onBack }: { onBack: () => void }) {
     <button
       type="button"
       onClick={onBack}
-      className="flex w-full items-center justify-center gap-2 rounded-xl px-5 py-3 text-sm font-semibold transition-colors hover:bg-[var(--surface-strong)]"
-      style={{ color: "var(--text-dim)", border: "1px solid var(--border)" }}
+      className="btn-secondary btn-lg w-full"
     >
       <ArrowLeft size={16} /> Back
     </button>
@@ -144,7 +143,7 @@ function TokenStep({ onVerified }: { onVerified: (tmdbConfigured: boolean) => vo
       <button
         type="submit"
         disabled={verifying || !token.trim()}
-        className="flex w-full items-center justify-center gap-2 rounded-xl bg-claw-500 px-5 py-3 text-sm font-semibold text-claw-on transition-all duration-base hover:bg-claw-600 disabled:opacity-50 shadow-glow"
+        className="btn-primary btn-lg w-full"
       >
         {verifying ? <><Loader2 size={16} className="animate-spin" /> Verifying...</> : <>Continue <ArrowRight size={16} /></>}
       </button>
@@ -177,7 +176,7 @@ function TmdbStep({ configured, onContinue, onBack }: { configured: boolean; onC
       <button
         type="button"
         onClick={onContinue}
-        className="flex w-full items-center justify-center gap-2 rounded-xl bg-claw-500 px-5 py-3 text-sm font-semibold text-claw-on transition-all duration-base hover:bg-claw-600 shadow-glow"
+        className="btn-primary btn-lg w-full"
       >
         Continue <ArrowRight size={16} />
       </button>
@@ -201,8 +200,7 @@ function TraktStep({ onContinue, onBack }: { onContinue: () => void; onBack: () 
       <button
         type="button"
         onClick={onContinue}
-        className="flex w-full items-center justify-center gap-2 rounded-xl px-5 py-3 text-sm font-semibold transition-colors hover:bg-[var(--surface-strong)]"
-        style={{ backgroundColor: "var(--surface)", color: "var(--text)", border: "1px solid var(--border)" }}
+        className="btn-secondary btn-lg w-full"
       >
         Continue <ArrowRight size={16} />
       </button>
@@ -226,7 +224,7 @@ function DoneStep({ onFinish, onBack }: { onFinish: () => void; onBack: () => vo
       <button
         type="button"
         onClick={onFinish}
-        className="flex w-full items-center justify-center gap-2 rounded-xl bg-claw-500 px-5 py-3 text-sm font-semibold text-claw-on transition-all duration-base hover:bg-claw-600 shadow-glow"
+        className="btn-primary btn-lg w-full"
       >
         Get Started
       </button>

--- a/apps/web/src/pages/StatsPage.tsx
+++ b/apps/web/src/pages/StatsPage.tsx
@@ -204,13 +204,25 @@ export function StatsPage() {
                       className={`absolute bottom-full z-10 mb-1.5 whitespace-nowrap rounded-lg px-2.5 py-1.5 text-2xs shadow-e2 ${
                         isFirst ? "left-0" : isLast ? "right-0" : "left-1/2 -translate-x-1/2"
                       }`}
-                      style={{ border: "1px solid var(--border)", background: "var(--bg-2)" }}
+                      // A normal themed surface, not --bg-2. The inverted
+                      // background is near-white on the four dark themes, and
+                      // the two series lines below are painted in the same
+                      // light accent tints as the bars they describe — on
+                      // near-white they were unreadable. On --bg-1 the swatch
+                      // carries the series and the label stays --text.
+                      style={{ border: "1px solid var(--border)", background: "var(--bg-1)" }}
                     >
-                      <p className="font-semibold" style={{ color: "var(--bg-0)" }}>
+                      <p className="font-semibold" style={{ color: "var(--text)" }}>
                         {new Date(m.month + "-15").toLocaleDateString(undefined, { month: "long", year: "numeric" })}
                       </p>
-                      <p className="text-claw-400">{m.movies} movies</p>
-                      <p className="text-plum-500">{m.episodes} episodes</p>
+                      <p className="flex items-center gap-1.5" style={{ color: "var(--text-dim)" }}>
+                        <span className="h-2 w-2 flex-none rounded-sm bg-claw-500/70" />
+                        {m.movies} movies
+                      </p>
+                      <p className="flex items-center gap-1.5" style={{ color: "var(--text-dim)" }}>
+                        <span className="h-2 w-2 flex-none rounded-sm bg-plum-500/70" />
+                        {m.episodes} episodes
+                      </p>
                     </div>
                   )}
                   <span className="text-2xs tabular-nums" style={{ color: "var(--text-mute)" }}>{total || ""}</span>


### PR DESCRIPTION
## Summary

This PR consolidates scattered button and status badge styles into reusable CSS component classes, improving consistency across the application and fixing accessibility issues on light and dark themes.

## Key Changes

- **Button components** (`btn-primary`, `btn-secondary`, `btn-tonal`, `btn-danger`, `btn-lg`, `btn-sm`, `btn-xs`): Extracted common button patterns from inline utilities into semantic classes with consistent shape, motion, focus rings, and disabled states. Buttons now use explicit transition properties instead of `transition-all` to prevent unintended layout animations.

- **Status badge component** (`.status-chip` with `--ok`, `--bad`, `--warn` variants): Replaced hard-coded Tailwind tints (green-400, rose-400, amber-400, slate-400) that were unreadable on the light theme with theme-aware CSS variables. All status colors now meet 4.5:1 contrast on both light and dark themes.

- **Theme-aware color tokens**: Added `--status-ok`, `--status-bad`, `--status-warn` CSS variables split between light and dark theme groups, ensuring consistent legibility across all five themes.

- **Glass surface improvements**: Extended `.glass-surface` class to modal dialogs, toasts, and banners—components that were previously opaque slabs. This completes the glass theme's frosted aesthetic.

- **Scrollbar theming**: Updated scrollbar colors to derive from `--text-mute` instead of hard-coded warm grey, maintaining proper contrast on cool-toned themes.

- **Pre-hydration spinner**: Added theme-aware accent colors to `theme-init.js` so the loading spinner displays the correct brand color before React hydration.

- **Close button fixes**: Updated detail panel close buttons to hover to `--text` instead of white, preventing the X from disappearing on the light theme's cream background.

- **Stats page tooltip**: Changed tooltip background from `--bg-2` to `--bg-1` and text from `--bg-0` to `--text` for proper contrast; added color swatches to legend items.

- **Card borders**: Replaced invisible `ring-black/5` with `ring-[var(--border)]` on game and search result cards for consistent styling across themes.

## Implementation Details

- Button variants are declared on a shared selector list to prevent drift in shape, motion, focus, and disabled states—only paint differs between variants.
- Status chips use CSS custom properties with fallbacks so unmatched statuses gracefully fall through to `--text-mute`.
- The `--tw-ring-offset-color` is set on buttons to ensure themed focus ring offsets without requiring additional classes.
- Scrollbar styling uses `color-mix()` with fallbacks for browsers without support.
- All changes maintain backward compatibility; existing inline button styles are replaced with class-based equivalents throughout the codebase.

https://claude.ai/code/session_01MrZ2SAyJFiMx6WMvcaDow7