### PR TITLE
Silence test warnings from localStorage and scrollTo probes

### DIFF
--- a/apps/web/src/pages/ListsPage.test.tsx
+++ b/apps/web/src/pages/ListsPage.test.tsx
@@ -136,6 +136,11 @@ describe("ListsPage selection in the URL", () => {
     getLists.mockResolvedValueOnce({ lists: [SCIFI, WATCHLIST] });
     renderPage();
     await waitFor(() => expect(currentSearch()).toBe(`?list=${SCIFI.id}`));
+    // Wait for the items too, not just the URL: the fetch the selection triggers
+    // is one effect behind the address bar, so clearing the mock on the URL alone
+    // can clear it before that fetch was even made — and then attribute it to the
+    // delete below.
+    expect(await screen.findByText("Solaris")).toBeInTheDocument();
 
     // Deferred, as a real reload is: an instantly-resolved one lets the
     // selection and the refreshed sidebar land in the same render and hides

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -41,13 +41,34 @@ class MemoryStorage implements Storage {
     this.#entries.clear();
   }
 }
-if (!window.localStorage) {
+// Reading that global is itself what prints Node's "localStorage is not
+// available because --localstorage-file was not provided" ExperimentalWarning —
+// once per worker, so the suite's output was mostly that. The read is only ever
+// a probe, and the answer is acted on right here, so silence the warning it
+// raises rather than the whole process's warnings.
+function probeLocalStorage(): Storage | undefined {
+  const emitWarning = process.emitWarning;
+  process.emitWarning = () => {};
+  try {
+    return window.localStorage;
+  } finally {
+    process.emitWarning = emitWarning;
+  }
+}
+
+if (!probeLocalStorage()) {
   Object.defineProperty(window, "localStorage", {
     value: new MemoryStorage(),
     configurable: true,
     writable: true,
   });
 }
+
+// jsdom has no viewport to scroll, so its `scrollTo` only logs "Not implemented"
+// through the virtual console. The scroll lock restores the page position when a
+// modal closes, so every modal test printed that line. A no-op is the honest
+// stand-in: there is nothing to scroll and nothing asserts that there was.
+window.scrollTo = () => {};
 
 // Likewise absent from jsdom; components read it to honour reduced motion.
 window.matchMedia ??= ((query: string) => ({


### PR DESCRIPTION
## Summary
Fixes excessive warning output during test runs by suppressing warnings from unavoidable Node.js/jsdom compatibility probes and providing honest no-op implementations for unimplemented APIs.

## Changes
- **localStorage probe**: Wrapped the `window.localStorage` check in a `probeLocalStorage()` function that temporarily disables `process.emitWarning` to prevent the "localStorage is not available" ExperimentalWarning from being printed once per worker
- **scrollTo implementation**: Replaced jsdom's "Not implemented" logging with a no-op `window.scrollTo` function, since jsdom has no viewport to scroll and modal tests were printing this message repeatedly
- **Test robustness**: Added a wait for fetched items in ListsPage test to ensure the selection effect completes before proceeding, preventing race conditions where the mock could be cleared before the fetch was made

## Details
The changes address test output pollution without affecting test behavior:
- The localStorage warning was unavoidable since checking for its existence is the only way to detect if it's available
- The scrollTo no-op is semantically correct for jsdom's headless environment where there's nothing to scroll
- The test fix ensures proper sequencing of async operations without changing the test's intent

https://claude.ai/code/session_01GLqzVSDa3tVBbLebtBcwqk