### PR TITLE
Cover the route modules that had no tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@ The fastest way to try Cataloggy is with Docker Compose — see [Docker Compose 
 
 ## For the technically curious
 
-The rest of this README covers setup, configuration, and the moving parts under the hood.
+The rest of this README covers setup, configuration, and the moving parts under the hood. Two companion docs go deeper:
+
+- **[Troubleshooting](docs/troubleshooting.md)** — what the startup errors mean, why the page loads on the server but not your phone, and why watch history isn't showing up.
+- **[API reference](docs/api.md)** — every endpoint, for scripting against Cataloggy or building your own client.
 
 Cataloggy is a Node.js monorepo set up with `pnpm` workspaces.
 
@@ -402,6 +405,8 @@ Plex has no such field, so `?token=WEBHOOK_SECRET` is the only form it can send.
 ## Contributing
 
 Want to contribute? See [CONTRIBUTING.md](CONTRIBUTING.md) for dev setup, checks to run before opening a PR, and how to report bugs. Notable changes are tracked in [CHANGELOG.md](CHANGELOG.md).
+
+Before filing a bug, it's worth checking [docs/troubleshooting.md](docs/troubleshooting.md) — most reports turn out to be a public URL still pointing at `localhost`.
 
 ## Author
 

--- a/apps/api/src/lib/redact-url.test.ts
+++ b/apps/api/src/lib/redact-url.test.ts
@@ -79,10 +79,12 @@ describe("redactedRequestSerializer wired into Fastify", () => {
     });
     app.get("/webhooks/plex", async () => ({ ok: true }));
 
-    const response = await app.inject({ method: "GET", url });
-    await app.close();
-
-    return { response, logged: JSON.stringify(lines) };
+    try {
+      const response = await app.inject({ method: "GET", url });
+      return { response, logged: JSON.stringify(lines) };
+    } finally {
+      await app.close();
+    }
   };
 
   it("never writes the webhook secret to the log", async () => {

--- a/apps/api/src/lib/test-fixtures/route-app.ts
+++ b/apps/api/src/lib/test-fixtures/route-app.ts
@@ -1,0 +1,34 @@
+import { afterEach, vi } from "vitest";
+import Fastify, { type FastifyInstance, type FastifyPluginAsync } from "fastify";
+
+/**
+ * Builds a Fastify instance carrying one route plugin, and closes it after the
+ * test regardless of how the test ended.
+ *
+ * Closing at the end of a test body — the pattern the older route tests use —
+ * is skipped when an assertion throws, so a failing test leaves its instance
+ * open. Tracking them here and closing in `afterEach` means a failure reports
+ * the assertion rather than the assertion plus whatever the leaked instance
+ * does next.
+ *
+ * The plugin is imported through a callback so `vi.resetModules()` can run
+ * first, which is what lets each test see the mock state set up for it.
+ */
+const openApps = new Set<FastifyInstance>();
+
+afterEach(async () => {
+  for (const app of openApps) await app.close();
+  openApps.clear();
+});
+
+export const buildRouteApp = async (
+  loadPlugin: () => Promise<{ default: FastifyPluginAsync }>
+): Promise<FastifyInstance> => {
+  vi.resetModules();
+  const { default: routes } = await loadPlugin();
+  const app = Fastify({ logger: false });
+  await app.register(routes);
+  await app.ready();
+  openApps.add(app);
+  return app;
+};

--- a/apps/api/src/lib/test-fixtures/route-app.ts
+++ b/apps/api/src/lib/test-fixtures/route-app.ts
@@ -1,5 +1,9 @@
 import { afterEach, vi } from "vitest";
-import Fastify, { type FastifyInstance, type FastifyPluginAsync } from "fastify";
+import Fastify, {
+  type FastifyInstance,
+  type FastifyPluginAsync,
+  type FastifyServerOptions,
+} from "fastify";
 
 /**
  * Builds a Fastify instance carrying one route plugin, and closes it after the
@@ -22,11 +26,13 @@ afterEach(async () => {
 });
 
 export const buildRouteApp = async (
-  loadPlugin: () => Promise<{ default: FastifyPluginAsync }>
+  loadPlugin: () => Promise<{ default: FastifyPluginAsync }>,
+  // A couple of suites need a non-default `bodyLimit` to exercise the 413 path.
+  options: FastifyServerOptions = {}
 ): Promise<FastifyInstance> => {
   vi.resetModules();
   const { default: routes } = await loadPlugin();
-  const app = Fastify({ logger: false });
+  const app = Fastify({ logger: false, ...options });
   await app.register(routes);
   await app.ready();
   openApps.add(app);

--- a/apps/api/src/routes/ai.test.ts
+++ b/apps/api/src/routes/ai.test.ts
@@ -1,8 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import Fastify, { type FastifyInstance } from "fastify";
+import type { FastifyInstance } from "fastify";
+import { buildRouteApp } from "../lib/test-fixtures/route-app.js";
 
 const PROFILE_ID = "11111111-1111-4111-8111-111111111111";
-const MIN_AI_CONFIG_MAX_TOKENS = 2048;
+
+// Read from the real module rather than restated here, so the assertions track
+// the floor the route actually applies. Deferred to call time: importing at the
+// top of the file would run the mock factories before the mocks they close over
+// have been initialised.
+const minAiConfigMaxTokens = async () =>
+  (await import("../lib/ai.js")).MIN_AI_CONFIG_MAX_TOKENS;
 
 const prismaMock = {
   kV: { findUnique: vi.fn(), upsert: vi.fn(), deleteMany: vi.fn() },
@@ -39,13 +46,14 @@ vi.mock("../lib/cache.js", () => ({
   trendingCacheSet: (...a: unknown[]) => trendingCacheSet(...a),
   trendingCacheDeletePrefix: (...a: unknown[]) => trendingCacheDeletePrefix(...a),
 }));
-vi.mock("../lib/ai.js", () => ({
-  AI_CONFIG_KEY: "ai:config",
-  AI_LAST_RECS_GENERATED_AT_KEY: "ai:lastRecsGeneratedAt",
-  MIN_AI_CONFIG_MAX_TOKENS,
+// Only the three functions that reach the database or an AI provider are
+// stubbed. The KV keys, the max-tokens floor and `redactAiConfig` come from the
+// real module: a hand-written redaction stub would only ever prove that the
+// stub redacts, which is not the property worth testing.
+vi.mock("../lib/ai.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../lib/ai.js")>()),
   getAiConfig: () => getAiConfig(),
   isAiConfigured: () => isAiConfigured(),
-  redactAiConfig: (c: Record<string, unknown>) => ({ ...c, headers: { Authorization: "***" } }),
   getAiRecommendations: (...a: unknown[]) => getAiRecommendations(...a),
 }));
 vi.mock("../lib/recommendations.js", () => ({
@@ -61,14 +69,8 @@ vi.mock("../lib/profile.js", () => ({
   },
 }));
 
-const buildApp = async (): Promise<FastifyInstance> => {
-  vi.resetModules();
-  const { default: aiRoutes } = await import("./ai.js");
-  const app = Fastify({ logger: false });
-  await app.register(aiRoutes);
-  await app.ready();
-  return app;
-};
+const buildApp = (): Promise<FastifyInstance> =>
+  buildRouteApp(() => import("./ai.js"));
 
 const tmdbResult = (over: Record<string, unknown> = {}) => ({
   imdbId: "tt1",
@@ -124,7 +126,6 @@ describe("ai routes", () => {
 
       expect(res.statusCode).toBe(200);
       expect(loadRecommendations).toHaveBeenCalledWith("series", "series", "tt1");
-      await app.close();
     });
 
     it("requires an imdbId", async () => {
@@ -133,7 +134,6 @@ describe("ai routes", () => {
       const res = await app.inject({ method: "GET", url: "/recommendations" });
 
       expect(res.statusCode).toBe(400);
-      await app.close();
     });
 
     it("rejects an unsupported type", async () => {
@@ -143,7 +143,6 @@ describe("ai routes", () => {
 
       expect(res.statusCode).toBe(400);
       expect(loadRecommendations).not.toHaveBeenCalled();
-      await app.close();
     });
   });
 
@@ -155,7 +154,6 @@ describe("ai routes", () => {
 
       expect(res.json()).toEqual({ metas: [] });
       expect(getTmdb).not.toHaveBeenCalled();
-      await app.close();
     });
 
     it("seeds movie recommendations from recent watches", async () => {
@@ -168,7 +166,6 @@ describe("ai routes", () => {
       expect(res.statusCode).toBe(200);
       expect(recommendations).toHaveBeenCalledWith("movie", 100);
       expect(res.json().metas).toEqual([expect.objectContaining({ id: "tt2" })]);
-      await app.close();
     });
 
     it("seeds series recommendations from series progress", async () => {
@@ -180,7 +177,6 @@ describe("ai routes", () => {
 
       expect(prismaMock.watchEvent.findMany).not.toHaveBeenCalled();
       expect(recommendations).toHaveBeenCalledWith("series", 900);
-      await app.close();
     });
 
     it("never recommends a seed back to the user", async () => {
@@ -192,7 +188,6 @@ describe("ai routes", () => {
       const res = await app.inject({ method: "GET", url: "/recommendations/personal" });
 
       expect(res.json().metas).toEqual([]);
-      await app.close();
     });
 
     it("clamps the limit to 40", async () => {
@@ -206,7 +201,6 @@ describe("ai routes", () => {
       const res = await app.inject({ method: "GET", url: "/recommendations/personal?limit=1000" });
 
       expect(res.json().metas).toHaveLength(40);
-      await app.close();
     });
 
     it("prefers AI recommendations when the provider is configured", async () => {
@@ -218,7 +212,6 @@ describe("ai routes", () => {
 
       expect(res.json().metas).toEqual([{ id: "ai1" }]);
       expect(prismaMock.watchEvent.findMany).not.toHaveBeenCalled();
-      await app.close();
     });
 
     it("falls back to TMDB seeds when the AI call yields nothing", async () => {
@@ -231,7 +224,6 @@ describe("ai routes", () => {
       const res = await app.inject({ method: "GET", url: "/recommendations/personal" });
 
       expect(res.json().metas).toEqual([expect.objectContaining({ id: "tt2" })]);
-      await app.close();
     });
 
     it("degrades to an empty list when TMDB is unavailable", async () => {
@@ -244,7 +236,6 @@ describe("ai routes", () => {
 
       expect(res.statusCode).toBe(200);
       expect(res.json()).toEqual({ metas: [] });
-      await app.close();
     });
 
     it("returns an empty list rather than an error for an unsupported type", async () => {
@@ -254,7 +245,6 @@ describe("ai routes", () => {
 
       expect(res.statusCode).toBe(200);
       expect(res.json()).toEqual({ metas: [] });
-      await app.close();
     });
   });
 
@@ -267,7 +257,6 @@ describe("ai routes", () => {
       const res = await app.inject({ method: "GET", url: "/recommendations/ai" });
 
       expect(res.json()).toEqual({ metas: [{ id: "tt5" }], reasons: { tt5: "because" } });
-      await app.close();
     });
 
     it("falls back to TMDB seeds with no reasons when AI is not configured", async () => {
@@ -279,7 +268,6 @@ describe("ai routes", () => {
 
       expect(res.json()).toMatchObject({ reasons: {} });
       expect(res.json().metas).toHaveLength(1);
-      await app.close();
     });
 
     it("returns an empty result for an unsupported type", async () => {
@@ -288,7 +276,6 @@ describe("ai routes", () => {
       const res = await app.inject({ method: "GET", url: "/recommendations/ai?type=episode" });
 
       expect(res.json()).toEqual({ metas: [], reasons: {} });
-      await app.close();
     });
   });
 
@@ -301,7 +288,6 @@ describe("ai routes", () => {
       expect(res.statusCode).toBe(200);
       expect(trending).toHaveBeenCalledWith("series", "day");
       expect(trendingCacheSet).toHaveBeenCalledWith("trending:series:day", expect.anything());
-      await app.close();
     });
 
     it("treats any window other than `day` as a week", async () => {
@@ -310,7 +296,6 @@ describe("ai routes", () => {
       await app.inject({ method: "GET", url: "/trending?window=month" });
 
       expect(trending).toHaveBeenCalledWith("movie", "week");
-      await app.close();
     });
 
     it("serves trending from cache without calling TMDB", async () => {
@@ -321,7 +306,6 @@ describe("ai routes", () => {
 
       expect(res.json().metas[0].name).toBe("Cached");
       expect(getTmdb).not.toHaveBeenCalled();
-      await app.close();
     });
 
     it("rejects an unsupported trending type", async () => {
@@ -330,7 +314,6 @@ describe("ai routes", () => {
       const res = await app.inject({ method: "GET", url: "/trending?type=episode" });
 
       expect(res.statusCode).toBe(400);
-      await app.close();
     });
 
     it("returns 500 when TMDB is unconfigured", async () => {
@@ -340,7 +323,6 @@ describe("ai routes", () => {
       const res = await app.inject({ method: "GET", url: "/popular" });
 
       expect(res.statusCode).toBe(500);
-      await app.close();
     });
 
     it("returns 500 and caches nothing when the popular fetch fails", async () => {
@@ -351,7 +333,6 @@ describe("ai routes", () => {
 
       expect(res.statusCode).toBe(500);
       expect(trendingCacheSet).not.toHaveBeenCalled();
-      await app.close();
     });
   });
 
@@ -366,9 +347,26 @@ describe("ai routes", () => {
       expect(res.statusCode).toBe(200);
       const body = res.json();
       expect(body.configured).toBe(true);
-      expect(body.config.headers.Authorization).toBe("***");
+      expect(body.config.headers.Authorization).toBe("Bearer ****");
+      // The point of the route, stated directly: the stored key never reaches
+      // the client, in that header or anywhere else in the payload.
+      expect(res.body).not.toContain("sk-test");
       expect(body.lastGeneratedAt).toBe("2026-01-01T00:00:00.000Z");
-      await app.close();
+    });
+
+    it("reports the clamped max_tokens rather than a stale stored value", async () => {
+      // A config saved before the floor existed can still hold a
+      // truncation-prone number; the settings UI should show what will
+      // actually be sent.
+      getAiConfig.mockResolvedValue({
+        ...validConfig,
+        payload: { model: "gpt-4o-mini", max_tokens: 1024 },
+      });
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/ai/config" });
+
+      expect(res.json().config.payload.max_tokens).toBe(await minAiConfigMaxTokens());
     });
 
     it("reports unconfigured when no config is stored", async () => {
@@ -377,7 +375,6 @@ describe("ai routes", () => {
       const res = await app.inject({ method: "GET", url: "/ai/config" });
 
       expect(res.json()).toMatchObject({ configured: false, config: null });
-      await app.close();
     });
 
     it("saves a valid config and drops the cached recommendations", async () => {
@@ -388,7 +385,6 @@ describe("ai routes", () => {
       expect(res.statusCode).toBe(200);
       expect(prismaMock.kV.upsert).toHaveBeenCalled();
       expect(trendingCacheDeletePrefix).toHaveBeenCalledWith("ai-recs:");
-      await app.close();
     });
 
     it("rejects a URL the SSRF guard refuses", async () => {
@@ -403,7 +399,6 @@ describe("ai routes", () => {
 
       expect(res.statusCode).toBe(400);
       expect(prismaMock.kV.upsert).not.toHaveBeenCalled();
-      await app.close();
     });
 
     it("rejects a config with no model", async () => {
@@ -416,7 +411,6 @@ describe("ai routes", () => {
       });
 
       expect(res.statusCode).toBe(400);
-      await app.close();
     });
 
     it("rejects headers sent as an array", async () => {
@@ -429,7 +423,6 @@ describe("ai routes", () => {
       });
 
       expect(res.statusCode).toBe(400);
-      await app.close();
     });
 
     it("clamps a too-small max_tokens up to the floor", async () => {
@@ -445,8 +438,7 @@ describe("ai routes", () => {
 
       expect(res.statusCode).toBe(200);
       const saved = JSON.parse(prismaMock.kV.upsert.mock.calls[0][0].create.value);
-      expect(saved.payload.max_tokens).toBe(MIN_AI_CONFIG_MAX_TOKENS);
-      await app.close();
+      expect(saved.payload.max_tokens).toBe(await minAiConfigMaxTokens());
     });
 
     it("keeps a max_tokens already above the floor", async () => {
@@ -460,7 +452,6 @@ describe("ai routes", () => {
 
       const saved = JSON.parse(prismaMock.kV.upsert.mock.calls[0][0].create.value);
       expect(saved.payload.max_tokens).toBe(8000);
-      await app.close();
     });
 
     it("rejects a negative max_tokens", async () => {
@@ -473,7 +464,6 @@ describe("ai routes", () => {
       });
 
       expect(res.statusCode).toBe(400);
-      await app.close();
     });
 
     it("clears both the config and the last-generated marker on delete", async () => {
@@ -485,7 +475,6 @@ describe("ai routes", () => {
       expect(prismaMock.kV.deleteMany).toHaveBeenCalledWith({
         where: { key: { in: ["ai:config", "ai:lastRecsGeneratedAt"] } },
       });
-      await app.close();
     });
   });
 
@@ -503,7 +492,6 @@ describe("ai routes", () => {
       const res = await app.inject({ method: "POST", url: "/ai/test", payload: { config: validConfig } });
 
       expect(res.json()).toEqual({ success: true, response: "OK" });
-      await app.close();
     });
 
     it("does not follow redirects, so an allowed host cannot bounce the request inward", async () => {
@@ -517,7 +505,6 @@ describe("ai routes", () => {
       await app.inject({ method: "POST", url: "/ai/test", payload: { config: validConfig } });
 
       expect(fetchMock.mock.calls[0][1]).toMatchObject({ redirect: "error" });
-      await app.close();
     });
 
     it("reports only the status code, never the upstream body", async () => {
@@ -533,7 +520,6 @@ describe("ai routes", () => {
 
       expect(res.json()).toEqual({ success: false, error: "HTTP 500" });
       expect(res.body).not.toContain("hunter2");
-      await app.close();
     });
 
     it("refuses a URL whose hostname resolves to a blocked address", async () => {
@@ -546,7 +532,6 @@ describe("ai routes", () => {
 
       expect(res.json().success).toBe(false);
       expect(fetchMock).not.toHaveBeenCalled();
-      await app.close();
     });
 
     it("reports a transport failure rather than throwing", async () => {
@@ -557,7 +542,6 @@ describe("ai routes", () => {
 
       expect(res.statusCode).toBe(200);
       expect(res.json()).toMatchObject({ success: false, error: "connect ECONNREFUSED" });
-      await app.close();
     });
 
     it("rejects an invalid config without making a request", async () => {
@@ -569,7 +553,6 @@ describe("ai routes", () => {
 
       expect(res.json().success).toBe(false);
       expect(fetchMock).not.toHaveBeenCalled();
-      await app.close();
     });
   });
 
@@ -581,7 +564,6 @@ describe("ai routes", () => {
 
       expect(res.json()).toEqual({ refreshed: true });
       expect(trendingCacheDeletePrefix).toHaveBeenCalledWith("ai-recs:");
-      await app.close();
     });
   });
 });

--- a/apps/api/src/routes/ai.test.ts
+++ b/apps/api/src/routes/ai.test.ts
@@ -1,0 +1,587 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import Fastify, { type FastifyInstance } from "fastify";
+
+const PROFILE_ID = "11111111-1111-4111-8111-111111111111";
+const MIN_AI_CONFIG_MAX_TOKENS = 2048;
+
+const prismaMock = {
+  kV: { findUnique: vi.fn(), upsert: vi.fn(), deleteMany: vi.fn() },
+  watchEvent: { findMany: vi.fn() },
+  seriesProgress: { findMany: vi.fn() },
+  metadata: { findMany: vi.fn() },
+};
+
+const trending = vi.fn();
+const popular = vi.fn();
+const recommendations = vi.fn();
+const getTmdb = vi.fn();
+const upsertMetadata = vi.fn();
+const getRpdbApiKey = vi.fn();
+const trendingCacheGet = vi.fn();
+const trendingCacheSet = vi.fn();
+const trendingCacheDeletePrefix = vi.fn();
+const getAiConfig = vi.fn();
+const isAiConfigured = vi.fn();
+const getAiRecommendations = vi.fn();
+const loadRecommendations = vi.fn();
+const validateAiProviderUrl = vi.fn();
+const resolveAiProviderUrl = vi.fn();
+
+vi.mock("../lib/prisma.js", () => ({ prisma: prismaMock }));
+vi.mock("../lib/tmdb-client.js", () => ({ getTmdb: () => getTmdb() }));
+vi.mock("../lib/metadata.js", () => ({ upsertMetadata: (...a: unknown[]) => upsertMetadata(...a) }));
+vi.mock("../lib/rpdb.js", () => ({
+  getRpdbApiKey: () => getRpdbApiKey(),
+  applyRpdbToMetaList: (metas: unknown[]) => metas,
+}));
+vi.mock("../lib/cache.js", () => ({
+  trendingCacheGet: (...a: unknown[]) => trendingCacheGet(...a),
+  trendingCacheSet: (...a: unknown[]) => trendingCacheSet(...a),
+  trendingCacheDeletePrefix: (...a: unknown[]) => trendingCacheDeletePrefix(...a),
+}));
+vi.mock("../lib/ai.js", () => ({
+  AI_CONFIG_KEY: "ai:config",
+  AI_LAST_RECS_GENERATED_AT_KEY: "ai:lastRecsGeneratedAt",
+  MIN_AI_CONFIG_MAX_TOKENS,
+  getAiConfig: () => getAiConfig(),
+  isAiConfigured: () => isAiConfigured(),
+  redactAiConfig: (c: Record<string, unknown>) => ({ ...c, headers: { Authorization: "***" } }),
+  getAiRecommendations: (...a: unknown[]) => getAiRecommendations(...a),
+}));
+vi.mock("../lib/recommendations.js", () => ({
+  loadRecommendations: (...a: unknown[]) => loadRecommendations(...a),
+}));
+vi.mock("../lib/ssrf.js", () => ({
+  validateAiProviderUrl: (...a: unknown[]) => validateAiProviderUrl(...a),
+  resolveAiProviderUrl: (...a: unknown[]) => resolveAiProviderUrl(...a),
+}));
+vi.mock("../lib/profile.js", () => ({
+  resolveProfile: async (request: { profileId?: string }) => {
+    request.profileId = PROFILE_ID;
+  },
+}));
+
+const buildApp = async (): Promise<FastifyInstance> => {
+  vi.resetModules();
+  const { default: aiRoutes } = await import("./ai.js");
+  const app = Fastify({ logger: false });
+  await app.register(aiRoutes);
+  await app.ready();
+  return app;
+};
+
+const tmdbResult = (over: Record<string, unknown> = {}) => ({
+  imdbId: "tt1",
+  tmdbId: 100,
+  name: "A Title",
+  poster: "p.jpg",
+  year: 2020,
+  description: "desc",
+  genres: ["Drama"],
+  rating: 7,
+  ...over,
+});
+
+const validConfig = {
+  url: "https://api.example.com/v1/chat/completions",
+  headers: { Authorization: "Bearer sk-test" },
+  payload: { model: "gpt-4o-mini" },
+};
+
+describe("ai routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getTmdb.mockResolvedValue({ trending, popular, recommendations });
+    trending.mockResolvedValue([tmdbResult()]);
+    popular.mockResolvedValue([tmdbResult()]);
+    recommendations.mockResolvedValue([tmdbResult({ imdbId: "tt2", tmdbId: 200 })]);
+    upsertMetadata.mockResolvedValue(undefined);
+    getRpdbApiKey.mockResolvedValue(null);
+    trendingCacheGet.mockReturnValue(undefined);
+    isAiConfigured.mockResolvedValue(false);
+    getAiConfig.mockResolvedValue(null);
+    loadRecommendations.mockResolvedValue({ metas: [] });
+    validateAiProviderUrl.mockReturnValue(true);
+    resolveAiProviderUrl.mockResolvedValue(true);
+    prismaMock.kV.findUnique.mockResolvedValue(null);
+    prismaMock.kV.upsert.mockResolvedValue({});
+    prismaMock.kV.deleteMany.mockResolvedValue({ count: 1 });
+    prismaMock.watchEvent.findMany.mockResolvedValue([]);
+    prismaMock.seriesProgress.findMany.mockResolvedValue([]);
+    prismaMock.metadata.findMany.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe("GET /recommendations", () => {
+    it("loads similar titles for an imdbId", async () => {
+      loadRecommendations.mockResolvedValue({ metas: [{ id: "tt2" }] });
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/recommendations?imdbId=tt1&type=series" });
+
+      expect(res.statusCode).toBe(200);
+      expect(loadRecommendations).toHaveBeenCalledWith("series", "series", "tt1");
+      await app.close();
+    });
+
+    it("requires an imdbId", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/recommendations" });
+
+      expect(res.statusCode).toBe(400);
+      await app.close();
+    });
+
+    it("rejects an unsupported type", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/recommendations?imdbId=tt1&type=episode" });
+
+      expect(res.statusCode).toBe(400);
+      expect(loadRecommendations).not.toHaveBeenCalled();
+      await app.close();
+    });
+  });
+
+  describe("GET /recommendations/personal", () => {
+    it("returns nothing when there is no watch history to seed from", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/recommendations/personal" });
+
+      expect(res.json()).toEqual({ metas: [] });
+      expect(getTmdb).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it("seeds movie recommendations from recent watches", async () => {
+      prismaMock.watchEvent.findMany.mockResolvedValue([{ imdbId: "tt1" }]);
+      prismaMock.metadata.findMany.mockResolvedValue([{ imdbId: "tt1", tmdbId: 100 }]);
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/recommendations/personal" });
+
+      expect(res.statusCode).toBe(200);
+      expect(recommendations).toHaveBeenCalledWith("movie", 100);
+      expect(res.json().metas).toEqual([expect.objectContaining({ id: "tt2" })]);
+      await app.close();
+    });
+
+    it("seeds series recommendations from series progress", async () => {
+      prismaMock.seriesProgress.findMany.mockResolvedValue([{ seriesImdbId: "tt9" }]);
+      prismaMock.metadata.findMany.mockResolvedValue([{ imdbId: "tt9", tmdbId: 900 }]);
+      const app = await buildApp();
+
+      await app.inject({ method: "GET", url: "/recommendations/personal?type=series" });
+
+      expect(prismaMock.watchEvent.findMany).not.toHaveBeenCalled();
+      expect(recommendations).toHaveBeenCalledWith("series", 900);
+      await app.close();
+    });
+
+    it("never recommends a seed back to the user", async () => {
+      prismaMock.watchEvent.findMany.mockResolvedValue([{ imdbId: "tt1" }]);
+      prismaMock.metadata.findMany.mockResolvedValue([{ imdbId: "tt1", tmdbId: 100 }]);
+      recommendations.mockResolvedValue([tmdbResult({ imdbId: "tt1" })]);
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/recommendations/personal" });
+
+      expect(res.json().metas).toEqual([]);
+      await app.close();
+    });
+
+    it("clamps the limit to 40", async () => {
+      prismaMock.watchEvent.findMany.mockResolvedValue([{ imdbId: "tt1" }]);
+      prismaMock.metadata.findMany.mockResolvedValue([{ imdbId: "tt1", tmdbId: 100 }]);
+      recommendations.mockResolvedValue(
+        Array.from({ length: 100 }, (_, i) => tmdbResult({ imdbId: `tt${i + 10}` }))
+      );
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/recommendations/personal?limit=1000" });
+
+      expect(res.json().metas).toHaveLength(40);
+      await app.close();
+    });
+
+    it("prefers AI recommendations when the provider is configured", async () => {
+      isAiConfigured.mockResolvedValue(true);
+      getAiRecommendations.mockResolvedValue({ metas: [{ id: "ai1" }], reasons: {} });
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/recommendations/personal" });
+
+      expect(res.json().metas).toEqual([{ id: "ai1" }]);
+      expect(prismaMock.watchEvent.findMany).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it("falls back to TMDB seeds when the AI call yields nothing", async () => {
+      isAiConfigured.mockResolvedValue(true);
+      getAiRecommendations.mockResolvedValue(null);
+      prismaMock.watchEvent.findMany.mockResolvedValue([{ imdbId: "tt1" }]);
+      prismaMock.metadata.findMany.mockResolvedValue([{ imdbId: "tt1", tmdbId: 100 }]);
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/recommendations/personal" });
+
+      expect(res.json().metas).toEqual([expect.objectContaining({ id: "tt2" })]);
+      await app.close();
+    });
+
+    it("degrades to an empty list when TMDB is unavailable", async () => {
+      prismaMock.watchEvent.findMany.mockResolvedValue([{ imdbId: "tt1" }]);
+      prismaMock.metadata.findMany.mockResolvedValue([{ imdbId: "tt1", tmdbId: 100 }]);
+      getTmdb.mockRejectedValue(new Error("no key"));
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/recommendations/personal" });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual({ metas: [] });
+      await app.close();
+    });
+
+    it("returns an empty list rather than an error for an unsupported type", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/recommendations/personal?type=episode" });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual({ metas: [] });
+      await app.close();
+    });
+  });
+
+  describe("GET /recommendations/ai", () => {
+    it("returns AI results with their reasons when configured", async () => {
+      isAiConfigured.mockResolvedValue(true);
+      getAiRecommendations.mockResolvedValue({ metas: [{ id: "tt5" }], reasons: { tt5: "because" } });
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/recommendations/ai" });
+
+      expect(res.json()).toEqual({ metas: [{ id: "tt5" }], reasons: { tt5: "because" } });
+      await app.close();
+    });
+
+    it("falls back to TMDB seeds with no reasons when AI is not configured", async () => {
+      prismaMock.watchEvent.findMany.mockResolvedValue([{ imdbId: "tt1" }]);
+      prismaMock.metadata.findMany.mockResolvedValue([{ imdbId: "tt1", tmdbId: 100 }]);
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/recommendations/ai" });
+
+      expect(res.json()).toMatchObject({ reasons: {} });
+      expect(res.json().metas).toHaveLength(1);
+      await app.close();
+    });
+
+    it("returns an empty result for an unsupported type", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/recommendations/ai?type=episode" });
+
+      expect(res.json()).toEqual({ metas: [], reasons: {} });
+      await app.close();
+    });
+  });
+
+  describe("GET /trending and /popular", () => {
+    it("fetches and caches trending titles", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/trending?type=series&window=day" });
+
+      expect(res.statusCode).toBe(200);
+      expect(trending).toHaveBeenCalledWith("series", "day");
+      expect(trendingCacheSet).toHaveBeenCalledWith("trending:series:day", expect.anything());
+      await app.close();
+    });
+
+    it("treats any window other than `day` as a week", async () => {
+      const app = await buildApp();
+
+      await app.inject({ method: "GET", url: "/trending?window=month" });
+
+      expect(trending).toHaveBeenCalledWith("movie", "week");
+      await app.close();
+    });
+
+    it("serves trending from cache without calling TMDB", async () => {
+      trendingCacheGet.mockReturnValue({ data: [{ id: "tt9", name: "Cached" }] });
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/trending" });
+
+      expect(res.json().metas[0].name).toBe("Cached");
+      expect(getTmdb).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it("rejects an unsupported trending type", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/trending?type=episode" });
+
+      expect(res.statusCode).toBe(400);
+      await app.close();
+    });
+
+    it("returns 500 when TMDB is unconfigured", async () => {
+      getTmdb.mockRejectedValue(new Error("no key"));
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/popular" });
+
+      expect(res.statusCode).toBe(500);
+      await app.close();
+    });
+
+    it("returns 500 and caches nothing when the popular fetch fails", async () => {
+      popular.mockRejectedValue(new Error("upstream"));
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/popular" });
+
+      expect(res.statusCode).toBe(500);
+      expect(trendingCacheSet).not.toHaveBeenCalled();
+      await app.close();
+    });
+  });
+
+  describe("AI config", () => {
+    it("redacts the stored headers when reporting the config", async () => {
+      getAiConfig.mockResolvedValue(validConfig);
+      prismaMock.kV.findUnique.mockResolvedValue({ value: "2026-01-01T00:00:00.000Z" });
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/ai/config" });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.configured).toBe(true);
+      expect(body.config.headers.Authorization).toBe("***");
+      expect(body.lastGeneratedAt).toBe("2026-01-01T00:00:00.000Z");
+      await app.close();
+    });
+
+    it("reports unconfigured when no config is stored", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/ai/config" });
+
+      expect(res.json()).toMatchObject({ configured: false, config: null });
+      await app.close();
+    });
+
+    it("saves a valid config and drops the cached recommendations", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "POST", url: "/ai/config", payload: { config: validConfig } });
+
+      expect(res.statusCode).toBe(200);
+      expect(prismaMock.kV.upsert).toHaveBeenCalled();
+      expect(trendingCacheDeletePrefix).toHaveBeenCalledWith("ai-recs:");
+      await app.close();
+    });
+
+    it("rejects a URL the SSRF guard refuses", async () => {
+      validateAiProviderUrl.mockReturnValue(false);
+      const app = await buildApp();
+
+      const res = await app.inject({
+        method: "POST",
+        url: "/ai/config",
+        payload: { config: { ...validConfig, url: "http://169.254.169.254/" } },
+      });
+
+      expect(res.statusCode).toBe(400);
+      expect(prismaMock.kV.upsert).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it("rejects a config with no model", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({
+        method: "POST",
+        url: "/ai/config",
+        payload: { config: { ...validConfig, payload: {} } },
+      });
+
+      expect(res.statusCode).toBe(400);
+      await app.close();
+    });
+
+    it("rejects headers sent as an array", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({
+        method: "POST",
+        url: "/ai/config",
+        payload: { config: { ...validConfig, headers: ["Authorization: x"] } },
+      });
+
+      expect(res.statusCode).toBe(400);
+      await app.close();
+    });
+
+    it("clamps a too-small max_tokens up to the floor", async () => {
+      // Below the floor the model truncates its JSON mid-response, which reads
+      // as "AI recommendations are broken" rather than as a config problem.
+      const app = await buildApp();
+
+      const res = await app.inject({
+        method: "POST",
+        url: "/ai/config",
+        payload: { config: { ...validConfig, payload: { model: "m", max_tokens: 16 } } },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const saved = JSON.parse(prismaMock.kV.upsert.mock.calls[0][0].create.value);
+      expect(saved.payload.max_tokens).toBe(MIN_AI_CONFIG_MAX_TOKENS);
+      await app.close();
+    });
+
+    it("keeps a max_tokens already above the floor", async () => {
+      const app = await buildApp();
+
+      await app.inject({
+        method: "POST",
+        url: "/ai/config",
+        payload: { config: { ...validConfig, payload: { model: "m", max_tokens: 8000 } } },
+      });
+
+      const saved = JSON.parse(prismaMock.kV.upsert.mock.calls[0][0].create.value);
+      expect(saved.payload.max_tokens).toBe(8000);
+      await app.close();
+    });
+
+    it("rejects a negative max_tokens", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({
+        method: "POST",
+        url: "/ai/config",
+        payload: { config: { ...validConfig, payload: { model: "m", max_tokens: -1 } } },
+      });
+
+      expect(res.statusCode).toBe(400);
+      await app.close();
+    });
+
+    it("clears both the config and the last-generated marker on delete", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "DELETE", url: "/ai/config" });
+
+      expect(res.json()).toEqual({ configured: false });
+      expect(prismaMock.kV.deleteMany).toHaveBeenCalledWith({
+        where: { key: { in: ["ai:config", "ai:lastRecsGeneratedAt"] } },
+      });
+      await app.close();
+    });
+  });
+
+  describe("POST /ai/test", () => {
+    it("reports the provider's reply on success", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: async () => ({ choices: [{ message: { content: " OK " } }] }),
+        })
+      );
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "POST", url: "/ai/test", payload: { config: validConfig } });
+
+      expect(res.json()).toEqual({ success: true, response: "OK" });
+      await app.close();
+    });
+
+    it("does not follow redirects, so an allowed host cannot bounce the request inward", async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ choices: [{ message: { content: "OK" } }] }),
+      });
+      vi.stubGlobal("fetch", fetchMock);
+      const app = await buildApp();
+
+      await app.inject({ method: "POST", url: "/ai/test", payload: { config: validConfig } });
+
+      expect(fetchMock.mock.calls[0][1]).toMatchObject({ redirect: "error" });
+      await app.close();
+    });
+
+    it("reports only the status code, never the upstream body", async () => {
+      // Echoing the body would turn this endpoint into an SSRF probe.
+      const secret = "internal service says: db password is hunter2";
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({ ok: false, status: 500, json: async () => ({ error: secret }) })
+      );
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "POST", url: "/ai/test", payload: { config: validConfig } });
+
+      expect(res.json()).toEqual({ success: false, error: "HTTP 500" });
+      expect(res.body).not.toContain("hunter2");
+      await app.close();
+    });
+
+    it("refuses a URL whose hostname resolves to a blocked address", async () => {
+      resolveAiProviderUrl.mockResolvedValue(false);
+      const fetchMock = vi.fn();
+      vi.stubGlobal("fetch", fetchMock);
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "POST", url: "/ai/test", payload: { config: validConfig } });
+
+      expect(res.json().success).toBe(false);
+      expect(fetchMock).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it("reports a transport failure rather than throwing", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("connect ECONNREFUSED")));
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "POST", url: "/ai/test", payload: { config: validConfig } });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toMatchObject({ success: false, error: "connect ECONNREFUSED" });
+      await app.close();
+    });
+
+    it("rejects an invalid config without making a request", async () => {
+      const fetchMock = vi.fn();
+      vi.stubGlobal("fetch", fetchMock);
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "POST", url: "/ai/test", payload: { config: { url: "x" } } });
+
+      expect(res.json().success).toBe(false);
+      expect(fetchMock).not.toHaveBeenCalled();
+      await app.close();
+    });
+  });
+
+  describe("POST /recommendations/ai/refresh", () => {
+    it("drops the cached AI recommendations", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "POST", url: "/recommendations/ai/refresh" });
+
+      expect(res.json()).toEqual({ refreshed: true });
+      expect(trendingCacheDeletePrefix).toHaveBeenCalledWith("ai-recs:");
+      await app.close();
+    });
+  });
+});

--- a/apps/api/src/routes/calendar.test.ts
+++ b/apps/api/src/routes/calendar.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import Fastify, { type FastifyInstance } from "fastify";
+import type { FastifyInstance } from "fastify";
+import { buildRouteApp } from "../lib/test-fixtures/route-app.js";
 
 const PROFILE_ID = "11111111-1111-4111-8111-111111111111";
 
@@ -16,14 +17,8 @@ vi.mock("../lib/profile.js", () => ({
   },
 }));
 
-const buildApp = async (): Promise<FastifyInstance> => {
-  vi.resetModules();
-  const { default: calendarRoutes } = await import("./calendar.js");
-  const app = Fastify();
-  await app.register(calendarRoutes);
-  await app.ready();
-  return app;
-};
+const buildApp = (): Promise<FastifyInstance> =>
+  buildRouteApp(() => import("./calendar.js"));
 
 /** The `days` argument the route passed through to the lookup. */
 const daysArg = () => getUpcomingEpisodes.mock.calls[0][1];
@@ -42,7 +37,6 @@ describe("calendar routes", () => {
 
     expect(res.statusCode).toBe(200);
     expect(getUpcomingEpisodes).toHaveBeenCalledWith(PROFILE_ID, 30, 30, false);
-    await app.close();
   });
 
   it("honours an explicit window", async () => {
@@ -51,7 +45,6 @@ describe("calendar routes", () => {
     await app.inject({ method: "GET", url: "/calendar?days=7" });
 
     expect(daysArg()).toBe(7);
-    await app.close();
   });
 
   it("clamps a window longer than 90 days", async () => {
@@ -60,7 +53,6 @@ describe("calendar routes", () => {
     await app.inject({ method: "GET", url: "/calendar?days=365" });
 
     expect(daysArg()).toBe(90);
-    await app.close();
   });
 
   it("clamps a zero or negative window up to a day", async () => {
@@ -69,7 +61,6 @@ describe("calendar routes", () => {
     await app.inject({ method: "GET", url: "/calendar?days=-5" });
 
     expect(daysArg()).toBe(1);
-    await app.close();
   });
 
   it("falls back to the default when days is not a number", async () => {
@@ -79,7 +70,6 @@ describe("calendar routes", () => {
     await app.inject({ method: "GET", url: "/calendar?days=soon" });
 
     expect(daysArg()).toBe(30);
-    await app.close();
   });
 
   it("passes the spoiler-protection setting through", async () => {
@@ -89,7 +79,6 @@ describe("calendar routes", () => {
     await app.inject({ method: "GET", url: "/calendar" });
 
     expect(getUpcomingEpisodes).toHaveBeenCalledWith(PROFILE_ID, 30, 30, true);
-    await app.close();
   });
 
   it("returns the calendar under a `calendar` key", async () => {
@@ -99,6 +88,5 @@ describe("calendar routes", () => {
     const res = await app.inject({ method: "GET", url: "/calendar" });
 
     expect(res.json().calendar).toHaveLength(1);
-    await app.close();
   });
 });

--- a/apps/api/src/routes/calendar.test.ts
+++ b/apps/api/src/routes/calendar.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import Fastify, { type FastifyInstance } from "fastify";
+
+const PROFILE_ID = "11111111-1111-4111-8111-111111111111";
+
+const getUpcomingEpisodes = vi.fn();
+const getSpoilerProtection = vi.fn();
+
+vi.mock("../lib/upcoming-episodes.js", () => ({
+  getUpcomingEpisodes: (...a: unknown[]) => getUpcomingEpisodes(...a),
+}));
+vi.mock("../lib/settings.js", () => ({ getSpoilerProtection: () => getSpoilerProtection() }));
+vi.mock("../lib/profile.js", () => ({
+  resolveProfile: async (request: { profileId?: string }) => {
+    request.profileId = PROFILE_ID;
+  },
+}));
+
+const buildApp = async (): Promise<FastifyInstance> => {
+  vi.resetModules();
+  const { default: calendarRoutes } = await import("./calendar.js");
+  const app = Fastify();
+  await app.register(calendarRoutes);
+  await app.ready();
+  return app;
+};
+
+/** The `days` argument the route passed through to the lookup. */
+const daysArg = () => getUpcomingEpisodes.mock.calls[0][1];
+
+describe("calendar routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getUpcomingEpisodes.mockResolvedValue([]);
+    getSpoilerProtection.mockResolvedValue(false);
+  });
+
+  it("looks 30 days ahead by default", async () => {
+    const app = await buildApp();
+
+    const res = await app.inject({ method: "GET", url: "/calendar" });
+
+    expect(res.statusCode).toBe(200);
+    expect(getUpcomingEpisodes).toHaveBeenCalledWith(PROFILE_ID, 30, 30, false);
+    await app.close();
+  });
+
+  it("honours an explicit window", async () => {
+    const app = await buildApp();
+
+    await app.inject({ method: "GET", url: "/calendar?days=7" });
+
+    expect(daysArg()).toBe(7);
+    await app.close();
+  });
+
+  it("clamps a window longer than 90 days", async () => {
+    const app = await buildApp();
+
+    await app.inject({ method: "GET", url: "/calendar?days=365" });
+
+    expect(daysArg()).toBe(90);
+    await app.close();
+  });
+
+  it("clamps a zero or negative window up to a day", async () => {
+    const app = await buildApp();
+
+    await app.inject({ method: "GET", url: "/calendar?days=-5" });
+
+    expect(daysArg()).toBe(1);
+    await app.close();
+  });
+
+  it("falls back to the default when days is not a number", async () => {
+    // `Number("soon")` is NaN, which would otherwise reach the query as-is.
+    const app = await buildApp();
+
+    await app.inject({ method: "GET", url: "/calendar?days=soon" });
+
+    expect(daysArg()).toBe(30);
+    await app.close();
+  });
+
+  it("passes the spoiler-protection setting through", async () => {
+    getSpoilerProtection.mockResolvedValue(true);
+    const app = await buildApp();
+
+    await app.inject({ method: "GET", url: "/calendar" });
+
+    expect(getUpcomingEpisodes).toHaveBeenCalledWith(PROFILE_ID, 30, 30, true);
+    await app.close();
+  });
+
+  it("returns the calendar under a `calendar` key", async () => {
+    getUpcomingEpisodes.mockResolvedValue([{ date: "2026-02-01", episodes: [] }]);
+    const app = await buildApp();
+
+    const res = await app.inject({ method: "GET", url: "/calendar" });
+
+    expect(res.json().calendar).toHaveLength(1);
+    await app.close();
+  });
+});

--- a/apps/api/src/routes/export.test.ts
+++ b/apps/api/src/routes/export.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import Fastify, { type FastifyInstance } from "fastify";
+import type { FastifyInstance } from "fastify";
+import { buildRouteApp } from "../lib/test-fixtures/route-app.js";
 import { MAX_IMPORT_ROWS } from "../lib/import-validation.js";
 
 const PROFILE_ID = "11111111-1111-4111-8111-111111111111";
@@ -46,14 +47,8 @@ const resetMocks = () => {
 // `bodyLimit` mirrors the configurable ceiling index.ts sets from
 // MAX_BODY_SIZE_MB; the row caps below it only come into play once a
 // deployment has raised the byte ceiling enough to fit that many rows.
-const buildApp = async (bodyLimit?: number): Promise<FastifyInstance> => {
-  vi.resetModules();
-  const { default: exportRoutes } = await import("./export.js");
-  const app = Fastify(bodyLimit ? { bodyLimit } : {});
-  await app.register(exportRoutes);
-  await app.ready();
-  return app;
-};
+const buildApp = (bodyLimit?: number): Promise<FastifyInstance> =>
+  buildRouteApp(() => import("./export.js"), bodyLimit ? { bodyLimit } : {});
 
 describe("export routes", () => {
   beforeEach(() => {
@@ -66,14 +61,12 @@ describe("export routes", () => {
       const response = await app.inject({ method: "POST", url: "/import", payload: { lists: [] } });
       expect(response.statusCode).toBe(400);
       expect(response.json()).toEqual(expect.objectContaining({ error: expect.stringContaining("version") }));
-      await app.close();
     });
 
     it("rejects a payload with a mismatched version", async () => {
       const app = await buildApp();
       const response = await app.inject({ method: "POST", url: "/import", payload: { version: 99, lists: [] } });
       expect(response.statusCode).toBe(400);
-      await app.close();
     });
 
     it("accepts a payload with the correct version and an empty body otherwise", async () => {
@@ -83,7 +76,6 @@ describe("export routes", () => {
       expect(response.json()).toEqual(
         expect.objectContaining({ status: "imported", summary: { lists: 0, listItems: 0, watchEvents: 0, seriesProgress: 0, ratings: 0 } })
       );
-      await app.close();
     });
   });
 
@@ -108,7 +100,6 @@ describe("export routes", () => {
         data: [expect.objectContaining({ imdbId: "tt1", type: "movie", plays: 1 })],
       });
       expect(response.json().summary.watchEvents).toBe(1);
-      await app.close();
     });
 
     it("increments plays for a duplicate watch event instead of creating a new row", async () => {
@@ -139,7 +130,6 @@ describe("export routes", () => {
       expect(prismaMock.watchEvent.update).toHaveBeenCalledWith(
         expect.objectContaining({ where: { id: "existing-1" }, data: { plays: { increment: 2 } } })
       );
-      await app.close();
     });
 
     it("skips a watch event entry with an invalid date", async () => {
@@ -153,7 +143,6 @@ describe("export routes", () => {
       expect(response.statusCode).toBe(200);
       expect(response.json().summary.watchEvents).toBe(0);
       expect(prismaMock.watchEvent.createMany).not.toHaveBeenCalled();
-      await app.close();
     });
 
     it("skips a watch event entry with an invalid type", async () => {
@@ -165,7 +154,6 @@ describe("export routes", () => {
       });
 
       expect(response.json().summary.watchEvents).toBe(0);
-      await app.close();
     });
   });
 
@@ -174,7 +162,6 @@ describe("export routes", () => {
       const app = await buildApp();
       const response = await app.inject({ method: "POST", url: "/import/csv", payload: {} });
       expect(response.statusCode).toBe(400);
-      await app.close();
     });
 
     it("rejects when the required header columns are missing", async () => {
@@ -185,7 +172,6 @@ describe("export routes", () => {
         payload: { csv: "foo,bar\n1,2" },
       });
       expect(response.statusCode).toBe(400);
-      await app.close();
     });
 
     it("imports a simple movie row", async () => {
@@ -203,7 +189,6 @@ describe("export routes", () => {
       expect(prismaMock.watchEvent.createMany).toHaveBeenCalledWith({
         data: [expect.objectContaining({ imdbId: "tt1", type: "movie" })],
       });
-      await app.close();
     });
 
     it("imports a quoted field", async () => {
@@ -217,7 +202,6 @@ describe("export routes", () => {
       expect(prismaMock.watchEvent.createMany).toHaveBeenCalledWith({
         data: [expect.objectContaining({ imdbId: "tt1" })],
       });
-      await app.close();
     });
 
     it("skips rows with missing required fields and counts them", async () => {
@@ -228,7 +212,6 @@ describe("export routes", () => {
       const response = await app.inject({ method: "POST", url: "/import/csv", payload: { csv } });
 
       expect(response.json().summary).toEqual({ imported: 1, skipped: 1 });
-      await app.close();
     });
 
     it("skips rows with an invalid type", async () => {
@@ -239,7 +222,6 @@ describe("export routes", () => {
       const response = await app.inject({ method: "POST", url: "/import/csv", payload: { csv } });
 
       expect(response.json().summary).toEqual({ imported: 0, skipped: 1 });
-      await app.close();
     });
 
     it("skips blank lines without counting them as imported or skipped", async () => {
@@ -250,7 +232,6 @@ describe("export routes", () => {
       const response = await app.inject({ method: "POST", url: "/import/csv", payload: { csv } });
 
       expect(response.json().summary).toEqual({ imported: 1, skipped: 0 });
-      await app.close();
     });
 
     it("sets seriesImdbId for episode rows and increments plays on a duplicate", async () => {
@@ -274,7 +255,6 @@ describe("export routes", () => {
       expect(prismaMock.watchEvent.update).toHaveBeenCalledWith(
         expect.objectContaining({ where: { id: "existing-ep" }, data: { plays: { increment: 1 } } })
       );
-      await app.close();
     });
 
     it("returns 200 with an empty summary when the CSV has only a header row", async () => {
@@ -287,7 +267,6 @@ describe("export routes", () => {
       // header parses, but there are no data rows to import — should be empty summary, not a crash
       expect(response.statusCode).toBe(200);
       expect(response.json().summary).toEqual({ imported: 0, skipped: 0 });
-      await app.close();
     });
   });
 
@@ -314,7 +293,6 @@ describe("export routes", () => {
         seriesProgress: 0,
         ratings: 0,
       });
-      await app.close();
     });
 
     it("skips rows whose imdbId isn't an IMDb id", async () => {
@@ -339,7 +317,6 @@ describe("export routes", () => {
       );
       expect(prismaMock.listItem.createMany).not.toHaveBeenCalled();
       expect(prismaMock.rating.createMany).not.toHaveBeenCalled();
-      await app.close();
     });
 
     it("skips a season/episode that would overflow the 32-bit column", async () => {
@@ -362,7 +339,6 @@ describe("export routes", () => {
       expect(response.json().summary).toEqual(
         expect.objectContaining({ watchEvents: 0, seriesProgress: 0 })
       );
-      await app.close();
     });
 
     it("skips a rating outside the 0-10 scale", async () => {
@@ -387,7 +363,6 @@ describe("export routes", () => {
           data: [expect.objectContaining({ imdbId: "tt3", rating: 7.5 })],
         })
       );
-      await app.close();
     });
 
     it("rejects a collection with more rows than the import limit", async () => {
@@ -403,7 +378,6 @@ describe("export routes", () => {
       expect(response.statusCode).toBe(413);
       expect(response.json().code).toBe("too_many_rows");
       expect(prismaMock.watchEvent.createMany).not.toHaveBeenCalled();
-      await app.close();
     });
 
     it("writes ratings in one batch rather than one round trip each", async () => {
@@ -434,7 +408,6 @@ describe("export routes", () => {
       expect(prismaMock.rating.updateMany).toHaveBeenCalledWith(
         expect.objectContaining({ where: expect.objectContaining({ imdbId: "tt2" }), data: expect.objectContaining({ rating: 9 }) })
       );
-      await app.close();
     });
   });
 
@@ -445,7 +418,6 @@ describe("export routes", () => {
       const response = await app.inject({ method: "POST", url: "/import/csv", payload: { csv } });
 
       expect(response.json().summary).toEqual({ imported: 0, skipped: 1 });
-      await app.close();
     });
 
     it("skips a row whose season would overflow the column", async () => {
@@ -454,7 +426,6 @@ describe("export routes", () => {
       const response = await app.inject({ method: "POST", url: "/import/csv", payload: { csv } });
 
       expect(response.json().summary).toEqual({ imported: 0, skipped: 1 });
-      await app.close();
     });
   });
 
@@ -474,7 +445,6 @@ describe("export routes", () => {
       const response = await app.inject({ method: "GET", url: "/export" });
       expect(response.statusCode).toBe(200);
       expect(response.json().version).toBe(1);
-      await app.close();
     });
   });
 });

--- a/apps/api/src/routes/games-steam.test.ts
+++ b/apps/api/src/routes/games-steam.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import Fastify, { type FastifyInstance } from "fastify";
+
+const PROFILE_ID = "11111111-1111-4111-8111-111111111111";
+
+const getPlayerSummary = vi.fn();
+const getSteam = vi.fn();
+const isSteamSyncConfigured = vi.fn();
+const syncSteamLibrary = vi.fn();
+
+vi.mock("../lib/steam-client.js", () => ({ getSteam: () => getSteam() }));
+vi.mock("../lib/steam-sync.js", () => ({
+  isSteamSyncConfigured: () => isSteamSyncConfigured(),
+  syncSteamLibrary: (...a: unknown[]) => syncSteamLibrary(...a),
+}));
+vi.mock("../lib/profile.js", () => ({
+  resolveProfile: async (request: { profileId?: string }) => {
+    request.profileId = PROFILE_ID;
+  },
+}));
+
+const buildApp = async (): Promise<FastifyInstance> => {
+  vi.resetModules();
+  const { default: gamesSteamRoutes } = await import("./games-steam.js");
+  const app = Fastify({ logger: false });
+  await app.register(gamesSteamRoutes);
+  await app.ready();
+  return app;
+};
+
+describe("Steam games routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.STEAM_ID = "76561198000000000";
+    getSteam.mockReturnValue({ getPlayerSummary });
+    getPlayerSummary.mockResolvedValue({ personaname: "player", avatar: null });
+    isSteamSyncConfigured.mockReturnValue(true);
+    syncSteamLibrary.mockResolvedValue({ added: 2, updated: 1 });
+  });
+
+  afterEach(() => {
+    delete process.env.STEAM_ID;
+  });
+
+  describe("GET /games/steam/status", () => {
+    it("reports the connected player when Steam is configured", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/games/steam/status" });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toMatchObject({ configured: true, player: { personaname: "player" } });
+      await app.close();
+    });
+
+    it("reports unconfigured without calling Steam", async () => {
+      isSteamSyncConfigured.mockReturnValue(false);
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/games/steam/status" });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual({ configured: false, player: null });
+      expect(getSteam).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it("still reports configured when the player lookup fails", async () => {
+      // The summary is a display nicety; sync does not depend on it, so a
+      // failing lookup must not read as "Steam is not set up".
+      getPlayerSummary.mockRejectedValue(new Error("Steam API 503"));
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/games/steam/status" });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual({ configured: true, player: null });
+      await app.close();
+    });
+  });
+
+  describe("POST /games/steam/sync", () => {
+    it("syncs into the calling profile and returns the summary", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "POST", url: "/games/steam/sync" });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual({ added: 2, updated: 1 });
+      expect(syncSteamLibrary).toHaveBeenCalledWith(expect.anything(), PROFILE_ID);
+      await app.close();
+    });
+
+    it("returns 500 when Steam is not configured", async () => {
+      isSteamSyncConfigured.mockReturnValue(false);
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "POST", url: "/games/steam/sync" });
+
+      expect(res.statusCode).toBe(500);
+      expect(syncSteamLibrary).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it("returns 500 when the sync throws", async () => {
+      syncSteamLibrary.mockRejectedValue(new Error("boom"));
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "POST", url: "/games/steam/sync" });
+
+      expect(res.statusCode).toBe(500);
+      expect(res.json().error).toMatch(/sync failed/i);
+      await app.close();
+    });
+  });
+});

--- a/apps/api/src/routes/games-steam.test.ts
+++ b/apps/api/src/routes/games-steam.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import Fastify, { type FastifyInstance } from "fastify";
+import type { FastifyInstance } from "fastify";
+import { buildRouteApp } from "../lib/test-fixtures/route-app.js";
 
 const PROFILE_ID = "11111111-1111-4111-8111-111111111111";
 
@@ -19,18 +20,19 @@ vi.mock("../lib/profile.js", () => ({
   },
 }));
 
-const buildApp = async (): Promise<FastifyInstance> => {
-  vi.resetModules();
-  const { default: gamesSteamRoutes } = await import("./games-steam.js");
-  const app = Fastify({ logger: false });
-  await app.register(gamesSteamRoutes);
-  await app.ready();
-  return app;
-};
+const buildApp = (): Promise<FastifyInstance> =>
+  buildRouteApp(() => import("./games-steam.js"));
 
 describe("Steam games routes", () => {
+  // The route reads STEAM_ID straight off the environment, so these tests set
+  // it. Restoring whatever was there before matters: a developer with a real
+  // STEAM_ID exported would otherwise have it deleted for every test file that
+  // runs after this one in the same worker.
+  let originalSteamId: string | undefined;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    originalSteamId = process.env.STEAM_ID;
     process.env.STEAM_ID = "76561198000000000";
     getSteam.mockReturnValue({ getPlayerSummary });
     getPlayerSummary.mockResolvedValue({ personaname: "player", avatar: null });
@@ -39,7 +41,8 @@ describe("Steam games routes", () => {
   });
 
   afterEach(() => {
-    delete process.env.STEAM_ID;
+    if (originalSteamId === undefined) delete process.env.STEAM_ID;
+    else process.env.STEAM_ID = originalSteamId;
   });
 
   describe("GET /games/steam/status", () => {
@@ -50,7 +53,6 @@ describe("Steam games routes", () => {
 
       expect(res.statusCode).toBe(200);
       expect(res.json()).toMatchObject({ configured: true, player: { personaname: "player" } });
-      await app.close();
     });
 
     it("reports unconfigured without calling Steam", async () => {
@@ -62,7 +64,6 @@ describe("Steam games routes", () => {
       expect(res.statusCode).toBe(200);
       expect(res.json()).toEqual({ configured: false, player: null });
       expect(getSteam).not.toHaveBeenCalled();
-      await app.close();
     });
 
     it("still reports configured when the player lookup fails", async () => {
@@ -75,7 +76,6 @@ describe("Steam games routes", () => {
 
       expect(res.statusCode).toBe(200);
       expect(res.json()).toEqual({ configured: true, player: null });
-      await app.close();
     });
   });
 
@@ -88,7 +88,6 @@ describe("Steam games routes", () => {
       expect(res.statusCode).toBe(200);
       expect(res.json()).toEqual({ added: 2, updated: 1 });
       expect(syncSteamLibrary).toHaveBeenCalledWith(expect.anything(), PROFILE_ID);
-      await app.close();
     });
 
     it("returns 500 when Steam is not configured", async () => {
@@ -99,7 +98,6 @@ describe("Steam games routes", () => {
 
       expect(res.statusCode).toBe(500);
       expect(syncSteamLibrary).not.toHaveBeenCalled();
-      await app.close();
     });
 
     it("returns 500 when the sync throws", async () => {
@@ -110,7 +108,6 @@ describe("Steam games routes", () => {
 
       expect(res.statusCode).toBe(500);
       expect(res.json().error).toMatch(/sync failed/i);
-      await app.close();
     });
   });
 });

--- a/apps/api/src/routes/games.test.ts
+++ b/apps/api/src/routes/games.test.ts
@@ -1,0 +1,371 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import Fastify, { type FastifyInstance } from "fastify";
+import { P2002 } from "../lib/test-fixtures/prisma-errors.js";
+
+const PROFILE_ID = "11111111-1111-4111-8111-111111111111";
+const GAME_ID = "22222222-2222-4222-8222-222222222222";
+
+const prismaMock = {
+  game: { findMany: vi.fn(), findFirst: vi.fn(), create: vi.fn(), update: vi.fn(), delete: vi.fn() },
+};
+
+const searchGames = vi.fn();
+const getIgdb = vi.fn();
+
+vi.mock("../lib/prisma.js", () => ({ prisma: prismaMock }));
+vi.mock("../lib/igdb-client.js", () => ({ getIgdb: () => getIgdb() }));
+vi.mock("../lib/profile.js", () => ({
+  resolveProfile: async (request: { profileId?: string }) => {
+    request.profileId = PROFILE_ID;
+  },
+}));
+
+const buildApp = async (): Promise<FastifyInstance> => {
+  vi.resetModules();
+  const { default: gamesRoutes } = await import("./games.js");
+  const app = Fastify();
+  await app.register(gamesRoutes);
+  await app.ready();
+  return app;
+};
+
+const gameRow = (over: Record<string, unknown> = {}) => ({
+  id: GAME_ID,
+  profileId: PROFILE_ID,
+  igdbId: 1234,
+  title: "Hollow Knight",
+  coverUrl: null,
+  releaseDate: null,
+  genres: [],
+  rating: null,
+  notes: null,
+  finished: false,
+  finishedAt: null,
+  playtimeMinutes: 0,
+  lastPlayedAt: null,
+  createdAt: new Date("2026-01-01T00:00:00Z"),
+  ...over,
+});
+
+/** The orderBy the route handed to Prisma for the current request. */
+const orderBy = () => prismaMock.game.findMany.mock.calls[0][0].orderBy;
+
+describe("games routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getIgdb.mockReturnValue({ searchGames });
+    searchGames.mockResolvedValue([]);
+    prismaMock.game.findMany.mockResolvedValue([]);
+  });
+
+  describe("GET /games", () => {
+    it("sorts by last played by default, with nulls last", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/games" });
+
+      expect(res.statusCode).toBe(200);
+      expect(orderBy()[0]).toEqual({ lastPlayedAt: { sort: "desc", nulls: "last" } });
+      await app.close();
+    });
+
+    it("sorts by playtime when asked", async () => {
+      const app = await buildApp();
+
+      await app.inject({ method: "GET", url: "/games?sort=playtime" });
+
+      expect(orderBy()[0]).toEqual({ playtimeMinutes: "desc" });
+      await app.close();
+    });
+
+    it("sorts by rating with unrated games last", async () => {
+      const app = await buildApp();
+
+      await app.inject({ method: "GET", url: "/games?sort=rating" });
+
+      expect(orderBy()[0]).toEqual({ rating: { sort: "desc", nulls: "last" } });
+      await app.close();
+    });
+
+    it("rejects an unknown sort rather than silently defaulting", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/games?sort=alphabetical" });
+
+      expect(res.statusCode).toBe(400);
+      expect(prismaMock.game.findMany).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it("only returns the calling profile's games", async () => {
+      const app = await buildApp();
+
+      await app.inject({ method: "GET", url: "/games" });
+
+      expect(prismaMock.game.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { profileId: PROFILE_ID } })
+      );
+      await app.close();
+    });
+  });
+
+  describe("GET /games/search", () => {
+    it("marks results already in the library", async () => {
+      searchGames.mockResolvedValue([{ igdbId: 1, title: "A" }, { igdbId: 2, title: "B" }]);
+      prismaMock.game.findMany.mockResolvedValue([{ igdbId: 2 }]);
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/games/search?q=hollow" });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().results).toEqual([
+        expect.objectContaining({ igdbId: 1, inLibrary: false }),
+        expect.objectContaining({ igdbId: 2, inLibrary: true }),
+      ]);
+      await app.close();
+    });
+
+    it("rejects a blank query", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/games/search?q=%20" });
+
+      expect(res.statusCode).toBe(400);
+      expect(getIgdb).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it("returns 500 when IGDB credentials are missing", async () => {
+      getIgdb.mockImplementation(() => {
+        throw new Error("TWITCH_CLIENT_ID is not set");
+      });
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/games/search?q=hollow" });
+
+      expect(res.statusCode).toBe(500);
+      expect(res.json().error).toMatch(/not configured/i);
+      await app.close();
+    });
+
+    it("returns 502 when IGDB itself fails", async () => {
+      searchGames.mockRejectedValue(new Error("503"));
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/games/search?q=hollow" });
+
+      expect(res.statusCode).toBe(502);
+      await app.close();
+    });
+  });
+
+  describe("POST /games", () => {
+    it("adds a game to the library", async () => {
+      prismaMock.game.create.mockResolvedValue(gameRow());
+      const app = await buildApp();
+
+      const res = await app.inject({
+        method: "POST",
+        url: "/games",
+        payload: { igdbId: 1234, title: "  Hollow Knight  ", genres: ["Metroidvania"] },
+      });
+
+      expect(res.statusCode).toBe(201);
+      expect(prismaMock.game.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          profileId: PROFILE_ID,
+          igdbId: 1234,
+          title: "Hollow Knight",
+          genres: ["Metroidvania"],
+        }),
+      });
+      await app.close();
+    });
+
+    it("returns 409 when the game is already in the library", async () => {
+      prismaMock.game.create.mockRejectedValue(P2002);
+      const app = await buildApp();
+
+      const res = await app.inject({
+        method: "POST",
+        url: "/games",
+        payload: { igdbId: 1234, title: "Hollow Knight" },
+      });
+
+      expect(res.statusCode).toBe(409);
+      await app.close();
+    });
+
+    it("rejects a non-integer igdbId", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({
+        method: "POST",
+        url: "/games",
+        payload: { igdbId: "1234", title: "Hollow Knight" },
+      });
+
+      expect(res.statusCode).toBe(400);
+      await app.close();
+    });
+
+    it("rejects an unparseable release date", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({
+        method: "POST",
+        url: "/games",
+        payload: { igdbId: 1, title: "A", releaseDate: "not-a-date" },
+      });
+
+      expect(res.statusCode).toBe(400);
+      expect(prismaMock.game.create).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it("rejects genres that are not all strings", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({
+        method: "POST",
+        url: "/games",
+        payload: { igdbId: 1, title: "A", genres: ["ok", 7] },
+      });
+
+      expect(res.statusCode).toBe(400);
+      await app.close();
+    });
+  });
+
+  describe("PATCH /games/:id", () => {
+    it("stamps a finish date when a game is marked finished", async () => {
+      prismaMock.game.findFirst.mockResolvedValue(gameRow());
+      prismaMock.game.update.mockResolvedValue(gameRow({ finished: true }));
+      const app = await buildApp();
+
+      const res = await app.inject({
+        method: "PATCH",
+        url: `/games/${GAME_ID}`,
+        payload: { finished: true },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const data = prismaMock.game.update.mock.calls[0][0].data;
+      expect(data.finished).toBe(true);
+      expect(data.finishedAt).toBeInstanceOf(Date);
+      await app.close();
+    });
+
+    it("keeps an existing finish date rather than moving it to today", async () => {
+      const original = new Date("2025-06-01T00:00:00Z");
+      prismaMock.game.findFirst.mockResolvedValue(gameRow({ finishedAt: original }));
+      prismaMock.game.update.mockResolvedValue(gameRow());
+      const app = await buildApp();
+
+      await app.inject({ method: "PATCH", url: `/games/${GAME_ID}`, payload: { finished: true } });
+
+      expect(prismaMock.game.update.mock.calls[0][0].data.finishedAt).toBe(original);
+      await app.close();
+    });
+
+    it("clears the finish date when a game is un-marked", async () => {
+      prismaMock.game.findFirst.mockResolvedValue(gameRow({ finished: true, finishedAt: new Date() }));
+      prismaMock.game.update.mockResolvedValue(gameRow());
+      const app = await buildApp();
+
+      await app.inject({ method: "PATCH", url: `/games/${GAME_ID}`, payload: { finished: false } });
+
+      expect(prismaMock.game.update.mock.calls[0][0].data.finishedAt).toBeNull();
+      await app.close();
+    });
+
+    it("lets an explicit finishedAt win over the automatic stamp", async () => {
+      prismaMock.game.findFirst.mockResolvedValue(gameRow());
+      prismaMock.game.update.mockResolvedValue(gameRow());
+      const app = await buildApp();
+
+      await app.inject({
+        method: "PATCH",
+        url: `/games/${GAME_ID}`,
+        payload: { finished: true, finishedAt: "2025-03-04T00:00:00Z" },
+      });
+
+      expect(prismaMock.game.update.mock.calls[0][0].data.finishedAt).toEqual(
+        new Date("2025-03-04T00:00:00Z")
+      );
+      await app.close();
+    });
+
+    it("accepts null to clear a rating", async () => {
+      prismaMock.game.findFirst.mockResolvedValue(gameRow({ rating: 8 }));
+      prismaMock.game.update.mockResolvedValue(gameRow());
+      const app = await buildApp();
+
+      const res = await app.inject({
+        method: "PATCH",
+        url: `/games/${GAME_ID}`,
+        payload: { rating: null },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(prismaMock.game.update.mock.calls[0][0].data.rating).toBeNull();
+      await app.close();
+    });
+
+    it("rejects a rating outside 1–10", async () => {
+      prismaMock.game.findFirst.mockResolvedValue(gameRow());
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "PATCH", url: `/games/${GAME_ID}`, payload: { rating: 11 } });
+
+      expect(res.statusCode).toBe(400);
+      expect(prismaMock.game.update).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it("404s on another profile's game", async () => {
+      prismaMock.game.findFirst.mockResolvedValue(null);
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "PATCH", url: `/games/${GAME_ID}`, payload: { rating: 5 } });
+
+      expect(res.statusCode).toBe(404);
+      await app.close();
+    });
+
+    it("rejects an id that is not a UUID", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "PATCH", url: "/games/abc", payload: { rating: 5 } });
+
+      expect(res.statusCode).toBe(400);
+      expect(prismaMock.game.findFirst).not.toHaveBeenCalled();
+      await app.close();
+    });
+  });
+
+  describe("DELETE /games/:id", () => {
+    it("removes a game the profile owns", async () => {
+      prismaMock.game.findFirst.mockResolvedValue(gameRow());
+      prismaMock.game.delete.mockResolvedValue(gameRow());
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "DELETE", url: `/games/${GAME_ID}` });
+
+      expect(res.statusCode).toBe(204);
+      expect(prismaMock.game.delete).toHaveBeenCalledWith({ where: { id: GAME_ID } });
+      await app.close();
+    });
+
+    it("404s on another profile's game", async () => {
+      prismaMock.game.findFirst.mockResolvedValue(null);
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "DELETE", url: `/games/${GAME_ID}` });
+
+      expect(res.statusCode).toBe(404);
+      expect(prismaMock.game.delete).not.toHaveBeenCalled();
+      await app.close();
+    });
+  });
+});

--- a/apps/api/src/routes/games.test.ts
+++ b/apps/api/src/routes/games.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import Fastify, { type FastifyInstance } from "fastify";
+import type { FastifyInstance } from "fastify";
+import { buildRouteApp } from "../lib/test-fixtures/route-app.js";
 import { P2002 } from "../lib/test-fixtures/prisma-errors.js";
 
 const PROFILE_ID = "11111111-1111-4111-8111-111111111111";
@@ -20,14 +21,8 @@ vi.mock("../lib/profile.js", () => ({
   },
 }));
 
-const buildApp = async (): Promise<FastifyInstance> => {
-  vi.resetModules();
-  const { default: gamesRoutes } = await import("./games.js");
-  const app = Fastify();
-  await app.register(gamesRoutes);
-  await app.ready();
-  return app;
-};
+const buildApp = (): Promise<FastifyInstance> =>
+  buildRouteApp(() => import("./games.js"));
 
 const gameRow = (over: Record<string, unknown> = {}) => ({
   id: GAME_ID,
@@ -66,7 +61,6 @@ describe("games routes", () => {
 
       expect(res.statusCode).toBe(200);
       expect(orderBy()[0]).toEqual({ lastPlayedAt: { sort: "desc", nulls: "last" } });
-      await app.close();
     });
 
     it("sorts by playtime when asked", async () => {
@@ -75,7 +69,6 @@ describe("games routes", () => {
       await app.inject({ method: "GET", url: "/games?sort=playtime" });
 
       expect(orderBy()[0]).toEqual({ playtimeMinutes: "desc" });
-      await app.close();
     });
 
     it("sorts by rating with unrated games last", async () => {
@@ -84,7 +77,6 @@ describe("games routes", () => {
       await app.inject({ method: "GET", url: "/games?sort=rating" });
 
       expect(orderBy()[0]).toEqual({ rating: { sort: "desc", nulls: "last" } });
-      await app.close();
     });
 
     it("rejects an unknown sort rather than silently defaulting", async () => {
@@ -94,7 +86,6 @@ describe("games routes", () => {
 
       expect(res.statusCode).toBe(400);
       expect(prismaMock.game.findMany).not.toHaveBeenCalled();
-      await app.close();
     });
 
     it("only returns the calling profile's games", async () => {
@@ -105,7 +96,6 @@ describe("games routes", () => {
       expect(prismaMock.game.findMany).toHaveBeenCalledWith(
         expect.objectContaining({ where: { profileId: PROFILE_ID } })
       );
-      await app.close();
     });
   });
 
@@ -122,7 +112,6 @@ describe("games routes", () => {
         expect.objectContaining({ igdbId: 1, inLibrary: false }),
         expect.objectContaining({ igdbId: 2, inLibrary: true }),
       ]);
-      await app.close();
     });
 
     it("rejects a blank query", async () => {
@@ -132,7 +121,6 @@ describe("games routes", () => {
 
       expect(res.statusCode).toBe(400);
       expect(getIgdb).not.toHaveBeenCalled();
-      await app.close();
     });
 
     it("returns 500 when IGDB credentials are missing", async () => {
@@ -145,7 +133,6 @@ describe("games routes", () => {
 
       expect(res.statusCode).toBe(500);
       expect(res.json().error).toMatch(/not configured/i);
-      await app.close();
     });
 
     it("returns 502 when IGDB itself fails", async () => {
@@ -155,7 +142,6 @@ describe("games routes", () => {
       const res = await app.inject({ method: "GET", url: "/games/search?q=hollow" });
 
       expect(res.statusCode).toBe(502);
-      await app.close();
     });
   });
 
@@ -179,7 +165,6 @@ describe("games routes", () => {
           genres: ["Metroidvania"],
         }),
       });
-      await app.close();
     });
 
     it("returns 409 when the game is already in the library", async () => {
@@ -193,7 +178,6 @@ describe("games routes", () => {
       });
 
       expect(res.statusCode).toBe(409);
-      await app.close();
     });
 
     it("rejects a non-integer igdbId", async () => {
@@ -206,7 +190,6 @@ describe("games routes", () => {
       });
 
       expect(res.statusCode).toBe(400);
-      await app.close();
     });
 
     it("rejects an unparseable release date", async () => {
@@ -220,7 +203,6 @@ describe("games routes", () => {
 
       expect(res.statusCode).toBe(400);
       expect(prismaMock.game.create).not.toHaveBeenCalled();
-      await app.close();
     });
 
     it("rejects genres that are not all strings", async () => {
@@ -233,7 +215,6 @@ describe("games routes", () => {
       });
 
       expect(res.statusCode).toBe(400);
-      await app.close();
     });
   });
 
@@ -253,7 +234,6 @@ describe("games routes", () => {
       const data = prismaMock.game.update.mock.calls[0][0].data;
       expect(data.finished).toBe(true);
       expect(data.finishedAt).toBeInstanceOf(Date);
-      await app.close();
     });
 
     it("keeps an existing finish date rather than moving it to today", async () => {
@@ -265,7 +245,6 @@ describe("games routes", () => {
       await app.inject({ method: "PATCH", url: `/games/${GAME_ID}`, payload: { finished: true } });
 
       expect(prismaMock.game.update.mock.calls[0][0].data.finishedAt).toBe(original);
-      await app.close();
     });
 
     it("clears the finish date when a game is un-marked", async () => {
@@ -276,7 +255,6 @@ describe("games routes", () => {
       await app.inject({ method: "PATCH", url: `/games/${GAME_ID}`, payload: { finished: false } });
 
       expect(prismaMock.game.update.mock.calls[0][0].data.finishedAt).toBeNull();
-      await app.close();
     });
 
     it("lets an explicit finishedAt win over the automatic stamp", async () => {
@@ -293,7 +271,6 @@ describe("games routes", () => {
       expect(prismaMock.game.update.mock.calls[0][0].data.finishedAt).toEqual(
         new Date("2025-03-04T00:00:00Z")
       );
-      await app.close();
     });
 
     it("accepts null to clear a rating", async () => {
@@ -309,7 +286,6 @@ describe("games routes", () => {
 
       expect(res.statusCode).toBe(200);
       expect(prismaMock.game.update.mock.calls[0][0].data.rating).toBeNull();
-      await app.close();
     });
 
     it("rejects a rating outside 1–10", async () => {
@@ -320,7 +296,6 @@ describe("games routes", () => {
 
       expect(res.statusCode).toBe(400);
       expect(prismaMock.game.update).not.toHaveBeenCalled();
-      await app.close();
     });
 
     it("404s on another profile's game", async () => {
@@ -330,7 +305,6 @@ describe("games routes", () => {
       const res = await app.inject({ method: "PATCH", url: `/games/${GAME_ID}`, payload: { rating: 5 } });
 
       expect(res.statusCode).toBe(404);
-      await app.close();
     });
 
     it("rejects an id that is not a UUID", async () => {
@@ -340,7 +314,6 @@ describe("games routes", () => {
 
       expect(res.statusCode).toBe(400);
       expect(prismaMock.game.findFirst).not.toHaveBeenCalled();
-      await app.close();
     });
   });
 
@@ -354,7 +327,6 @@ describe("games routes", () => {
 
       expect(res.statusCode).toBe(204);
       expect(prismaMock.game.delete).toHaveBeenCalledWith({ where: { id: GAME_ID } });
-      await app.close();
     });
 
     it("404s on another profile's game", async () => {
@@ -365,7 +337,6 @@ describe("games routes", () => {
 
       expect(res.statusCode).toBe(404);
       expect(prismaMock.game.delete).not.toHaveBeenCalled();
-      await app.close();
     });
   });
 });

--- a/apps/api/src/routes/health.test.ts
+++ b/apps/api/src/routes/health.test.ts
@@ -1,34 +1,29 @@
 import { describe, expect, it } from "vitest";
-import Fastify from "fastify";
-import healthRoutes from "./health.js";
+import { buildRouteApp } from "../lib/test-fixtures/route-app.js";
+
+const buildApp = () => buildRouteApp(() => import("./health.js"));
 
 // The health endpoint is what `docker compose` waits on before starting the
 // services that depend on the API, and what `pnpm smoke` checks first — so its
 // shape is a contract, not an implementation detail.
 describe("health route", () => {
   it("reports the service as ok", async () => {
-    const app = Fastify({ logger: false });
-    await app.register(healthRoutes);
-    await app.ready();
+    const app = await buildApp();
 
     const res = await app.inject({ method: "GET", url: "/health" });
 
     expect(res.statusCode).toBe(200);
     expect(res.json()).toEqual({ status: "ok", service: "api" });
-    await app.close();
   });
 
   it("needs no database or upstream to answer", async () => {
     // Nothing is mocked in this file: if the route ever grows a dependency,
     // this test fails rather than the probe silently going unhealthy in
     // production when that dependency is down.
-    const app = Fastify({ logger: false });
-    await app.register(healthRoutes);
-    await app.ready();
+    const app = await buildApp();
 
     const res = await app.inject({ method: "GET", url: "/health" });
 
     expect(res.statusCode).toBe(200);
-    await app.close();
   });
 });

--- a/apps/api/src/routes/health.test.ts
+++ b/apps/api/src/routes/health.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import Fastify from "fastify";
+import healthRoutes from "./health.js";
+
+// The health endpoint is what `docker compose` waits on before starting the
+// services that depend on the API, and what `pnpm smoke` checks first — so its
+// shape is a contract, not an implementation detail.
+describe("health route", () => {
+  it("reports the service as ok", async () => {
+    const app = Fastify({ logger: false });
+    await app.register(healthRoutes);
+    await app.ready();
+
+    const res = await app.inject({ method: "GET", url: "/health" });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ status: "ok", service: "api" });
+    await app.close();
+  });
+
+  it("needs no database or upstream to answer", async () => {
+    // Nothing is mocked in this file: if the route ever grows a dependency,
+    // this test fails rather than the probe silently going unhealthy in
+    // production when that dependency is down.
+    const app = Fastify({ logger: false });
+    await app.register(healthRoutes);
+    await app.ready();
+
+    const res = await app.inject({ method: "GET", url: "/health" });
+
+    expect(res.statusCode).toBe(200);
+    await app.close();
+  });
+});

--- a/apps/api/src/routes/import.test.ts
+++ b/apps/api/src/routes/import.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import Fastify, { type FastifyInstance } from "fastify";
+import type { FastifyInstance } from "fastify";
+import { buildRouteApp } from "../lib/test-fixtures/route-app.js";
 
 const PROFILE_ID = "11111111-1111-4111-8111-111111111111";
 
@@ -24,14 +25,8 @@ vi.mock("../lib/batch-ratings.js", () => ({
 }));
 
 /** Big enough to hold the row-cap payloads; production sets this from MAX_BODY_SIZE_MB. */
-const buildApp = async (): Promise<FastifyInstance> => {
-  vi.resetModules();
-  const { default: importRoutes } = await import("./import.js");
-  const app = Fastify({ bodyLimit: 256 * 1024 * 1024 });
-  await app.register(importRoutes);
-  await app.ready();
-  return app;
-};
+const buildApp = (): Promise<FastifyInstance> =>
+  buildRouteApp(() => import("./import.js"), { bodyLimit: 256 * 1024 * 1024 });
 
 const csvWithRows = (header: string, row: string, count: number) =>
   [header, ...Array.from({ length: count }, () => row)].join("\n");
@@ -58,7 +53,6 @@ describe("POST /import/external — row caps", () => {
     expect(response.json().code).toBe("too_many_rows");
     expect(response.json().error).toContain("10,000");
     expect(tmdbMock.search).not.toHaveBeenCalled();
-    await app.close();
   });
 
   it("accepts an id-carrying format at a row count the Letterboxd cap would reject", async () => {
@@ -73,7 +67,6 @@ describe("POST /import/external — row caps", () => {
 
     expect(response.statusCode).toBe(200);
     expect(response.json().summary.ratingsImported).toBe(10_001);
-    await app.close();
   });
 
   it("still rejects an id-carrying format past the global import cap", async () => {
@@ -89,6 +82,5 @@ describe("POST /import/external — row caps", () => {
     expect(response.statusCode).toBe(413);
     expect(response.json().error).toContain("200,000");
     expect(batchMocks.batchUpsertRatings).not.toHaveBeenCalled();
-    await app.close();
   });
 });

--- a/apps/api/src/routes/lists.test.ts
+++ b/apps/api/src/routes/lists.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import Fastify, { type FastifyInstance } from "fastify";
+import type { FastifyInstance } from "fastify";
+import { buildRouteApp } from "../lib/test-fixtures/route-app.js";
 import { P2002 } from "../lib/test-fixtures/prisma-errors.js";
 
 const PROFILE_ID = "11111111-1111-4111-8111-111111111111";
@@ -38,14 +39,8 @@ vi.mock("../lib/profile.js", () => ({
   },
 }));
 
-const buildApp = async (): Promise<FastifyInstance> => {
-  vi.resetModules();
-  const { default: listsRoutes } = await import("./lists.js");
-  const app = Fastify();
-  await app.register(listsRoutes);
-  await app.ready();
-  return app;
-};
+const buildApp = (): Promise<FastifyInstance> =>
+  buildRouteApp(() => import("./lists.js"));
 
 const listRow = (over: Record<string, unknown> = {}) => ({
   id: LIST_ID,
@@ -83,7 +78,6 @@ describe("lists routes", () => {
         data: { name: "Weekend", kind: "custom", profileId: PROFILE_ID },
       });
       expect(res.json().list).toMatchObject({ name: "Weekend", itemCount: 0 });
-      await app.close();
     });
 
     it("rejects a kind that is not one of the known list kinds", async () => {
@@ -97,7 +91,6 @@ describe("lists routes", () => {
 
       expect(res.statusCode).toBe(400);
       expect(prismaMock.list.create).not.toHaveBeenCalled();
-      await app.close();
     });
 
     it("rejects a name that is only whitespace", async () => {
@@ -110,7 +103,6 @@ describe("lists routes", () => {
       });
 
       expect(res.statusCode).toBe(400);
-      await app.close();
     });
   });
 
@@ -132,7 +124,6 @@ describe("lists routes", () => {
         expect.objectContaining({ name: "Watchlist", itemCount: 4 }),
         expect.objectContaining({ name: "Collection", itemCount: 0 }),
       ]);
-      await app.close();
     });
   });
 
@@ -153,7 +144,6 @@ describe("lists routes", () => {
         where: { id: LIST_ID },
         data: { name: "Renamed" },
       });
-      await app.close();
     });
 
     it("rejects an id that is not a UUID before touching the database", async () => {
@@ -163,7 +153,6 @@ describe("lists routes", () => {
 
       expect(res.statusCode).toBe(400);
       expect(prismaMock.list.findFirst).not.toHaveBeenCalled();
-      await app.close();
     });
 
     it("404s on a list belonging to another profile", async () => {
@@ -176,7 +165,6 @@ describe("lists routes", () => {
 
       expect(res.statusCode).toBe(404);
       expect(prismaMock.list.update).not.toHaveBeenCalled();
-      await app.close();
     });
   });
 
@@ -190,7 +178,6 @@ describe("lists routes", () => {
 
       expect(res.statusCode).toBe(204);
       expect(prismaMock.list.delete).toHaveBeenCalledWith({ where: { id: LIST_ID } });
-      await app.close();
     });
 
     it("404s when the list is not the profile's", async () => {
@@ -201,7 +188,6 @@ describe("lists routes", () => {
 
       expect(res.statusCode).toBe(404);
       expect(prismaMock.list.delete).not.toHaveBeenCalled();
-      await app.close();
     });
   });
 
@@ -229,7 +215,6 @@ describe("lists routes", () => {
         { type: "movie", imdbId: "tt0111161" },
         expect.anything()
       );
-      await app.close();
     });
 
     it("does not push to Trakt for a custom list", async () => {
@@ -247,7 +232,6 @@ describe("lists routes", () => {
 
       expect(res.statusCode).toBe(201);
       expect(pushTraktWatchlistChange).not.toHaveBeenCalled();
-      await app.close();
     });
 
     it("returns 409 rather than 500 when the item is already in the list", async () => {
@@ -263,7 +247,6 @@ describe("lists routes", () => {
 
       expect(res.statusCode).toBe(409);
       expect(res.json().error).toMatch(/already exists/i);
-      await app.close();
     });
 
     it("validates the body before looking the list up", async () => {
@@ -277,7 +260,6 @@ describe("lists routes", () => {
 
       expect(res.statusCode).toBe(400);
       expect(prismaMock.list.findFirst).not.toHaveBeenCalled();
-      await app.close();
     });
 
     it("rejects a non-string title instead of storing it", async () => {
@@ -290,7 +272,6 @@ describe("lists routes", () => {
       });
 
       expect(res.statusCode).toBe(400);
-      await app.close();
     });
   });
 
@@ -307,7 +288,6 @@ describe("lists routes", () => {
       expect(prismaMock.listItem.deleteMany).toHaveBeenCalledWith({
         where: { listId: LIST_ID, imdbId: "tt0903747", type: "series" },
       });
-      await app.close();
     });
 
     it("asks for a type when a movie and a series share the imdbId", async () => {
@@ -321,7 +301,6 @@ describe("lists routes", () => {
       expect(res.statusCode).toBe(400);
       expect(res.json().error).toMatch(/type=movie or \?type=series/);
       expect(prismaMock.listItem.deleteMany).not.toHaveBeenCalled();
-      await app.close();
     });
 
     it("404s when nothing matches the imdbId", async () => {
@@ -332,7 +311,6 @@ describe("lists routes", () => {
       const res = await app.inject({ method: "DELETE", url: `/lists/${LIST_ID}/items/tt1` });
 
       expect(res.statusCode).toBe(404);
-      await app.close();
     });
 
     it("mirrors the removal to Trakt for a watchlist", async () => {
@@ -351,7 +329,6 @@ describe("lists routes", () => {
         { type: "movie", imdbId: "tt1" },
         expect.anything()
       );
-      await app.close();
     });
   });
 
@@ -367,7 +344,6 @@ describe("lists routes", () => {
       expect(prismaMock.listItem.deleteMany).toHaveBeenCalledWith({
         where: { listId: LIST_ID, type: "movie", imdbId: "tt1" },
       });
-      await app.close();
     });
 
     it("404s when the row does not exist", async () => {
@@ -378,7 +354,6 @@ describe("lists routes", () => {
       const res = await app.inject({ method: "DELETE", url: `/lists/${LIST_ID}/items/movie/tt1` });
 
       expect(res.statusCode).toBe(404);
-      await app.close();
     });
   });
 
@@ -398,7 +373,6 @@ describe("lists routes", () => {
       expect(res.statusCode).toBe(200);
       expect(res.json().items[0].metadata).toMatchObject({ name: "A Movie", year: 2020 });
       expect(prismaMock.item.findMany).not.toHaveBeenCalled();
-      await app.close();
     });
 
     it("falls back to the captured title and schedules a backfill when metadata is missing", async () => {
@@ -418,7 +392,6 @@ describe("lists routes", () => {
         [{ imdbId: "tt1", type: "movie" }],
         expect.anything()
       );
-      await app.close();
     });
 
     it("keeps a movie and a series sharing an imdbId apart", async () => {
@@ -440,7 +413,6 @@ describe("lists routes", () => {
       const items = res.json().items;
       expect(items[0].metadata).toMatchObject({ name: "The Movie" });
       expect(items[1].metadata).toBeNull();
-      await app.close();
     });
   });
 
@@ -464,7 +436,6 @@ describe("lists routes", () => {
         })
       );
       expect(res.json().lists[0]).toMatchObject({ listName: "Watchlist", listKind: "watchlist" });
-      await app.close();
     });
 
     it("ignores a type filter that is not a valid item type", async () => {
@@ -479,7 +450,6 @@ describe("lists routes", () => {
           where: expect.not.objectContaining({ type: expect.anything() }),
         })
       );
-      await app.close();
     });
   });
 });

--- a/apps/api/src/routes/lists.test.ts
+++ b/apps/api/src/routes/lists.test.ts
@@ -1,0 +1,485 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import Fastify, { type FastifyInstance } from "fastify";
+import { P2002 } from "../lib/test-fixtures/prisma-errors.js";
+
+const PROFILE_ID = "11111111-1111-4111-8111-111111111111";
+const LIST_ID = "22222222-2222-4222-8222-222222222222";
+const OTHER_LIST_ID = "33333333-3333-4333-8333-333333333333";
+
+const prismaMock = {
+  list: {
+    create: vi.fn(),
+    findMany: vi.fn(),
+    findFirst: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+  listItem: { create: vi.fn(), findMany: vi.fn(), deleteMany: vi.fn() },
+  item: { upsert: vi.fn(), findMany: vi.fn() },
+  metadata: { findMany: vi.fn() },
+  $transaction: vi.fn(),
+};
+
+const syncMetadata = vi.fn();
+const backfillMissingMetadata = vi.fn();
+const pushTraktWatchlistChange = vi.fn();
+
+vi.mock("../lib/prisma.js", () => ({ prisma: prismaMock }));
+vi.mock("../lib/metadata.js", () => ({
+  syncMetadata: (...args: unknown[]) => syncMetadata(...args),
+  backfillMissingMetadata: (...args: unknown[]) => backfillMissingMetadata(...args),
+}));
+vi.mock("../lib/trakt-client.js", () => ({
+  pushTraktWatchlistChange: (...args: unknown[]) => pushTraktWatchlistChange(...args),
+}));
+vi.mock("../lib/profile.js", () => ({
+  resolveProfile: async (request: { profileId?: string }) => {
+    request.profileId = PROFILE_ID;
+  },
+}));
+
+const buildApp = async (): Promise<FastifyInstance> => {
+  vi.resetModules();
+  const { default: listsRoutes } = await import("./lists.js");
+  const app = Fastify();
+  await app.register(listsRoutes);
+  await app.ready();
+  return app;
+};
+
+const listRow = (over: Record<string, unknown> = {}) => ({
+  id: LIST_ID,
+  name: "Watchlist",
+  kind: "watchlist",
+  profileId: PROFILE_ID,
+  createdAt: new Date("2026-01-01T00:00:00Z"),
+  ...over,
+});
+
+describe("lists routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    syncMetadata.mockResolvedValue(undefined);
+    pushTraktWatchlistChange.mockResolvedValue(undefined);
+    // The route runs its item upsert and list-item insert in one transaction;
+    // running the callback against the same mock keeps assertions on the inner
+    // calls working.
+    prismaMock.$transaction.mockImplementation((fn: (tx: unknown) => unknown) => fn(prismaMock));
+  });
+
+  describe("POST /lists", () => {
+    it("creates a list scoped to the calling profile", async () => {
+      prismaMock.list.create.mockResolvedValue(listRow({ name: "Weekend", kind: "custom" }));
+      const app = await buildApp();
+
+      const res = await app.inject({
+        method: "POST",
+        url: "/lists",
+        payload: { name: "  Weekend  ", kind: "custom" },
+      });
+
+      expect(res.statusCode).toBe(201);
+      expect(prismaMock.list.create).toHaveBeenCalledWith({
+        data: { name: "Weekend", kind: "custom", profileId: PROFILE_ID },
+      });
+      expect(res.json().list).toMatchObject({ name: "Weekend", itemCount: 0 });
+      await app.close();
+    });
+
+    it("rejects a kind that is not one of the known list kinds", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({
+        method: "POST",
+        url: "/lists",
+        payload: { name: "Weekend", kind: "favourites" },
+      });
+
+      expect(res.statusCode).toBe(400);
+      expect(prismaMock.list.create).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it("rejects a name that is only whitespace", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({
+        method: "POST",
+        url: "/lists",
+        payload: { name: "   ", kind: "custom" },
+      });
+
+      expect(res.statusCode).toBe(400);
+      await app.close();
+    });
+  });
+
+  describe("GET /lists", () => {
+    it("returns each list with its item count", async () => {
+      prismaMock.list.findMany.mockResolvedValue([
+        { ...listRow(), _count: { items: 4 } },
+        { ...listRow({ id: OTHER_LIST_ID, name: "Collection", kind: "collection" }), _count: { items: 0 } },
+      ]);
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/lists" });
+
+      expect(res.statusCode).toBe(200);
+      expect(prismaMock.list.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { profileId: PROFILE_ID } })
+      );
+      expect(res.json().lists).toEqual([
+        expect.objectContaining({ name: "Watchlist", itemCount: 4 }),
+        expect.objectContaining({ name: "Collection", itemCount: 0 }),
+      ]);
+      await app.close();
+    });
+  });
+
+  describe("PATCH /lists/:id", () => {
+    it("renames a list the profile owns", async () => {
+      prismaMock.list.findFirst.mockResolvedValue(listRow());
+      prismaMock.list.update.mockResolvedValue(listRow({ name: "Renamed" }));
+      const app = await buildApp();
+
+      const res = await app.inject({
+        method: "PATCH",
+        url: `/lists/${LIST_ID}`,
+        payload: { name: "  Renamed  " },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(prismaMock.list.update).toHaveBeenCalledWith({
+        where: { id: LIST_ID },
+        data: { name: "Renamed" },
+      });
+      await app.close();
+    });
+
+    it("rejects an id that is not a UUID before touching the database", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "PATCH", url: "/lists/not-a-uuid", payload: { name: "x" } });
+
+      expect(res.statusCode).toBe(400);
+      expect(prismaMock.list.findFirst).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it("404s on a list belonging to another profile", async () => {
+      // The lookup is scoped by profileId, so another profile's list simply
+      // isn't found — it must not be reported as existing-but-forbidden.
+      prismaMock.list.findFirst.mockResolvedValue(null);
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "PATCH", url: `/lists/${LIST_ID}`, payload: { name: "x" } });
+
+      expect(res.statusCode).toBe(404);
+      expect(prismaMock.list.update).not.toHaveBeenCalled();
+      await app.close();
+    });
+  });
+
+  describe("DELETE /lists/:id", () => {
+    it("deletes a list the profile owns", async () => {
+      prismaMock.list.findFirst.mockResolvedValue(listRow());
+      prismaMock.list.delete.mockResolvedValue(listRow());
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "DELETE", url: `/lists/${LIST_ID}` });
+
+      expect(res.statusCode).toBe(204);
+      expect(prismaMock.list.delete).toHaveBeenCalledWith({ where: { id: LIST_ID } });
+      await app.close();
+    });
+
+    it("404s when the list is not the profile's", async () => {
+      prismaMock.list.findFirst.mockResolvedValue(null);
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "DELETE", url: `/lists/${LIST_ID}` });
+
+      expect(res.statusCode).toBe(404);
+      expect(prismaMock.list.delete).not.toHaveBeenCalled();
+      await app.close();
+    });
+  });
+
+  describe("POST /lists/:listId/items", () => {
+    it("adds an item and mirrors the add to Trakt for a watchlist", async () => {
+      prismaMock.list.findFirst.mockResolvedValue(listRow({ kind: "watchlist" }));
+      prismaMock.item.upsert.mockResolvedValue({});
+      prismaMock.listItem.create.mockResolvedValue({ listId: LIST_ID, type: "movie", imdbId: "tt0111161" });
+      const app = await buildApp();
+
+      const res = await app.inject({
+        method: "POST",
+        url: `/lists/${LIST_ID}/items`,
+        payload: { type: "movie", imdbId: " tt0111161 ", title: " The Shawshank Redemption " },
+      });
+
+      expect(res.statusCode).toBe(201);
+      expect(prismaMock.item.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { type_imdbId: { type: "movie", imdbId: "tt0111161" } },
+        })
+      );
+      expect(pushTraktWatchlistChange).toHaveBeenCalledWith(
+        "add",
+        { type: "movie", imdbId: "tt0111161" },
+        expect.anything()
+      );
+      await app.close();
+    });
+
+    it("does not push to Trakt for a custom list", async () => {
+      // Only the watchlist mirrors to Trakt; a custom list is local-only.
+      prismaMock.list.findFirst.mockResolvedValue(listRow({ kind: "custom" }));
+      prismaMock.item.upsert.mockResolvedValue({});
+      prismaMock.listItem.create.mockResolvedValue({ listId: LIST_ID, type: "series", imdbId: "tt0903747" });
+      const app = await buildApp();
+
+      const res = await app.inject({
+        method: "POST",
+        url: `/lists/${LIST_ID}/items`,
+        payload: { type: "series", imdbId: "tt0903747" },
+      });
+
+      expect(res.statusCode).toBe(201);
+      expect(pushTraktWatchlistChange).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it("returns 409 rather than 500 when the item is already in the list", async () => {
+      prismaMock.list.findFirst.mockResolvedValue(listRow());
+      prismaMock.$transaction.mockRejectedValue(P2002);
+      const app = await buildApp();
+
+      const res = await app.inject({
+        method: "POST",
+        url: `/lists/${LIST_ID}/items`,
+        payload: { type: "movie", imdbId: "tt0111161" },
+      });
+
+      expect(res.statusCode).toBe(409);
+      expect(res.json().error).toMatch(/already exists/i);
+      await app.close();
+    });
+
+    it("validates the body before looking the list up", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({
+        method: "POST",
+        url: `/lists/${LIST_ID}/items`,
+        payload: { type: "book", imdbId: "tt0111161" },
+      });
+
+      expect(res.statusCode).toBe(400);
+      expect(prismaMock.list.findFirst).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it("rejects a non-string title instead of storing it", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({
+        method: "POST",
+        url: `/lists/${LIST_ID}/items`,
+        payload: { type: "movie", imdbId: "tt1", title: 42 },
+      });
+
+      expect(res.statusCode).toBe(400);
+      await app.close();
+    });
+  });
+
+  describe("DELETE /lists/:listId/items/:imdbId", () => {
+    it("infers the type when exactly one item matches", async () => {
+      prismaMock.list.findFirst.mockResolvedValue(listRow({ kind: "custom" }));
+      prismaMock.listItem.findMany.mockResolvedValue([{ type: "series" }]);
+      prismaMock.listItem.deleteMany.mockResolvedValue({ count: 1 });
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "DELETE", url: `/lists/${LIST_ID}/items/tt0903747` });
+
+      expect(res.statusCode).toBe(204);
+      expect(prismaMock.listItem.deleteMany).toHaveBeenCalledWith({
+        where: { listId: LIST_ID, imdbId: "tt0903747", type: "series" },
+      });
+      await app.close();
+    });
+
+    it("asks for a type when a movie and a series share the imdbId", async () => {
+      // Both rows would otherwise be deleted by one ambiguous request.
+      prismaMock.list.findFirst.mockResolvedValue(listRow());
+      prismaMock.listItem.findMany.mockResolvedValue([{ type: "movie" }, { type: "series" }]);
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "DELETE", url: `/lists/${LIST_ID}/items/tt1` });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error).toMatch(/type=movie or \?type=series/);
+      expect(prismaMock.listItem.deleteMany).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it("404s when nothing matches the imdbId", async () => {
+      prismaMock.list.findFirst.mockResolvedValue(listRow());
+      prismaMock.listItem.findMany.mockResolvedValue([]);
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "DELETE", url: `/lists/${LIST_ID}/items/tt1` });
+
+      expect(res.statusCode).toBe(404);
+      await app.close();
+    });
+
+    it("mirrors the removal to Trakt for a watchlist", async () => {
+      prismaMock.list.findFirst.mockResolvedValue(listRow({ kind: "watchlist" }));
+      prismaMock.listItem.deleteMany.mockResolvedValue({ count: 1 });
+      const app = await buildApp();
+
+      const res = await app.inject({
+        method: "DELETE",
+        url: `/lists/${LIST_ID}/items/tt1?type=movie`,
+      });
+
+      expect(res.statusCode).toBe(204);
+      expect(pushTraktWatchlistChange).toHaveBeenCalledWith(
+        "remove",
+        { type: "movie", imdbId: "tt1" },
+        expect.anything()
+      );
+      await app.close();
+    });
+  });
+
+  describe("DELETE /lists/:listId/items/:type/:imdbId", () => {
+    it("deletes the row matching both type and imdbId", async () => {
+      prismaMock.list.findFirst.mockResolvedValue(listRow({ kind: "custom" }));
+      prismaMock.listItem.deleteMany.mockResolvedValue({ count: 1 });
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "DELETE", url: `/lists/${LIST_ID}/items/movie/tt1` });
+
+      expect(res.statusCode).toBe(204);
+      expect(prismaMock.listItem.deleteMany).toHaveBeenCalledWith({
+        where: { listId: LIST_ID, type: "movie", imdbId: "tt1" },
+      });
+      await app.close();
+    });
+
+    it("404s when the row does not exist", async () => {
+      prismaMock.list.findFirst.mockResolvedValue(listRow());
+      prismaMock.listItem.deleteMany.mockResolvedValue({ count: 0 });
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "DELETE", url: `/lists/${LIST_ID}/items/movie/tt1` });
+
+      expect(res.statusCode).toBe(404);
+      await app.close();
+    });
+  });
+
+  describe("GET /lists/:listId/items", () => {
+    it("joins metadata onto each item", async () => {
+      prismaMock.list.findFirst.mockResolvedValue(listRow());
+      prismaMock.listItem.findMany.mockResolvedValue([
+        { listId: LIST_ID, type: "movie", imdbId: "tt1", addedAt: new Date("2026-01-01T00:00:00Z") },
+      ]);
+      prismaMock.metadata.findMany.mockResolvedValue([
+        { imdbId: "tt1", type: "movie", name: "A Movie", poster: null, year: 2020, genres: ["Drama"], rating: 7.5 },
+      ]);
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: `/lists/${LIST_ID}/items` });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().items[0].metadata).toMatchObject({ name: "A Movie", year: 2020 });
+      expect(prismaMock.item.findMany).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it("falls back to the captured title and schedules a backfill when metadata is missing", async () => {
+      prismaMock.list.findFirst.mockResolvedValue(listRow());
+      prismaMock.listItem.findMany.mockResolvedValue([
+        { listId: LIST_ID, type: "movie", imdbId: "tt1", addedAt: new Date("2026-01-01T00:00:00Z") },
+      ]);
+      prismaMock.metadata.findMany.mockResolvedValue([]);
+      prismaMock.item.findMany.mockResolvedValue([{ imdbId: "tt1", type: "movie", title: "A Movie" }]);
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: `/lists/${LIST_ID}/items` });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().items[0]).toMatchObject({ title: "A Movie", metadata: null });
+      expect(backfillMissingMetadata).toHaveBeenCalledWith(
+        [{ imdbId: "tt1", type: "movie" }],
+        expect.anything()
+      );
+      await app.close();
+    });
+
+    it("keeps a movie and a series sharing an imdbId apart", async () => {
+      // Metadata is keyed on imdbId *and* type — keying on imdbId alone would
+      // show the movie's poster on the series row.
+      prismaMock.list.findFirst.mockResolvedValue(listRow());
+      prismaMock.listItem.findMany.mockResolvedValue([
+        { listId: LIST_ID, type: "movie", imdbId: "tt1", addedAt: new Date("2026-01-02T00:00:00Z") },
+        { listId: LIST_ID, type: "series", imdbId: "tt1", addedAt: new Date("2026-01-01T00:00:00Z") },
+      ]);
+      prismaMock.metadata.findMany.mockResolvedValue([
+        { imdbId: "tt1", type: "movie", name: "The Movie", poster: null, year: 2020, genres: [], rating: null },
+      ]);
+      prismaMock.item.findMany.mockResolvedValue([]);
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: `/lists/${LIST_ID}/items` });
+
+      const items = res.json().items;
+      expect(items[0].metadata).toMatchObject({ name: "The Movie" });
+      expect(items[1].metadata).toBeNull();
+      await app.close();
+    });
+  });
+
+  describe("GET /items/:imdbId/lists", () => {
+    it("reports every list of the profile holding the item", async () => {
+      prismaMock.listItem.findMany.mockResolvedValue([
+        {
+          type: "movie",
+          addedAt: new Date("2026-01-01T00:00:00Z"),
+          list: { id: LIST_ID, name: "Watchlist", kind: "watchlist" },
+        },
+      ]);
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/items/tt1/lists" });
+
+      expect(res.statusCode).toBe(200);
+      expect(prismaMock.listItem.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ imdbId: "tt1", list: { profileId: PROFILE_ID } }),
+        })
+      );
+      expect(res.json().lists[0]).toMatchObject({ listName: "Watchlist", listKind: "watchlist" });
+      await app.close();
+    });
+
+    it("ignores a type filter that is not a valid item type", async () => {
+      prismaMock.listItem.findMany.mockResolvedValue([]);
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/items/tt1/lists?type=book" });
+
+      expect(res.statusCode).toBe(200);
+      expect(prismaMock.listItem.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.not.objectContaining({ type: expect.anything() }),
+        })
+      );
+      await app.close();
+    });
+  });
+});

--- a/apps/api/src/routes/metadata.test.ts
+++ b/apps/api/src/routes/metadata.test.ts
@@ -1,0 +1,398 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import Fastify, { type FastifyInstance } from "fastify";
+
+const PROFILE_ID = "11111111-1111-4111-8111-111111111111";
+
+const prismaMock = {
+  kV: { findUnique: vi.fn() },
+  metadata: { findMany: vi.fn() },
+};
+
+const loadMeta = vi.fn();
+const loadCast = vi.fn();
+const loadSeasons = vi.fn();
+const loadEpisodes = vi.fn();
+const loadProviders = vi.fn();
+const loadRecommendations = vi.fn();
+const syncMetadata = vi.fn();
+const upsertMetadata = vi.fn();
+const searchAnime = vi.fn();
+const getTmdb = vi.fn();
+const findByImdbId = vi.fn();
+const getOmdbApiKey = vi.fn();
+
+const EMPTY_PROVIDERS = { flatrate: [], rent: [], buy: [] };
+
+vi.mock("../lib/prisma.js", () => ({ prisma: prismaMock }));
+vi.mock("../lib/detail.js", () => ({
+  EMPTY_PROVIDERS,
+  loadMeta: (...a: unknown[]) => loadMeta(...a),
+  loadCast: (...a: unknown[]) => loadCast(...a),
+  loadSeasons: (...a: unknown[]) => loadSeasons(...a),
+  loadEpisodes: (...a: unknown[]) => loadEpisodes(...a),
+  loadProviders: (...a: unknown[]) => loadProviders(...a),
+}));
+vi.mock("../lib/recommendations.js", () => ({
+  loadRecommendations: (...a: unknown[]) => loadRecommendations(...a),
+}));
+vi.mock("../lib/metadata.js", () => ({
+  syncMetadata: (...a: unknown[]) => syncMetadata(...a),
+  upsertMetadata: (...a: unknown[]) => upsertMetadata(...a),
+}));
+vi.mock("../lib/anilist-client.js", () => ({ searchAnime: (...a: unknown[]) => searchAnime(...a) }));
+vi.mock("../lib/tmdb-client.js", () => ({ getTmdb: () => getTmdb() }));
+vi.mock("../lib/omdb.js", () => ({
+  getOmdbApiKey: () => getOmdbApiKey(),
+  fetchOmdbRatings: vi.fn().mockResolvedValue(null),
+  upsertOmdbRatings: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("../lib/dropped-shows.js", () => ({
+  droppedSeriesKey: (profileId: string, imdbId: string) => `dropped:${profileId}:${imdbId}`,
+}));
+vi.mock("../lib/profile.js", () => ({
+  resolveProfile: async (request: { profileId?: string }) => {
+    request.profileId = PROFILE_ID;
+  },
+}));
+
+const buildApp = async (): Promise<FastifyInstance> => {
+  vi.resetModules();
+  const { default: metadataRoutes } = await import("./metadata.js");
+  const app = Fastify({ logger: false });
+  await app.register(metadataRoutes);
+  await app.ready();
+  return app;
+};
+
+describe("metadata routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    loadMeta.mockResolvedValue({ id: "tt1", name: "A Title" });
+    loadCast.mockResolvedValue({ cast: [{ name: "An Actor" }], director: "A Director" });
+    loadSeasons.mockResolvedValue([{ season: 1 }]);
+    loadEpisodes.mockResolvedValue([{ episode: 1 }]);
+    loadProviders.mockResolvedValue({ flatrate: [{ name: "Netflix" }], rent: [], buy: [] });
+    loadRecommendations.mockResolvedValue({ metas: [{ id: "tt2" }] });
+    prismaMock.kV.findUnique.mockResolvedValue(null);
+    prismaMock.metadata.findMany.mockResolvedValue([]);
+    getTmdb.mockResolvedValue({ findByImdbId });
+    getOmdbApiKey.mockResolvedValue(null);
+  });
+
+  describe("GET /meta/:type/:imdbId", () => {
+    it("returns the metadata for a known title", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/meta/movie/tt1" });
+
+      expect(res.statusCode).toBe(200);
+      expect(loadMeta).toHaveBeenCalledWith("movie", "tt1");
+      await app.close();
+    });
+
+    it("rejects a type that is not movie or series", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/meta/episode/tt1" });
+
+      expect(res.statusCode).toBe(400);
+      expect(loadMeta).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it("404s when nothing is found", async () => {
+      loadMeta.mockResolvedValue(null);
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/meta/movie/tt1" });
+
+      expect(res.statusCode).toBe(404);
+      await app.close();
+    });
+
+    it("returns 500 when the lookup throws", async () => {
+      loadMeta.mockRejectedValue(new Error("upstream"));
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/meta/movie/tt1" });
+
+      expect(res.statusCode).toBe(500);
+      await app.close();
+    });
+  });
+
+  describe("GET /meta/series/:imdbId/season/:seasonNumber/episodes", () => {
+    it("loads a season's episodes", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/meta/series/tt1/season/2/episodes" });
+
+      expect(res.statusCode).toBe(200);
+      expect(loadEpisodes).toHaveBeenCalledWith("tt1", 2, expect.anything());
+      await app.close();
+    });
+
+    it("rejects season 0 and other non-positive season numbers", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/meta/series/tt1/season/0/episodes" });
+
+      expect(res.statusCode).toBe(400);
+      expect(loadEpisodes).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it("rejects a non-numeric season", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/meta/series/tt1/season/two/episodes" });
+
+      expect(res.statusCode).toBe(400);
+      await app.close();
+    });
+  });
+
+  describe("GET /meta/:type/:imdbId/providers", () => {
+    it("degrades to an empty provider set for an unknown type", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/meta/book/tt1/providers" });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual({ providers: EMPTY_PROVIDERS });
+      await app.close();
+    });
+  });
+
+  describe("GET /meta/:type/:imdbId/bundle", () => {
+    it("returns every section of the detail panel in one response", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/meta/series/tt1/bundle" });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.meta).toMatchObject({ name: "A Title" });
+      expect(body.cast).toHaveLength(1);
+      expect(body.director).toBe("A Director");
+      expect(body.recommendations).toHaveLength(1);
+      expect(body.seasons).toHaveLength(1);
+      await app.close();
+    });
+
+    it("skips the seasons and dropped lookups for a movie", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/meta/movie/tt1/bundle" });
+
+      expect(res.json()).toMatchObject({ seasons: [], dropped: false });
+      expect(loadSeasons).not.toHaveBeenCalled();
+      expect(prismaMock.kV.findUnique).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it("reports a series the profile has dropped", async () => {
+      prismaMock.kV.findUnique.mockResolvedValue({ key: `dropped:${PROFILE_ID}:tt1`, value: "1" });
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/meta/series/tt1/bundle" });
+
+      expect(res.json().dropped).toBe(true);
+      await app.close();
+    });
+
+    it("still renders the panel when an optional section fails", async () => {
+      // Each section degrades on its own; one failing upstream must not take
+      // the whole panel down.
+      loadCast.mockRejectedValue(new Error("tmdb down"));
+      loadProviders.mockRejectedValue(new Error("tmdb down"));
+      loadRecommendations.mockRejectedValue(new Error("tmdb down"));
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/meta/movie/tt1/bundle" });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toMatchObject({ cast: [], director: null, providers: EMPTY_PROVIDERS, recommendations: [] });
+      await app.close();
+    });
+
+    it("404s when the title itself is missing", async () => {
+      loadMeta.mockResolvedValue(null);
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/meta/movie/tt1/bundle" });
+
+      expect(res.statusCode).toBe(404);
+      await app.close();
+    });
+  });
+
+  describe("POST /metadata/sync", () => {
+    it("syncs a title from TMDB", async () => {
+      syncMetadata.mockResolvedValue({ imdbId: "tt1", name: "A Title" });
+      const app = await buildApp();
+
+      const res = await app.inject({
+        method: "POST",
+        url: "/metadata/sync",
+        payload: { imdbId: " tt1 ", type: "movie" },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(syncMetadata).toHaveBeenCalledWith("tt1", "movie");
+      await app.close();
+    });
+
+    it("404s when TMDB has no record of the title", async () => {
+      syncMetadata.mockResolvedValue(null);
+      const app = await buildApp();
+
+      const res = await app.inject({
+        method: "POST",
+        url: "/metadata/sync",
+        payload: { imdbId: "tt1", type: "movie" },
+      });
+
+      expect(res.statusCode).toBe(404);
+      await app.close();
+    });
+
+    it("requires a type", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "POST", url: "/metadata/sync", payload: { imdbId: "tt1" } });
+
+      expect(res.statusCode).toBe(400);
+      await app.close();
+    });
+
+    it("requires an imdbId", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "POST", url: "/metadata/sync", payload: { type: "movie" } });
+
+      expect(res.statusCode).toBe(400);
+      await app.close();
+    });
+  });
+
+  describe("POST /metadata/refresh-all", () => {
+    it("short-circuits when there is nothing stored", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "POST", url: "/metadata/refresh-all" });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual({ refreshed: 0, total: 0, limit: 50 });
+      expect(getTmdb).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it("caps the limit at 500", async () => {
+      const app = await buildApp();
+
+      await app.inject({ method: "POST", url: "/metadata/refresh-all?limit=100000" });
+
+      expect(prismaMock.metadata.findMany).toHaveBeenCalledWith(expect.objectContaining({ take: 500 }));
+      await app.close();
+    });
+
+    it("falls back to 50 for a non-numeric limit", async () => {
+      const app = await buildApp();
+
+      await app.inject({ method: "POST", url: "/metadata/refresh-all?limit=lots" });
+
+      expect(prismaMock.metadata.findMany).toHaveBeenCalledWith(expect.objectContaining({ take: 50 }));
+      await app.close();
+    });
+
+    it("counts only the rows TMDB actually returned", async () => {
+      prismaMock.metadata.findMany.mockResolvedValue([
+        { imdbId: "tt1", type: "movie" },
+        { imdbId: "tt2", type: "movie" },
+      ]);
+      findByImdbId.mockResolvedValueOnce({ imdbId: "tt1" }).mockResolvedValueOnce(null);
+      upsertMetadata.mockResolvedValue(undefined);
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "POST", url: "/metadata/refresh-all" });
+
+      expect(res.json()).toMatchObject({ refreshed: 1, total: 2 });
+      await app.close();
+    });
+
+    it("keeps going when one title's refresh throws", async () => {
+      prismaMock.metadata.findMany.mockResolvedValue([
+        { imdbId: "tt1", type: "movie" },
+        { imdbId: "tt2", type: "movie" },
+      ]);
+      findByImdbId.mockRejectedValueOnce(new Error("429")).mockResolvedValueOnce({ imdbId: "tt2" });
+      upsertMetadata.mockResolvedValue(undefined);
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "POST", url: "/metadata/refresh-all" });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().refreshed).toBe(1);
+      await app.close();
+    });
+
+    it("returns 500 when TMDB cannot be initialised", async () => {
+      prismaMock.metadata.findMany.mockResolvedValue([{ imdbId: "tt1", type: "movie" }]);
+      getTmdb.mockRejectedValue(new Error("no key"));
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "POST", url: "/metadata/refresh-all" });
+
+      expect(res.statusCode).toBe(500);
+      await app.close();
+    });
+  });
+
+  describe("GET /metadata/anime-search", () => {
+    it("returns AniList results", async () => {
+      searchAnime.mockResolvedValue([{ id: 1, title: "Cowboy Bebop" }]);
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/metadata/anime-search?q=bebop" });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().results).toHaveLength(1);
+      await app.close();
+    });
+
+    it("requires a query", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/metadata/anime-search" });
+
+      expect(res.statusCode).toBe(400);
+      await app.close();
+    });
+
+    it("returns 502 when AniList fails", async () => {
+      searchAnime.mockRejectedValue(new Error("down"));
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/metadata/anime-search?q=bebop" });
+
+      expect(res.statusCode).toBe(502);
+      await app.close();
+    });
+  });
+
+  describe("GET /genres", () => {
+    it("returns a sorted, de-duplicated genre list", async () => {
+      prismaMock.metadata.findMany.mockResolvedValue([
+        { genres: ["Drama", "Crime"] },
+        { genres: ["Crime", "Action"] },
+      ]);
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/genres" });
+
+      expect(res.json().genres).toEqual(["Action", "Crime", "Drama"]);
+      await app.close();
+    });
+  });
+});

--- a/apps/api/src/routes/metadata.test.ts
+++ b/apps/api/src/routes/metadata.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import Fastify, { type FastifyInstance } from "fastify";
+import type { FastifyInstance } from "fastify";
+import { buildRouteApp } from "../lib/test-fixtures/route-app.js";
 
 const PROFILE_ID = "11111111-1111-4111-8111-111111111111";
 
@@ -55,14 +56,8 @@ vi.mock("../lib/profile.js", () => ({
   },
 }));
 
-const buildApp = async (): Promise<FastifyInstance> => {
-  vi.resetModules();
-  const { default: metadataRoutes } = await import("./metadata.js");
-  const app = Fastify({ logger: false });
-  await app.register(metadataRoutes);
-  await app.ready();
-  return app;
-};
+const buildApp = (): Promise<FastifyInstance> =>
+  buildRouteApp(() => import("./metadata.js"));
 
 describe("metadata routes", () => {
   beforeEach(() => {
@@ -87,7 +82,6 @@ describe("metadata routes", () => {
 
       expect(res.statusCode).toBe(200);
       expect(loadMeta).toHaveBeenCalledWith("movie", "tt1");
-      await app.close();
     });
 
     it("rejects a type that is not movie or series", async () => {
@@ -97,7 +91,6 @@ describe("metadata routes", () => {
 
       expect(res.statusCode).toBe(400);
       expect(loadMeta).not.toHaveBeenCalled();
-      await app.close();
     });
 
     it("404s when nothing is found", async () => {
@@ -107,7 +100,6 @@ describe("metadata routes", () => {
       const res = await app.inject({ method: "GET", url: "/meta/movie/tt1" });
 
       expect(res.statusCode).toBe(404);
-      await app.close();
     });
 
     it("returns 500 when the lookup throws", async () => {
@@ -117,7 +109,6 @@ describe("metadata routes", () => {
       const res = await app.inject({ method: "GET", url: "/meta/movie/tt1" });
 
       expect(res.statusCode).toBe(500);
-      await app.close();
     });
   });
 
@@ -129,7 +120,6 @@ describe("metadata routes", () => {
 
       expect(res.statusCode).toBe(200);
       expect(loadEpisodes).toHaveBeenCalledWith("tt1", 2, expect.anything());
-      await app.close();
     });
 
     it("rejects season 0 and other non-positive season numbers", async () => {
@@ -139,7 +129,6 @@ describe("metadata routes", () => {
 
       expect(res.statusCode).toBe(400);
       expect(loadEpisodes).not.toHaveBeenCalled();
-      await app.close();
     });
 
     it("rejects a non-numeric season", async () => {
@@ -148,7 +137,6 @@ describe("metadata routes", () => {
       const res = await app.inject({ method: "GET", url: "/meta/series/tt1/season/two/episodes" });
 
       expect(res.statusCode).toBe(400);
-      await app.close();
     });
   });
 
@@ -160,7 +148,6 @@ describe("metadata routes", () => {
 
       expect(res.statusCode).toBe(200);
       expect(res.json()).toEqual({ providers: EMPTY_PROVIDERS });
-      await app.close();
     });
   });
 
@@ -177,7 +164,6 @@ describe("metadata routes", () => {
       expect(body.director).toBe("A Director");
       expect(body.recommendations).toHaveLength(1);
       expect(body.seasons).toHaveLength(1);
-      await app.close();
     });
 
     it("skips the seasons and dropped lookups for a movie", async () => {
@@ -188,7 +174,6 @@ describe("metadata routes", () => {
       expect(res.json()).toMatchObject({ seasons: [], dropped: false });
       expect(loadSeasons).not.toHaveBeenCalled();
       expect(prismaMock.kV.findUnique).not.toHaveBeenCalled();
-      await app.close();
     });
 
     it("reports a series the profile has dropped", async () => {
@@ -198,7 +183,6 @@ describe("metadata routes", () => {
       const res = await app.inject({ method: "GET", url: "/meta/series/tt1/bundle" });
 
       expect(res.json().dropped).toBe(true);
-      await app.close();
     });
 
     it("still renders the panel when an optional section fails", async () => {
@@ -213,7 +197,6 @@ describe("metadata routes", () => {
 
       expect(res.statusCode).toBe(200);
       expect(res.json()).toMatchObject({ cast: [], director: null, providers: EMPTY_PROVIDERS, recommendations: [] });
-      await app.close();
     });
 
     it("404s when the title itself is missing", async () => {
@@ -223,7 +206,6 @@ describe("metadata routes", () => {
       const res = await app.inject({ method: "GET", url: "/meta/movie/tt1/bundle" });
 
       expect(res.statusCode).toBe(404);
-      await app.close();
     });
   });
 
@@ -240,7 +222,6 @@ describe("metadata routes", () => {
 
       expect(res.statusCode).toBe(200);
       expect(syncMetadata).toHaveBeenCalledWith("tt1", "movie");
-      await app.close();
     });
 
     it("404s when TMDB has no record of the title", async () => {
@@ -254,7 +235,6 @@ describe("metadata routes", () => {
       });
 
       expect(res.statusCode).toBe(404);
-      await app.close();
     });
 
     it("requires a type", async () => {
@@ -263,7 +243,6 @@ describe("metadata routes", () => {
       const res = await app.inject({ method: "POST", url: "/metadata/sync", payload: { imdbId: "tt1" } });
 
       expect(res.statusCode).toBe(400);
-      await app.close();
     });
 
     it("requires an imdbId", async () => {
@@ -272,7 +251,6 @@ describe("metadata routes", () => {
       const res = await app.inject({ method: "POST", url: "/metadata/sync", payload: { type: "movie" } });
 
       expect(res.statusCode).toBe(400);
-      await app.close();
     });
   });
 
@@ -285,7 +263,6 @@ describe("metadata routes", () => {
       expect(res.statusCode).toBe(200);
       expect(res.json()).toEqual({ refreshed: 0, total: 0, limit: 50 });
       expect(getTmdb).not.toHaveBeenCalled();
-      await app.close();
     });
 
     it("caps the limit at 500", async () => {
@@ -294,7 +271,6 @@ describe("metadata routes", () => {
       await app.inject({ method: "POST", url: "/metadata/refresh-all?limit=100000" });
 
       expect(prismaMock.metadata.findMany).toHaveBeenCalledWith(expect.objectContaining({ take: 500 }));
-      await app.close();
     });
 
     it("falls back to 50 for a non-numeric limit", async () => {
@@ -303,7 +279,6 @@ describe("metadata routes", () => {
       await app.inject({ method: "POST", url: "/metadata/refresh-all?limit=lots" });
 
       expect(prismaMock.metadata.findMany).toHaveBeenCalledWith(expect.objectContaining({ take: 50 }));
-      await app.close();
     });
 
     it("counts only the rows TMDB actually returned", async () => {
@@ -318,7 +293,6 @@ describe("metadata routes", () => {
       const res = await app.inject({ method: "POST", url: "/metadata/refresh-all" });
 
       expect(res.json()).toMatchObject({ refreshed: 1, total: 2 });
-      await app.close();
     });
 
     it("keeps going when one title's refresh throws", async () => {
@@ -334,7 +308,6 @@ describe("metadata routes", () => {
 
       expect(res.statusCode).toBe(200);
       expect(res.json().refreshed).toBe(1);
-      await app.close();
     });
 
     it("returns 500 when TMDB cannot be initialised", async () => {
@@ -345,7 +318,6 @@ describe("metadata routes", () => {
       const res = await app.inject({ method: "POST", url: "/metadata/refresh-all" });
 
       expect(res.statusCode).toBe(500);
-      await app.close();
     });
   });
 
@@ -358,7 +330,6 @@ describe("metadata routes", () => {
 
       expect(res.statusCode).toBe(200);
       expect(res.json().results).toHaveLength(1);
-      await app.close();
     });
 
     it("requires a query", async () => {
@@ -367,7 +338,6 @@ describe("metadata routes", () => {
       const res = await app.inject({ method: "GET", url: "/metadata/anime-search" });
 
       expect(res.statusCode).toBe(400);
-      await app.close();
     });
 
     it("returns 502 when AniList fails", async () => {
@@ -377,7 +347,6 @@ describe("metadata routes", () => {
       const res = await app.inject({ method: "GET", url: "/metadata/anime-search?q=bebop" });
 
       expect(res.statusCode).toBe(502);
-      await app.close();
     });
   });
 
@@ -392,7 +361,6 @@ describe("metadata routes", () => {
       const res = await app.inject({ method: "GET", url: "/genres" });
 
       expect(res.json().genres).toEqual(["Action", "Crime", "Drama"]);
-      await app.close();
     });
   });
 });

--- a/apps/api/src/routes/profiles.test.ts
+++ b/apps/api/src/routes/profiles.test.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import Fastify, { type FastifyInstance } from "fastify";
+import type { FastifyInstance } from "fastify";
+import { buildRouteApp } from "../lib/test-fixtures/route-app.js";
 
 const PROFILE_ID = "11111111-1111-4111-8111-111111111111";
 /**
@@ -31,14 +32,8 @@ const resetMocks = () => {
   );
 };
 
-const buildApp = async (): Promise<FastifyInstance> => {
-  vi.resetModules();
-  const { default: profilesRoutes } = await import("./profiles.js");
-  const app = Fastify();
-  await app.register(profilesRoutes);
-  await app.ready();
-  return app;
-};
+const buildApp = (): Promise<FastifyInstance> =>
+  buildRouteApp(() => import("./profiles.js"));
 
 describe("profiles routes", () => {
   beforeEach(() => {
@@ -60,7 +55,6 @@ describe("profiles routes", () => {
         { id: "p1", name: "Alice", hasPin: true },
         { id: "p2", name: "Bob", hasPin: false },
       ]);
-      await app.close();
     });
   });
 
@@ -69,14 +63,12 @@ describe("profiles routes", () => {
       const app = await buildApp();
       const response = await app.inject({ method: "POST", url: "/profiles", payload: {} });
       expect(response.statusCode).toBe(400);
-      await app.close();
     });
 
     it("rejects a blank pin when explicitly provided", async () => {
       const app = await buildApp();
       const response = await app.inject({ method: "POST", url: "/profiles", payload: { name: "Alice", pin: "  " } });
       expect(response.statusCode).toBe(400);
-      await app.close();
     });
 
     it("creates a profile without a pin", async () => {
@@ -87,7 +79,6 @@ describe("profiles routes", () => {
 
       expect(response.statusCode).toBe(201);
       expect(response.json().profile).toEqual({ id: PROFILE_ID, name: "Alice", hasPin: false });
-      await app.close();
     });
 
     it("rejects a PIN shorter than the minimum length", async () => {
@@ -97,7 +88,6 @@ describe("profiles routes", () => {
       expect(response.statusCode).toBe(400);
       expect(response.json().error).toMatch(/at least|between/i);
       expect(prismaMock.profile.create).not.toHaveBeenCalled();
-      await app.close();
     });
 
     it("creates a profile with a hashed pin", async () => {
@@ -109,7 +99,6 @@ describe("profiles routes", () => {
       expect(prismaMock.profile.create).toHaveBeenCalledWith(
         expect.objectContaining({ data: expect.objectContaining({ pinHash: SCRYPT_HASH }) })
       );
-      await app.close();
     });
   });
 
@@ -118,7 +107,6 @@ describe("profiles routes", () => {
       const app = await buildApp();
       const response = await app.inject({ method: "POST", url: "/profiles/not-a-uuid/verify", payload: {} });
       expect(response.statusCode).toBe(400);
-      await app.close();
     });
 
     it("returns 404 for an unknown profile", async () => {
@@ -126,7 +114,6 @@ describe("profiles routes", () => {
       const app = await buildApp();
       const response = await app.inject({ method: "POST", url: `/profiles/${PROFILE_ID}/verify`, payload: {} });
       expect(response.statusCode).toBe(404);
-      await app.close();
     });
 
     it("allows verification immediately when the profile has no PIN set", async () => {
@@ -134,7 +121,6 @@ describe("profiles routes", () => {
       const app = await buildApp();
       const response = await app.inject({ method: "POST", url: `/profiles/${PROFILE_ID}/verify`, payload: {} });
       expect(response.statusCode).toBe(200);
-      await app.close();
     });
 
     it("accepts the correct PIN and clears prior attempts", async () => {
@@ -149,7 +135,6 @@ describe("profiles routes", () => {
 
       expect(response.statusCode).toBe(200);
       expect(prismaMock.kV.deleteMany).toHaveBeenCalled();
-      await app.close();
     });
 
     it("rejects an incorrect PIN and records a failed attempt", async () => {
@@ -164,7 +149,6 @@ describe("profiles routes", () => {
 
       expect(response.statusCode).toBe(401);
       expect(prismaMock.$transaction).toHaveBeenCalled();
-      await app.close();
     });
 
     it("verifies a PIN stored under the pre-scrypt hash and rewrites it in the new format", async () => {
@@ -183,7 +167,6 @@ describe("profiles routes", () => {
         where: { id: PROFILE_ID },
         data: { pinHash: SCRYPT_HASH },
       });
-      await app.close();
     });
 
     it("still verifies when rewriting the legacy hash fails", async () => {
@@ -198,7 +181,6 @@ describe("profiles routes", () => {
       });
 
       expect(response.statusCode).toBe(200);
-      await app.close();
     });
 
     it("leaves an already-scrypt hash alone on a successful verify", async () => {
@@ -218,7 +200,6 @@ describe("profiles routes", () => {
 
       expect(response.statusCode).toBe(200);
       expect(prismaMock.profile.update).not.toHaveBeenCalled();
-      await app.close();
     });
 
     it("locks out after MAX_PIN_ATTEMPTS (5) failures and returns 429 on the next attempt", async () => {
@@ -266,7 +247,6 @@ describe("profiles routes", () => {
       expect(lockedResponse.json()).toEqual(
         expect.objectContaining({ error: expect.stringContaining("Too many incorrect attempts") })
       );
-      await app.close();
     });
 
     it("makes each successive lockout longer instead of re-locking for the same five minutes", async () => {
@@ -304,7 +284,6 @@ describe("profiles routes", () => {
       expect(lockoutDurations[1]).toBeGreaterThan(lockoutDurations[0] * 1.5);
       expect(lockoutDurations[2]).toBeGreaterThan(lockoutDurations[1] * 1.5);
       expect(kvState!.lockouts).toBe(3);
-      await app.close();
     });
   });
 
@@ -313,7 +292,6 @@ describe("profiles routes", () => {
       const app = await buildApp();
       const response = await app.inject({ method: "PATCH", url: "/profiles/not-a-uuid", payload: { name: "Alice" } });
       expect(response.statusCode).toBe(400);
-      await app.close();
     });
 
     it("404s for an unknown profile", async () => {
@@ -321,7 +299,6 @@ describe("profiles routes", () => {
       const app = await buildApp();
       const response = await app.inject({ method: "PATCH", url: `/profiles/${PROFILE_ID}`, payload: { name: "Alice" } });
       expect(response.statusCode).toBe(404);
-      await app.close();
     });
 
     it("rejects an empty body (nothing to update)", async () => {
@@ -330,7 +307,6 @@ describe("profiles routes", () => {
       const response = await app.inject({ method: "PATCH", url: `/profiles/${PROFILE_ID}`, payload: {} });
       expect(response.statusCode).toBe(400);
       expect(prismaMock.profile.update).not.toHaveBeenCalled();
-      await app.close();
     });
 
     it("rejects a blank name", async () => {
@@ -338,7 +314,6 @@ describe("profiles routes", () => {
       const app = await buildApp();
       const response = await app.inject({ method: "PATCH", url: `/profiles/${PROFILE_ID}`, payload: { name: "  " } });
       expect(response.statusCode).toBe(400);
-      await app.close();
     });
 
     it("renames a profile", async () => {
@@ -354,7 +329,6 @@ describe("profiles routes", () => {
         where: { id: PROFILE_ID },
         data: { name: "Alicia" },
       });
-      await app.close();
     });
 
     it("sets a PIN and clears any prior lockout attempts", async () => {
@@ -371,7 +345,6 @@ describe("profiles routes", () => {
         data: { pinHash: SCRYPT_HASH },
       });
       expect(prismaMock.kV.deleteMany).toHaveBeenCalled();
-      await app.close();
     });
 
     it("removes a PIN when pin is explicitly null and the correct currentPin is given", async () => {
@@ -392,7 +365,6 @@ describe("profiles routes", () => {
         data: { pinHash: null },
       });
       expect(prismaMock.kV.deleteMany).toHaveBeenCalled();
-      await app.close();
     });
 
     it("rejects a new PIN shorter than the minimum length", async () => {
@@ -402,7 +374,6 @@ describe("profiles routes", () => {
 
       expect(response.statusCode).toBe(400);
       expect(prismaMock.profile.update).not.toHaveBeenCalled();
-      await app.close();
     });
 
     it("rejects a blank pin string (use null to remove)", async () => {
@@ -411,7 +382,6 @@ describe("profiles routes", () => {
       const response = await app.inject({ method: "PATCH", url: `/profiles/${PROFILE_ID}`, payload: { pin: "  " } });
       expect(response.statusCode).toBe(400);
       expect(prismaMock.profile.update).not.toHaveBeenCalled();
-      await app.close();
     });
 
     describe("changing/removing an existing PIN requires the current PIN", () => {
@@ -423,7 +393,6 @@ describe("profiles routes", () => {
 
         expect(response.statusCode).toBe(401);
         expect(prismaMock.profile.update).not.toHaveBeenCalled();
-        await app.close();
       });
 
       it("rejects an incorrect currentPin and records a failed attempt", async () => {
@@ -439,7 +408,6 @@ describe("profiles routes", () => {
         expect(response.statusCode).toBe(401);
         expect(prismaMock.profile.update).not.toHaveBeenCalled();
         expect(prismaMock.$transaction).toHaveBeenCalled();
-        await app.close();
       });
 
       it("does not derive a hash for the new PIN when the currentPin is wrong", async () => {
@@ -462,7 +430,6 @@ describe("profiles routes", () => {
           expect(response.statusCode).toBe(401);
           expect(hashSpy).not.toHaveBeenCalled();
           expect(prismaMock.profile.update).not.toHaveBeenCalled();
-          await app.close();
         } finally {
           vi.doUnmock("../lib/pin-hash.js");
           vi.resetModules();
@@ -485,7 +452,6 @@ describe("profiles routes", () => {
           where: { id: PROFILE_ID },
           data: { pinHash: SCRYPT_HASH },
         });
-        await app.close();
       });
 
       it("does not require currentPin when setting a PIN for the first time", async () => {
@@ -496,7 +462,6 @@ describe("profiles routes", () => {
         const response = await app.inject({ method: "PATCH", url: `/profiles/${PROFILE_ID}`, payload: { pin: "9999" } });
 
         expect(response.statusCode).toBe(200);
-        await app.close();
       });
     });
   });
@@ -511,7 +476,6 @@ describe("profiles routes", () => {
 
       expect(response.statusCode).toBe(400);
       expect(prismaMock.profile.delete).not.toHaveBeenCalled();
-      await app.close();
     });
 
     it("deletes a profile when more than one exists", async () => {
@@ -523,7 +487,6 @@ describe("profiles routes", () => {
 
       expect(response.statusCode).toBe(204);
       expect(prismaMock.profile.delete).toHaveBeenCalledWith({ where: { id: PROFILE_ID } });
-      await app.close();
     });
 
     describe("a PIN-protected profile requires proof of the PIN", () => {
@@ -543,7 +506,6 @@ describe("profiles routes", () => {
         expect(response.statusCode).toBe(401);
         expect(prismaMock.profile.delete).not.toHaveBeenCalled();
         expect(prismaMock.$transaction).toHaveBeenCalled();
-        await app.close();
       });
 
       it("refuses an incorrect currentPin", async () => {
@@ -557,7 +519,6 @@ describe("profiles routes", () => {
 
         expect(response.statusCode).toBe(401);
         expect(prismaMock.profile.delete).not.toHaveBeenCalled();
-        await app.close();
       });
 
       it("deletes when the correct currentPin is given", async () => {
@@ -571,7 +532,6 @@ describe("profiles routes", () => {
 
         expect(response.statusCode).toBe(204);
         expect(prismaMock.profile.delete).toHaveBeenCalledWith({ where: { id: PROFILE_ID } });
-        await app.close();
       });
 
       it("deletes without a PIN when the caller holds this profile's access token", async () => {
@@ -585,7 +545,6 @@ describe("profiles routes", () => {
         });
 
         expect(response.statusCode).toBe(204);
-        await app.close();
       });
 
       it("ignores an access token minted for a different profile", async () => {
@@ -600,7 +559,6 @@ describe("profiles routes", () => {
 
         expect(response.statusCode).toBe(401);
         expect(prismaMock.profile.delete).not.toHaveBeenCalled();
-        await app.close();
       });
 
       it("returns 429 while the profile is locked out", async () => {
@@ -617,7 +575,6 @@ describe("profiles routes", () => {
 
         expect(response.statusCode).toBe(429);
         expect(prismaMock.profile.delete).not.toHaveBeenCalled();
-        await app.close();
       });
     });
   });

--- a/apps/api/src/routes/push.test.ts
+++ b/apps/api/src/routes/push.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import Fastify, { type FastifyInstance } from "fastify";
+import type { FastifyInstance } from "fastify";
+import { buildRouteApp } from "../lib/test-fixtures/route-app.js";
 
 const PROFILE_ID = "11111111-1111-4111-8111-111111111111";
 const ENDPOINT = "https://fcm.googleapis.com/fcm/send/abc123";
@@ -18,14 +19,8 @@ vi.mock("../lib/profile.js", () => ({
   },
 }));
 
-const buildApp = async (): Promise<FastifyInstance> => {
-  vi.resetModules();
-  const { default: pushRoutes } = await import("./push.js");
-  const app = Fastify();
-  await app.register(pushRoutes);
-  await app.ready();
-  return app;
-};
+const buildApp = (): Promise<FastifyInstance> =>
+  buildRouteApp(() => import("./push.js"));
 
 const subscribeBody = (over: Record<string, unknown> = {}) => ({
   endpoint: ENDPOINT,
@@ -50,7 +45,6 @@ describe("push routes", () => {
 
       expect(res.statusCode).toBe(200);
       expect(res.json()).toEqual({ publicKey: "vapid-public-key" });
-      await app.close();
     });
   });
 
@@ -66,7 +60,6 @@ describe("push routes", () => {
         create: { endpoint: ENDPOINT, p256dh: "p256dh-value", auth: "auth-value", profileId: PROFILE_ID },
         update: { p256dh: "p256dh-value", auth: "auth-value", profileId: PROFILE_ID },
       });
-      await app.close();
     });
 
     it("re-subscribing rotates the keys rather than creating a second row", async () => {
@@ -81,7 +74,6 @@ describe("push routes", () => {
       expect(prismaMock.pushSubscription.upsert).toHaveBeenCalledWith(
         expect.objectContaining({ update: expect.objectContaining({ p256dh: "new-p256dh" }) })
       );
-      await app.close();
     });
 
     it("rejects an endpoint that is not a real push service", async () => {
@@ -98,7 +90,6 @@ describe("push routes", () => {
 
       expect(res.statusCode).toBe(400);
       expect(prismaMock.pushSubscription.upsert).not.toHaveBeenCalled();
-      await app.close();
     });
 
     it("rejects a subscription missing its keys", async () => {
@@ -112,7 +103,6 @@ describe("push routes", () => {
 
       expect(res.statusCode).toBe(400);
       expect(resolvePushEndpoint).not.toHaveBeenCalled();
-      await app.close();
     });
 
     it("rejects a blank endpoint", async () => {
@@ -125,7 +115,6 @@ describe("push routes", () => {
       });
 
       expect(res.statusCode).toBe(400);
-      await app.close();
     });
   });
 
@@ -144,7 +133,6 @@ describe("push routes", () => {
       expect(prismaMock.pushSubscription.deleteMany).toHaveBeenCalledWith({
         where: { endpoint: ENDPOINT, profileId: PROFILE_ID },
       });
-      await app.close();
     });
 
     it("rejects a missing endpoint", async () => {
@@ -154,7 +142,6 @@ describe("push routes", () => {
 
       expect(res.statusCode).toBe(400);
       expect(prismaMock.pushSubscription.deleteMany).not.toHaveBeenCalled();
-      await app.close();
     });
   });
 });

--- a/apps/api/src/routes/push.test.ts
+++ b/apps/api/src/routes/push.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import Fastify, { type FastifyInstance } from "fastify";
+
+const PROFILE_ID = "11111111-1111-4111-8111-111111111111";
+const ENDPOINT = "https://fcm.googleapis.com/fcm/send/abc123";
+
+const prismaMock = { pushSubscription: { upsert: vi.fn(), deleteMany: vi.fn() } };
+
+const getPushPublicKey = vi.fn();
+const resolvePushEndpoint = vi.fn();
+
+vi.mock("../lib/prisma.js", () => ({ prisma: prismaMock }));
+vi.mock("../lib/push.js", () => ({ getPushPublicKey: () => getPushPublicKey() }));
+vi.mock("../lib/ssrf.js", () => ({ resolvePushEndpoint: (...a: unknown[]) => resolvePushEndpoint(...a) }));
+vi.mock("../lib/profile.js", () => ({
+  resolveProfile: async (request: { profileId?: string }) => {
+    request.profileId = PROFILE_ID;
+  },
+}));
+
+const buildApp = async (): Promise<FastifyInstance> => {
+  vi.resetModules();
+  const { default: pushRoutes } = await import("./push.js");
+  const app = Fastify();
+  await app.register(pushRoutes);
+  await app.ready();
+  return app;
+};
+
+const subscribeBody = (over: Record<string, unknown> = {}) => ({
+  endpoint: ENDPOINT,
+  keys: { p256dh: "p256dh-value", auth: "auth-value" },
+  ...over,
+});
+
+describe("push routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getPushPublicKey.mockResolvedValue("vapid-public-key");
+    resolvePushEndpoint.mockResolvedValue(true);
+    prismaMock.pushSubscription.upsert.mockResolvedValue({});
+    prismaMock.pushSubscription.deleteMany.mockResolvedValue({ count: 1 });
+  });
+
+  describe("GET /push/public-key", () => {
+    it("returns the VAPID public key", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/push/public-key" });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual({ publicKey: "vapid-public-key" });
+      await app.close();
+    });
+  });
+
+  describe("POST /push/subscribe", () => {
+    it("stores a subscription against the calling profile", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "POST", url: "/push/subscribe", payload: subscribeBody() });
+
+      expect(res.statusCode).toBe(201);
+      expect(prismaMock.pushSubscription.upsert).toHaveBeenCalledWith({
+        where: { endpoint: ENDPOINT },
+        create: { endpoint: ENDPOINT, p256dh: "p256dh-value", auth: "auth-value", profileId: PROFILE_ID },
+        update: { p256dh: "p256dh-value", auth: "auth-value", profileId: PROFILE_ID },
+      });
+      await app.close();
+    });
+
+    it("re-subscribing rotates the keys rather than creating a second row", async () => {
+      const app = await buildApp();
+
+      await app.inject({
+        method: "POST",
+        url: "/push/subscribe",
+        payload: subscribeBody({ keys: { p256dh: "new-p256dh", auth: "new-auth" } }),
+      });
+
+      expect(prismaMock.pushSubscription.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({ update: expect.objectContaining({ p256dh: "new-p256dh" }) })
+      );
+      await app.close();
+    });
+
+    it("rejects an endpoint that is not a real push service", async () => {
+      // Otherwise a stolen API token could point the notification job at an
+      // internal address and use it as an SSRF proxy.
+      resolvePushEndpoint.mockResolvedValue(false);
+      const app = await buildApp();
+
+      const res = await app.inject({
+        method: "POST",
+        url: "/push/subscribe",
+        payload: subscribeBody({ endpoint: "http://169.254.169.254/latest/meta-data" }),
+      });
+
+      expect(res.statusCode).toBe(400);
+      expect(prismaMock.pushSubscription.upsert).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it("rejects a subscription missing its keys", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({
+        method: "POST",
+        url: "/push/subscribe",
+        payload: { endpoint: ENDPOINT },
+      });
+
+      expect(res.statusCode).toBe(400);
+      expect(resolvePushEndpoint).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it("rejects a blank endpoint", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({
+        method: "POST",
+        url: "/push/subscribe",
+        payload: subscribeBody({ endpoint: "   " }),
+      });
+
+      expect(res.statusCode).toBe(400);
+      await app.close();
+    });
+  });
+
+  describe("POST /push/unsubscribe", () => {
+    it("removes only the calling profile's subscription", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({
+        method: "POST",
+        url: "/push/unsubscribe",
+        payload: { endpoint: ENDPOINT },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual({ subscribed: false });
+      expect(prismaMock.pushSubscription.deleteMany).toHaveBeenCalledWith({
+        where: { endpoint: ENDPOINT, profileId: PROFILE_ID },
+      });
+      await app.close();
+    });
+
+    it("rejects a missing endpoint", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "POST", url: "/push/unsubscribe", payload: {} });
+
+      expect(res.statusCode).toBe(400);
+      expect(prismaMock.pushSubscription.deleteMany).not.toHaveBeenCalled();
+      await app.close();
+    });
+  });
+});

--- a/apps/api/src/routes/ratings.test.ts
+++ b/apps/api/src/routes/ratings.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import Fastify, { type FastifyInstance } from "fastify";
+import type { FastifyInstance } from "fastify";
+import { buildRouteApp } from "../lib/test-fixtures/route-app.js";
 
 const PROFILE_ID = "11111111-1111-4111-8111-111111111111";
 
@@ -14,14 +15,8 @@ vi.mock("../lib/profile.js", () => ({
   },
 }));
 
-const buildApp = async (): Promise<FastifyInstance> => {
-  vi.resetModules();
-  const { default: ratingsRoutes } = await import("./ratings.js");
-  const app = Fastify();
-  await app.register(ratingsRoutes);
-  await app.ready();
-  return app;
-};
+const buildApp = (): Promise<FastifyInstance> =>
+  buildRouteApp(() => import("./ratings.js"));
 
 const row = (over: Record<string, unknown> = {}) => ({
   imdbId: "tt1",
@@ -65,7 +60,6 @@ describe("ratings routes", () => {
         })
       );
       expect(res.json().rating).toMatchObject({ type: "season", season: 3, rating: 9 });
-      await app.close();
     });
 
     it("keeps a Specials rating apart from the show's own rating", async () => {
@@ -95,7 +89,6 @@ describe("ratings routes", () => {
           },
         })
       );
-      await app.close();
     });
 
     it("rejects a season rating with no season number", async () => {
@@ -110,7 +103,6 @@ describe("ratings routes", () => {
       expect(res.statusCode).toBe(400);
       expect(res.json().error).toContain("season must be an integer");
       expect(prismaMock.rating.upsert).not.toHaveBeenCalled();
-      await app.close();
     });
 
     it("reads and deletes a season rating by its season number", async () => {
@@ -146,7 +138,6 @@ describe("ratings routes", () => {
           },
         },
       });
-      await app.close();
     });
 
     it("refuses to read or delete a season rating with no season, rather than answering for Specials", async () => {
@@ -161,7 +152,6 @@ describe("ratings routes", () => {
       const removed = await app.inject({ method: "DELETE", url: "/ratings/season/tt2" });
       expect(removed.statusCode).toBe(400);
       expect(prismaMock.rating.delete).not.toHaveBeenCalled();
-      await app.close();
     });
 
     it("rejects a season number too large for the column to hold", async () => {
@@ -175,7 +165,6 @@ describe("ratings routes", () => {
 
       expect(res.statusCode).toBe(400);
       expect(prismaMock.rating.upsert).not.toHaveBeenCalled();
-      await app.close();
     });
 
     it("rejects an episode number too large for the column to hold", async () => {
@@ -189,7 +178,6 @@ describe("ratings routes", () => {
 
       expect(res.statusCode).toBe(400);
       expect(prismaMock.rating.upsert).not.toHaveBeenCalled();
-      await app.close();
     });
 
     it("names season alongside the other types when the type is unknown", async () => {
@@ -197,7 +185,6 @@ describe("ratings routes", () => {
       const res = await app.inject({ method: "GET", url: "/ratings/decade/tt2" });
       expect(res.statusCode).toBe(400);
       expect(res.json().error).toBe("type must be one of: movie, series, season, episode");
-      await app.close();
     });
   });
 
@@ -220,7 +207,6 @@ describe("ratings routes", () => {
       );
       expect(prismaMock.rating.findMany.mock.calls[0][0]).not.toHaveProperty("take");
       expect(res.json().ratings).toHaveLength(3);
-      await app.close();
     });
 
     it("still caps the unfiltered list", async () => {
@@ -230,7 +216,6 @@ describe("ratings routes", () => {
       await app.inject({ method: "GET", url: "/ratings" });
 
       expect(prismaMock.rating.findMany).toHaveBeenCalledWith(expect.objectContaining({ take: 50 }));
-      await app.close();
     });
   });
 });

--- a/apps/api/src/routes/scrobble.test.ts
+++ b/apps/api/src/routes/scrobble.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import Fastify, { type FastifyInstance } from "fastify";
+import type { FastifyInstance } from "fastify";
+import { buildRouteApp } from "../lib/test-fixtures/route-app.js";
 
 const PROFILE_ID = "11111111-1111-4111-8111-111111111111";
 
@@ -35,14 +36,8 @@ const resetMocks = () => {
   traktClientMock.pushTraktScrobble.mockResolvedValue(null);
 };
 
-const buildApp = async (): Promise<FastifyInstance> => {
-  vi.resetModules();
-  const { default: scrobbleRoutes } = await import("./scrobble.js");
-  const app = Fastify();
-  await app.register(scrobbleRoutes);
-  await app.ready();
-  return app;
-};
+const buildApp = (): Promise<FastifyInstance> =>
+  buildRouteApp(() => import("./scrobble.js"));
 
 describe("scrobble routes", () => {
   beforeEach(() => {
@@ -58,14 +53,12 @@ describe("scrobble routes", () => {
         payload: { type: "bogus", imdbId: "tt1" },
       });
       expect(response.statusCode).toBe(400);
-      await app.close();
     });
 
     it("rejects a missing imdbId", async () => {
       const app = await buildApp();
       const response = await app.inject({ method: "POST", url: "/scrobble/start", payload: { type: "movie" } });
       expect(response.statusCode).toBe(400);
-      await app.close();
     });
 
     it("creates a new session when none exists and returns 201", async () => {
@@ -85,7 +78,6 @@ describe("scrobble routes", () => {
         expect.objectContaining({ imdbId: "tt1" }),
         expect.anything()
       );
-      await app.close();
     });
 
     it("reuses an existing playing/paused session instead of creating a new one", async () => {
@@ -104,7 +96,6 @@ describe("scrobble routes", () => {
       expect(txMock.scrobbleSession.update).toHaveBeenCalledWith(
         expect.objectContaining({ where: { id: "s1" }, data: { status: "playing", progress: 50 } })
       );
-      await app.close();
     });
 
     it("does not re-push to Trakt when resuming a session that was already playing", async () => {
@@ -115,7 +106,6 @@ describe("scrobble routes", () => {
       await app.inject({ method: "POST", url: "/scrobble/start", payload: { type: "movie", imdbId: "tt1", progress: 50 } });
 
       expect(traktClientMock.pushTraktScrobble).not.toHaveBeenCalled();
-      await app.close();
     });
 
     it("clamps progress to the 0-100 range", async () => {
@@ -128,7 +118,6 @@ describe("scrobble routes", () => {
       expect(txMock.scrobbleSession.create).toHaveBeenCalledWith(
         expect.objectContaining({ data: expect.objectContaining({ progress: 100 }) })
       );
-      await app.close();
     });
   });
 
@@ -138,7 +127,6 @@ describe("scrobble routes", () => {
       const app = await buildApp();
       const response = await app.inject({ method: "POST", url: "/scrobble/pause", payload: { imdbId: "tt1" } });
       expect(response.statusCode).toBe(404);
-      await app.close();
     });
 
     it("pauses an active session and pushes a pause event to Trakt", async () => {
@@ -158,7 +146,6 @@ describe("scrobble routes", () => {
         expect.objectContaining({ progress: 42 }),
         expect.anything()
       );
-      await app.close();
     });
   });
 
@@ -168,7 +155,6 @@ describe("scrobble routes", () => {
       const app = await buildApp();
       const response = await app.inject({ method: "POST", url: "/scrobble/stop", payload: { imdbId: "tt1" } });
       expect(response.statusCode).toBe(404);
-      await app.close();
     });
 
     it("records a watch event when progress meets the 80% completion threshold", async () => {
@@ -193,7 +179,6 @@ describe("scrobble routes", () => {
       expect(response.json().recorded).toBe(true);
       expect(watchEventMock.recordWatchEvent).toHaveBeenCalled();
       expect(traktClientMock.pushTraktScrobble).not.toHaveBeenCalled();
-      await app.close();
     });
 
     it("does not record a watch event when progress is just below the 80% threshold", async () => {
@@ -221,7 +206,6 @@ describe("scrobble routes", () => {
         expect.objectContaining({ progress: 79 }),
         expect.anything()
       );
-      await app.close();
     });
 
     it("falls back to the session's stored progress when no progress is supplied", async () => {
@@ -239,7 +223,6 @@ describe("scrobble routes", () => {
       const response = await app.inject({ method: "POST", url: "/scrobble/stop", payload: { imdbId: "tt1" } });
 
       expect(response.json().recorded).toBe(true);
-      await app.close();
     });
   });
 
@@ -249,7 +232,6 @@ describe("scrobble routes", () => {
       const app = await buildApp();
       const response = await app.inject({ method: "GET", url: "/scrobble/now-playing" });
       expect(response.json()).toEqual({ sessions: [] });
-      await app.close();
     });
 
     it("attaches metadata name/poster to active sessions", async () => {
@@ -264,7 +246,6 @@ describe("scrobble routes", () => {
       expect(response.json().sessions[0]).toEqual(
         expect.objectContaining({ name: "Movie A", poster: "poster.jpg" })
       );
-      await app.close();
     });
   });
 });

--- a/apps/api/src/routes/search.test.ts
+++ b/apps/api/src/routes/search.test.ts
@@ -1,0 +1,206 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import Fastify, { type FastifyInstance } from "fastify";
+
+const PROFILE_ID = "11111111-1111-4111-8111-111111111111";
+
+const prismaMock = { listItem: { findMany: vi.fn() } };
+
+const search = vi.fn();
+const searchMulti = vi.fn();
+const getTmdb = vi.fn();
+const upsertMetadata = vi.fn();
+const getRpdbApiKey = vi.fn();
+
+vi.mock("../lib/prisma.js", () => ({ prisma: prismaMock }));
+vi.mock("../lib/tmdb-client.js", () => ({ getTmdb: () => getTmdb() }));
+vi.mock("../lib/metadata.js", () => ({ upsertMetadata: (...a: unknown[]) => upsertMetadata(...a) }));
+vi.mock("../lib/rpdb.js", () => ({
+  getRpdbApiKey: () => getRpdbApiKey(),
+  withRpdbPoster: (imdbId: string, poster: string | null, key: string | null) =>
+    key ? `https://api.ratingposterdb.com/${key}/imdb/poster-default/${imdbId}.jpg` : poster,
+}));
+vi.mock("../lib/profile.js", () => ({
+  resolveProfile: async (request: { profileId?: string }) => {
+    request.profileId = PROFILE_ID;
+  },
+}));
+
+const buildApp = async (): Promise<FastifyInstance> => {
+  vi.resetModules();
+  const { default: searchRoutes } = await import("./search.js");
+  const app = Fastify();
+  await app.register(searchRoutes);
+  await app.ready();
+  return app;
+};
+
+const result = (over: Record<string, unknown> = {}) => ({
+  imdbId: "tt0111161",
+  type: "movie",
+  name: "The Shawshank Redemption",
+  year: 1994,
+  poster: "https://image.tmdb.org/poster.jpg",
+  description: "Two imprisoned men bond.",
+  genres: ["Drama"],
+  rating: 8.7,
+  ...over,
+});
+
+describe("search routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getTmdb.mockResolvedValue({ search, searchMulti });
+    search.mockResolvedValue([result()]);
+    searchMulti.mockResolvedValue([result()]);
+    upsertMetadata.mockResolvedValue(undefined);
+    getRpdbApiKey.mockResolvedValue(null);
+    prismaMock.listItem.findMany.mockResolvedValue([]);
+  });
+
+  it("searches a single type when one is given", async () => {
+    const app = await buildApp();
+
+    const res = await app.inject({ method: "GET", url: "/search?type=movie&q=shawshank" });
+
+    expect(res.statusCode).toBe(200);
+    expect(search).toHaveBeenCalledWith("movie", "shawshank");
+    expect(searchMulti).not.toHaveBeenCalled();
+    await app.close();
+  });
+
+  it("defaults to a multi-search across movies and series", async () => {
+    const app = await buildApp();
+
+    const res = await app.inject({ method: "GET", url: "/search?q=shawshank" });
+
+    expect(res.statusCode).toBe(200);
+    expect(searchMulti).toHaveBeenCalledWith("shawshank");
+    await app.close();
+  });
+
+  it("accepts `query` as an alias for `q`", async () => {
+    const app = await buildApp();
+
+    const res = await app.inject({ method: "GET", url: "/search?query=shawshank" });
+
+    expect(res.statusCode).toBe(200);
+    expect(searchMulti).toHaveBeenCalledWith("shawshank");
+    await app.close();
+  });
+
+  it("rejects a blank query", async () => {
+    const app = await buildApp();
+
+    const res = await app.inject({ method: "GET", url: "/search?q=%20%20" });
+
+    expect(res.statusCode).toBe(400);
+    expect(getTmdb).not.toHaveBeenCalled();
+    await app.close();
+  });
+
+  it("rejects a type that is neither movie, series nor all", async () => {
+    const app = await buildApp();
+
+    const res = await app.inject({ method: "GET", url: "/search?type=book&q=x" });
+
+    expect(res.statusCode).toBe(400);
+    await app.close();
+  });
+
+  it("returns 500 when TMDB is not configured", async () => {
+    getTmdb.mockRejectedValue(new Error("no api key"));
+    const app = await buildApp();
+
+    const res = await app.inject({ method: "GET", url: "/search?q=x" });
+
+    expect(res.statusCode).toBe(500);
+    expect(res.json().error).toMatch(/not configured/i);
+    await app.close();
+  });
+
+  it("returns 502 when the TMDB search itself fails", async () => {
+    // Distinct from the 500 above: the integration is configured, the upstream
+    // is the thing that broke.
+    searchMulti.mockRejectedValue(new Error("upstream 503"));
+    const app = await buildApp();
+
+    const res = await app.inject({ method: "GET", url: "/search?q=x" });
+
+    expect(res.statusCode).toBe(502);
+    await app.close();
+  });
+
+  it("caps the result set at 20", async () => {
+    searchMulti.mockResolvedValue(
+      Array.from({ length: 50 }, (_, i) => result({ imdbId: `tt${i}` }))
+    );
+    const app = await buildApp();
+
+    const res = await app.inject({ method: "GET", url: "/search?q=x" });
+
+    expect(res.json()).toHaveLength(20);
+    await app.close();
+  });
+
+  it("flags results already on the watchlist or in the collection", async () => {
+    prismaMock.listItem.findMany.mockResolvedValue([
+      { imdbId: "tt0111161", type: "movie", list: { id: "l1", name: "Watchlist", kind: "watchlist" } },
+      { imdbId: "tt0111161", type: "movie", list: { id: "l2", name: "Collection", kind: "collection" } },
+    ]);
+    const app = await buildApp();
+
+    const res = await app.inject({ method: "GET", url: "/search?q=x" });
+
+    expect(res.json()[0]).toMatchObject({ inWatchlist: true, inCollection: true, lists: ["l1", "l2"] });
+    await app.close();
+  });
+
+  it("does not flag a movie because the series with that imdbId is listed", async () => {
+    // The list lookup keys on imdbId *and* type.
+    prismaMock.listItem.findMany.mockResolvedValue([
+      { imdbId: "tt0111161", type: "series", list: { id: "l1", name: "Watchlist", kind: "watchlist" } },
+    ]);
+    const app = await buildApp();
+
+    const res = await app.inject({ method: "GET", url: "/search?q=x" });
+
+    expect(res.json()[0]).toMatchObject({ inWatchlist: false, lists: [] });
+    await app.close();
+  });
+
+  it("only considers lists belonging to the calling profile", async () => {
+    const app = await buildApp();
+
+    await app.inject({ method: "GET", url: "/search?q=x" });
+
+    expect(prismaMock.listItem.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ list: { profileId: PROFILE_ID } }),
+      })
+    );
+    await app.close();
+  });
+
+  it("swaps in an RPDB poster when a key is configured", async () => {
+    getRpdbApiKey.mockResolvedValue("rpdb-key");
+    const app = await buildApp();
+
+    const res = await app.inject({ method: "GET", url: "/search?q=x" });
+
+    expect(res.json()[0].poster).toContain("ratingposterdb.com");
+    await app.close();
+  });
+
+  it("still returns results when caching a result's metadata fails", async () => {
+    // upsertMetadata runs under allSettled — a write failure is not the
+    // user's search failing.
+    upsertMetadata.mockRejectedValue(new Error("db write failed"));
+    const app = await buildApp();
+
+    const res = await app.inject({ method: "GET", url: "/search?q=x" });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toHaveLength(1);
+    await app.close();
+  });
+});

--- a/apps/api/src/routes/search.test.ts
+++ b/apps/api/src/routes/search.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import Fastify, { type FastifyInstance } from "fastify";
+import type { FastifyInstance } from "fastify";
+import { buildRouteApp } from "../lib/test-fixtures/route-app.js";
 
 const PROFILE_ID = "11111111-1111-4111-8111-111111111111";
 
@@ -25,14 +26,8 @@ vi.mock("../lib/profile.js", () => ({
   },
 }));
 
-const buildApp = async (): Promise<FastifyInstance> => {
-  vi.resetModules();
-  const { default: searchRoutes } = await import("./search.js");
-  const app = Fastify();
-  await app.register(searchRoutes);
-  await app.ready();
-  return app;
-};
+const buildApp = (): Promise<FastifyInstance> =>
+  buildRouteApp(() => import("./search.js"));
 
 const result = (over: Record<string, unknown> = {}) => ({
   imdbId: "tt0111161",
@@ -65,7 +60,6 @@ describe("search routes", () => {
     expect(res.statusCode).toBe(200);
     expect(search).toHaveBeenCalledWith("movie", "shawshank");
     expect(searchMulti).not.toHaveBeenCalled();
-    await app.close();
   });
 
   it("defaults to a multi-search across movies and series", async () => {
@@ -75,7 +69,6 @@ describe("search routes", () => {
 
     expect(res.statusCode).toBe(200);
     expect(searchMulti).toHaveBeenCalledWith("shawshank");
-    await app.close();
   });
 
   it("accepts `query` as an alias for `q`", async () => {
@@ -85,7 +78,6 @@ describe("search routes", () => {
 
     expect(res.statusCode).toBe(200);
     expect(searchMulti).toHaveBeenCalledWith("shawshank");
-    await app.close();
   });
 
   it("rejects a blank query", async () => {
@@ -95,7 +87,6 @@ describe("search routes", () => {
 
     expect(res.statusCode).toBe(400);
     expect(getTmdb).not.toHaveBeenCalled();
-    await app.close();
   });
 
   it("rejects a type that is neither movie, series nor all", async () => {
@@ -104,7 +95,6 @@ describe("search routes", () => {
     const res = await app.inject({ method: "GET", url: "/search?type=book&q=x" });
 
     expect(res.statusCode).toBe(400);
-    await app.close();
   });
 
   it("returns 500 when TMDB is not configured", async () => {
@@ -115,7 +105,6 @@ describe("search routes", () => {
 
     expect(res.statusCode).toBe(500);
     expect(res.json().error).toMatch(/not configured/i);
-    await app.close();
   });
 
   it("returns 502 when the TMDB search itself fails", async () => {
@@ -127,7 +116,6 @@ describe("search routes", () => {
     const res = await app.inject({ method: "GET", url: "/search?q=x" });
 
     expect(res.statusCode).toBe(502);
-    await app.close();
   });
 
   it("caps the result set at 20", async () => {
@@ -139,7 +127,6 @@ describe("search routes", () => {
     const res = await app.inject({ method: "GET", url: "/search?q=x" });
 
     expect(res.json()).toHaveLength(20);
-    await app.close();
   });
 
   it("flags results already on the watchlist or in the collection", async () => {
@@ -152,7 +139,6 @@ describe("search routes", () => {
     const res = await app.inject({ method: "GET", url: "/search?q=x" });
 
     expect(res.json()[0]).toMatchObject({ inWatchlist: true, inCollection: true, lists: ["l1", "l2"] });
-    await app.close();
   });
 
   it("does not flag a movie because the series with that imdbId is listed", async () => {
@@ -165,7 +151,6 @@ describe("search routes", () => {
     const res = await app.inject({ method: "GET", url: "/search?q=x" });
 
     expect(res.json()[0]).toMatchObject({ inWatchlist: false, lists: [] });
-    await app.close();
   });
 
   it("only considers lists belonging to the calling profile", async () => {
@@ -178,7 +163,6 @@ describe("search routes", () => {
         where: expect.objectContaining({ list: { profileId: PROFILE_ID } }),
       })
     );
-    await app.close();
   });
 
   it("swaps in an RPDB poster when a key is configured", async () => {
@@ -188,7 +172,6 @@ describe("search routes", () => {
     const res = await app.inject({ method: "GET", url: "/search?q=x" });
 
     expect(res.json()[0].poster).toContain("ratingposterdb.com");
-    await app.close();
   });
 
   it("still returns results when caching a result's metadata fails", async () => {
@@ -201,6 +184,5 @@ describe("search routes", () => {
 
     expect(res.statusCode).toBe(200);
     expect(res.json()).toHaveLength(1);
-    await app.close();
   });
 });

--- a/apps/api/src/routes/series.test.ts
+++ b/apps/api/src/routes/series.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import Fastify, { type FastifyInstance } from "fastify";
+import type { FastifyInstance } from "fastify";
+import { buildRouteApp } from "../lib/test-fixtures/route-app.js";
 
 const PROFILE_ID = "11111111-1111-4111-8111-111111111111";
 
@@ -43,14 +44,8 @@ const resetMocks = () => {
   seasonsMock.getSeasonsForImdbId.mockResolvedValue([]);
 };
 
-const buildApp = async (): Promise<FastifyInstance> => {
-  vi.resetModules();
-  const { default: seriesRoutes } = await import("./series.js");
-  const app = Fastify();
-  await app.register(seriesRoutes);
-  await app.ready();
-  return app;
-};
+const buildApp = (): Promise<FastifyInstance> =>
+  buildRouteApp(() => import("./series.js"));
 
 describe("series routes — completion drops from Continue Watching", () => {
   beforeEach(() => {
@@ -96,7 +91,6 @@ describe("series routes — completion drops from Continue Watching", () => {
 
       expect(response.statusCode).toBe(200);
       expect(response.json().progress).toEqual([]);
-      await app.close();
     });
 
     it("keeps a show with unwatched episodes remaining", async () => {
@@ -138,7 +132,6 @@ describe("series routes — completion drops from Continue Watching", () => {
       expect(progress).toHaveLength(1);
       expect(progress[0].nextSeason).toBe(8);
       expect(progress[0].nextEpisode).toBe(11);
-      await app.close();
     });
   });
 
@@ -159,7 +152,6 @@ describe("series routes — completion drops from Continue Watching", () => {
 
       expect(response.statusCode).toBe(409);
       expect(prismaMock.watchEvent.create).not.toHaveBeenCalled();
-      await app.close();
     });
   });
 });
@@ -217,7 +209,6 @@ describe("GET /series/progress — season-level counts", () => {
     // Series-wide numbers are untouched — the carousel card still shows them.
     expect(progress.watchedEpisodes).toBe(5);
     expect(progress.totalEpisodes).toBe(144);
-    await app.close();
   });
 
   it("looks the seasons up once per series and hands them to the next-episode math", async () => {
@@ -232,7 +223,6 @@ describe("GET /series/progress — season-level counts", () => {
 
     expect(seasonsMock.getSeasonsForImdbId).toHaveBeenCalledTimes(1);
     expect(nextEpisodeMock.computeNextEpisode).toHaveBeenCalledWith("tt-buffy", 95, 2, 3, seasons);
-    await app.close();
   });
 
   it("ignores a row carrying no episode number, which is not one watched episode", async () => {
@@ -248,7 +238,6 @@ describe("GET /series/progress — season-level counts", () => {
     const response = await app.inject({ method: "GET", url: "/series/progress" });
 
     expect(response.json().progress[0].seasonWatchedEpisodes).toBe(1);
-    await app.close();
   });
 
   it("leaves the season total null when TMDB has no season data", async () => {
@@ -260,7 +249,6 @@ describe("GET /series/progress — season-level counts", () => {
 
     const [progress] = response.json().progress;
     expect(progress.seasonTotalEpisodes).toBeNull();
-    await app.close();
   });
 
   it("counts an untouched season as zero rather than borrowing another season's count", async () => {
@@ -278,6 +266,5 @@ describe("GET /series/progress — season-level counts", () => {
 
     const [progress] = response.json().progress;
     expect(progress.seasonWatchedEpisodes).toBe(0);
-    await app.close();
   });
 });

--- a/apps/api/src/routes/settings.test.ts
+++ b/apps/api/src/routes/settings.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import Fastify, { type FastifyInstance } from "fastify";
+import type { FastifyInstance } from "fastify";
+import { buildRouteApp } from "../lib/test-fixtures/route-app.js";
 
 const prismaMock = {
   kV: { upsert: vi.fn(), deleteMany: vi.fn() },
@@ -39,14 +40,8 @@ vi.mock("../lib/rpdb.js", () => ({
 vi.mock("../lib/cache.js", () => ({ trendingCache: { clear: () => trendingCacheClear() } }));
 vi.mock("../lib/job-status.js", () => ({ getFailedJobStatuses: () => getFailedJobStatuses() }));
 
-const buildApp = async (): Promise<FastifyInstance> => {
-  vi.resetModules();
-  const { default: settingsRoutes } = await import("./settings.js");
-  const app = Fastify();
-  await app.register(settingsRoutes);
-  await app.ready();
-  return app;
-};
+const buildApp = (): Promise<FastifyInstance> =>
+  buildRouteApp(() => import("./settings.js"));
 
 describe("settings routes", () => {
   beforeEach(() => {
@@ -78,7 +73,6 @@ describe("settings routes", () => {
       expect(body.availableProviders).toEqual(
         expect.arrayContaining([expect.objectContaining({ key: "netflix", name: "Netflix" })])
       );
-      await app.close();
     });
   });
 
@@ -99,7 +93,6 @@ describe("settings routes", () => {
           update: expect.objectContaining({ value: "en-US" }),
         })
       );
-      await app.close();
     });
 
     it("accepts a bare language without a region subtag", async () => {
@@ -115,7 +108,6 @@ describe("settings routes", () => {
       expect(prismaMock.kV.upsert).toHaveBeenCalledWith(
         expect.objectContaining({ update: expect.objectContaining({ value: "fr" }) })
       );
-      await app.close();
     });
 
     it("rejects a malformed language tag", async () => {
@@ -129,7 +121,6 @@ describe("settings routes", () => {
 
       expect(res.statusCode).toBe(400);
       expect(prismaMock.kV.upsert).not.toHaveBeenCalled();
-      await app.close();
     });
 
     it("uppercases a region code", async () => {
@@ -148,7 +139,6 @@ describe("settings routes", () => {
           update: expect.objectContaining({ value: "GB" }),
         })
       );
-      await app.close();
     });
 
     it("rejects a region that is not two letters", async () => {
@@ -161,7 +151,6 @@ describe("settings routes", () => {
       });
 
       expect(res.statusCode).toBe(400);
-      await app.close();
     });
 
     it("stores spoiler protection when it is switched off", async () => {
@@ -182,7 +171,6 @@ describe("settings routes", () => {
           update: expect.objectContaining({ value: "false" }),
         })
       );
-      await app.close();
     });
 
     it("clears the trending cache so cached rows pick up the new region", async () => {
@@ -191,7 +179,6 @@ describe("settings routes", () => {
       await app.inject({ method: "POST", url: "/settings/preferences", payload: { region: "GB" } });
 
       expect(trendingCacheClear).toHaveBeenCalled();
-      await app.close();
     });
   });
 
@@ -207,7 +194,6 @@ describe("settings routes", () => {
       expect(prismaMock.kV.upsert).toHaveBeenCalledWith(
         expect.objectContaining({ update: expect.objectContaining({ value: "abc123" }) })
       );
-      await app.close();
     });
 
     it("refuses to overwrite a working key with one TMDB rejects", async () => {
@@ -219,7 +205,6 @@ describe("settings routes", () => {
       expect(res.statusCode).toBe(400);
       expect(res.json().error).toMatch(/rejected/i);
       expect(prismaMock.kV.upsert).not.toHaveBeenCalled();
-      await app.close();
     });
 
     it("reports a validation failure when TMDB is unreachable", async () => {
@@ -230,7 +215,6 @@ describe("settings routes", () => {
 
       expect(res.statusCode).toBe(400);
       expect(res.json().error).toMatch(/could not reach/i);
-      await app.close();
     });
 
     it("rejects an empty key", async () => {
@@ -239,7 +223,6 @@ describe("settings routes", () => {
       const res = await app.inject({ method: "POST", url: "/tmdb/key", payload: { apiKey: "   " } });
 
       expect(res.statusCode).toBe(400);
-      await app.close();
     });
 
     it("reports the env fallback that remains after the saved key is deleted", async () => {
@@ -250,7 +233,6 @@ describe("settings routes", () => {
 
       expect(res.statusCode).toBe(200);
       expect(res.json()).toEqual({ configured: true, source: "env" });
-      await app.close();
     });
   });
 
@@ -263,7 +245,6 @@ describe("settings routes", () => {
       expect(res.statusCode).toBe(200);
       expect(res.json()).toEqual({ configured: false });
       expect(prismaMock.kV.deleteMany).toHaveBeenCalledWith({ where: { key: "omdb:apiKey" } });
-      await app.close();
     });
 
     it("surfaces OMDB's own error message for a bad key", async () => {
@@ -277,7 +258,6 @@ describe("settings routes", () => {
 
       expect(res.statusCode).toBe(400);
       expect(res.json().error).toBe("Invalid API key!");
-      await app.close();
     });
 
     it("saves a key OMDB accepts", async () => {
@@ -288,7 +268,6 @@ describe("settings routes", () => {
 
       expect(res.statusCode).toBe(200);
       expect(res.json()).toEqual({ configured: true });
-      await app.close();
     });
   });
 
@@ -302,7 +281,6 @@ describe("settings routes", () => {
 
       expect(res.statusCode).toBe(200);
       expect(fetchMock).not.toHaveBeenCalled();
-      await app.close();
     });
 
     it("404s the poster route when no key is configured", async () => {
@@ -311,7 +289,6 @@ describe("settings routes", () => {
       const res = await app.inject({ method: "GET", url: "/rpdb/poster/tt1" });
 
       expect(res.statusCode).toBe(404);
-      await app.close();
     });
 
     it("builds a poster URL once a key exists", async () => {
@@ -322,7 +299,6 @@ describe("settings routes", () => {
 
       expect(res.statusCode).toBe(200);
       expect(res.json().poster).toContain("tt1");
-      await app.close();
     });
   });
 
@@ -337,7 +313,6 @@ describe("settings routes", () => {
 
       expect(res.statusCode).toBe(200);
       expect(res.json().failures).toHaveLength(1);
-      await app.close();
     });
 
     it("reports an empty list when every job is healthy", async () => {
@@ -346,7 +321,6 @@ describe("settings routes", () => {
       const res = await app.inject({ method: "GET", url: "/settings/job-status" });
 
       expect(res.json()).toEqual({ failures: [] });
-      await app.close();
     });
   });
 });

--- a/apps/api/src/routes/settings.test.ts
+++ b/apps/api/src/routes/settings.test.ts
@@ -1,0 +1,352 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import Fastify, { type FastifyInstance } from "fastify";
+
+const prismaMock = {
+  kV: { upsert: vi.fn(), deleteMany: vi.fn() },
+};
+
+const getLanguageSetting = vi.fn();
+const getRegionSetting = vi.fn();
+const getSpoilerProtection = vi.fn();
+const getOmdbApiKey = vi.fn();
+const getTmdbApiKey = vi.fn();
+const getRpdbApiKey = vi.fn();
+const getFailedJobStatuses = vi.fn();
+const trendingCacheClear = vi.fn();
+
+vi.mock("../lib/prisma.js", () => ({ prisma: prismaMock }));
+vi.mock("../lib/settings.js", () => ({
+  LANGUAGE_KV_KEY: "settings:language",
+  REGION_KV_KEY: "settings:region",
+  SPOILER_PROTECTION_KV_KEY: "settings:spoilerProtection",
+  getLanguageSetting: () => getLanguageSetting(),
+  getRegionSetting: () => getRegionSetting(),
+  getSpoilerProtection: () => getSpoilerProtection(),
+}));
+vi.mock("../lib/omdb.js", () => ({
+  OMDB_API_KEY_KV: "omdb:apiKey",
+  getOmdbApiKey: () => getOmdbApiKey(),
+}));
+vi.mock("../lib/tmdb-client.js", () => ({
+  TMDB_API_KEY_KV: "tmdb:apiKey",
+  getTmdbApiKey: () => getTmdbApiKey(),
+}));
+vi.mock("../lib/rpdb.js", () => ({
+  RPDB_API_KEY_KV: "rpdb:apiKey",
+  getRpdbApiKey: () => getRpdbApiKey(),
+  buildRpdbPosterUrl: (key: string, imdbId: string) => `https://api.ratingposterdb.com/${key}/imdb/poster-default/${imdbId}.jpg`,
+}));
+vi.mock("../lib/cache.js", () => ({ trendingCache: { clear: () => trendingCacheClear() } }));
+vi.mock("../lib/job-status.js", () => ({ getFailedJobStatuses: () => getFailedJobStatuses() }));
+
+const buildApp = async (): Promise<FastifyInstance> => {
+  vi.resetModules();
+  const { default: settingsRoutes } = await import("./settings.js");
+  const app = Fastify();
+  await app.register(settingsRoutes);
+  await app.ready();
+  return app;
+};
+
+describe("settings routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getLanguageSetting.mockResolvedValue("en-US");
+    getRegionSetting.mockResolvedValue("US");
+    getSpoilerProtection.mockResolvedValue(false);
+    getTmdbApiKey.mockResolvedValue({ apiKey: null, source: "none" });
+    getOmdbApiKey.mockResolvedValue(null);
+    getRpdbApiKey.mockResolvedValue(null);
+    getFailedJobStatuses.mockResolvedValue([]);
+    prismaMock.kV.upsert.mockResolvedValue({});
+    prismaMock.kV.deleteMany.mockResolvedValue({ count: 1 });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe("GET /settings/preferences", () => {
+    it("returns the stored preferences alongside the provider catalogue", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/settings/preferences" });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body).toMatchObject({ language: "en-US", region: "US", spoilerProtection: false });
+      expect(body.availableProviders).toEqual(
+        expect.arrayContaining([expect.objectContaining({ key: "netflix", name: "Netflix" })])
+      );
+      await app.close();
+    });
+  });
+
+  describe("POST /settings/preferences", () => {
+    it("normalizes the casing of a language tag before storing it", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({
+        method: "POST",
+        url: "/settings/preferences",
+        payload: { language: "EN-us" },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(prismaMock.kV.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { key: "settings:language" },
+          update: expect.objectContaining({ value: "en-US" }),
+        })
+      );
+      await app.close();
+    });
+
+    it("accepts a bare language without a region subtag", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({
+        method: "POST",
+        url: "/settings/preferences",
+        payload: { language: "fr" },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(prismaMock.kV.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({ update: expect.objectContaining({ value: "fr" }) })
+      );
+      await app.close();
+    });
+
+    it("rejects a malformed language tag", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({
+        method: "POST",
+        url: "/settings/preferences",
+        payload: { language: "english" },
+      });
+
+      expect(res.statusCode).toBe(400);
+      expect(prismaMock.kV.upsert).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it("uppercases a region code", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({
+        method: "POST",
+        url: "/settings/preferences",
+        payload: { region: "gb" },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(prismaMock.kV.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { key: "settings:region" },
+          update: expect.objectContaining({ value: "GB" }),
+        })
+      );
+      await app.close();
+    });
+
+    it("rejects a region that is not two letters", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({
+        method: "POST",
+        url: "/settings/preferences",
+        payload: { region: "USA" },
+      });
+
+      expect(res.statusCode).toBe(400);
+      await app.close();
+    });
+
+    it("stores spoiler protection when it is switched off", async () => {
+      // `false` is a real value here, not an absent one — a truthiness check
+      // would silently drop it.
+      const app = await buildApp();
+
+      const res = await app.inject({
+        method: "POST",
+        url: "/settings/preferences",
+        payload: { spoilerProtection: false },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(prismaMock.kV.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { key: "settings:spoilerProtection" },
+          update: expect.objectContaining({ value: "false" }),
+        })
+      );
+      await app.close();
+    });
+
+    it("clears the trending cache so cached rows pick up the new region", async () => {
+      const app = await buildApp();
+
+      await app.inject({ method: "POST", url: "/settings/preferences", payload: { region: "GB" } });
+
+      expect(trendingCacheClear).toHaveBeenCalled();
+      await app.close();
+    });
+  });
+
+  describe("TMDB key", () => {
+    it("saves a key that TMDB accepts", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, status: 200 }));
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "POST", url: "/tmdb/key", payload: { apiKey: " abc123 " } });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual({ configured: true, source: "db" });
+      expect(prismaMock.kV.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({ update: expect.objectContaining({ value: "abc123" }) })
+      );
+      await app.close();
+    });
+
+    it("refuses to overwrite a working key with one TMDB rejects", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 401 }));
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "POST", url: "/tmdb/key", payload: { apiKey: "bad" } });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error).toMatch(/rejected/i);
+      expect(prismaMock.kV.upsert).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it("reports a validation failure when TMDB is unreachable", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network down")));
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "POST", url: "/tmdb/key", payload: { apiKey: "abc" } });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error).toMatch(/could not reach/i);
+      await app.close();
+    });
+
+    it("rejects an empty key", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "POST", url: "/tmdb/key", payload: { apiKey: "   " } });
+
+      expect(res.statusCode).toBe(400);
+      await app.close();
+    });
+
+    it("reports the env fallback that remains after the saved key is deleted", async () => {
+      getTmdbApiKey.mockResolvedValue({ apiKey: "from-env", source: "env" });
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "DELETE", url: "/tmdb/key" });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual({ configured: true, source: "env" });
+      await app.close();
+    });
+  });
+
+  describe("OMDB key", () => {
+    it("deletes the stored key when an empty value is posted", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "POST", url: "/omdb/key", payload: { apiKey: "" } });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual({ configured: false });
+      expect(prismaMock.kV.deleteMany).toHaveBeenCalledWith({ where: { key: "omdb:apiKey" } });
+      await app.close();
+    });
+
+    it("surfaces OMDB's own error message for a bad key", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({ json: async () => ({ Response: "False", Error: "Invalid API key!" }) })
+      );
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "POST", url: "/omdb/key", payload: { apiKey: "bad" } });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error).toBe("Invalid API key!");
+      await app.close();
+    });
+
+    it("saves a key OMDB accepts", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ json: async () => ({ Response: "True" }) }));
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "POST", url: "/omdb/key", payload: { apiKey: "good" } });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual({ configured: true });
+      await app.close();
+    });
+  });
+
+  describe("RPDB", () => {
+    it("stores a key without calling out to validate it", async () => {
+      const fetchMock = vi.fn();
+      vi.stubGlobal("fetch", fetchMock);
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "POST", url: "/rpdb/key", payload: { apiKey: "rpdb-key" } });
+
+      expect(res.statusCode).toBe(200);
+      expect(fetchMock).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it("404s the poster route when no key is configured", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/rpdb/poster/tt1" });
+
+      expect(res.statusCode).toBe(404);
+      await app.close();
+    });
+
+    it("builds a poster URL once a key exists", async () => {
+      getRpdbApiKey.mockResolvedValue("rpdb-key");
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/rpdb/poster/tt1" });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().poster).toContain("tt1");
+      await app.close();
+    });
+  });
+
+  describe("GET /settings/job-status", () => {
+    it("reports failing background jobs", async () => {
+      getFailedJobStatuses.mockResolvedValue([
+        { job: "steam-sync", message: "Steam API returned 503", failedAt: "2026-01-01T00:00:00.000Z" },
+      ]);
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/settings/job-status" });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().failures).toHaveLength(1);
+      await app.close();
+    });
+
+    it("reports an empty list when every job is healthy", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/settings/job-status" });
+
+      expect(res.json()).toEqual({ failures: [] });
+      await app.close();
+    });
+  });
+});

--- a/apps/api/src/routes/streaming.test.ts
+++ b/apps/api/src/routes/streaming.test.ts
@@ -1,0 +1,218 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import Fastify, { type FastifyInstance } from "fastify";
+
+const discoverByProvider = vi.fn();
+const discoverAnime = vi.fn();
+const getTmdb = vi.fn();
+const getRegionSetting = vi.fn();
+const upsertMetadata = vi.fn();
+const getRpdbApiKey = vi.fn();
+const trendingCacheGet = vi.fn();
+const trendingCacheSet = vi.fn();
+
+vi.mock("../lib/tmdb-client.js", () => ({ getTmdb: () => getTmdb() }));
+vi.mock("../lib/settings.js", () => ({ getRegionSetting: () => getRegionSetting() }));
+vi.mock("../lib/metadata.js", () => ({ upsertMetadata: (...a: unknown[]) => upsertMetadata(...a) }));
+vi.mock("../lib/rpdb.js", () => ({
+  getRpdbApiKey: () => getRpdbApiKey(),
+  applyRpdbToMetaList: (metas: unknown[], key: string | null) =>
+    key ? metas.map((m) => ({ ...(m as object), poster: "rpdb" })) : metas,
+}));
+vi.mock("../lib/cache.js", () => ({
+  trendingCacheGet: (...a: unknown[]) => trendingCacheGet(...a),
+  trendingCacheSet: (...a: unknown[]) => trendingCacheSet(...a),
+}));
+
+const buildApp = async (): Promise<FastifyInstance> => {
+  vi.resetModules();
+  const { default: streamingRoutes } = await import("./streaming.js");
+  const app = Fastify();
+  await app.register(streamingRoutes);
+  await app.ready();
+  return app;
+};
+
+const payload = (over: Record<string, unknown> = {}) => ({
+  imdbId: "tt1",
+  name: "A Title",
+  poster: "https://image.tmdb.org/p.jpg",
+  year: 2020,
+  description: "desc",
+  genres: ["Drama"],
+  rating: 7,
+  ...over,
+});
+
+describe("streaming routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getTmdb.mockResolvedValue({ discoverByProvider, discoverAnime });
+    discoverByProvider.mockResolvedValue([payload()]);
+    discoverAnime.mockResolvedValue([payload()]);
+    getRegionSetting.mockResolvedValue("US");
+    upsertMetadata.mockResolvedValue(undefined);
+    getRpdbApiKey.mockResolvedValue(null);
+    trendingCacheGet.mockReturnValue(undefined);
+  });
+
+  describe("GET /streaming", () => {
+    it("discovers titles for a known provider", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/streaming?provider=netflix&type=movie" });
+
+      expect(res.statusCode).toBe(200);
+      expect(discoverByProvider).toHaveBeenCalledWith("movie", 8, "US");
+      expect(res.json()).toMatchObject({ provider: "Netflix" });
+      await app.close();
+    });
+
+    it("matches a provider key case-insensitively", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/streaming?provider=NETFLIX" });
+
+      expect(res.statusCode).toBe(200);
+      await app.close();
+    });
+
+    it("lists the available providers when none is given", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/streaming?type=movie" });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.json().available).toEqual(
+        expect.arrayContaining([expect.objectContaining({ key: "netflix" })])
+      );
+      await app.close();
+    });
+
+    it("rejects an unknown provider", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/streaming?provider=nowtv" });
+
+      expect(res.statusCode).toBe(400);
+      expect(discoverByProvider).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it("rejects a type that is not movie or series", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/streaming?provider=netflix&type=episode" });
+
+      expect(res.statusCode).toBe(400);
+      await app.close();
+    });
+
+    it("prefers an explicit region over the stored setting", async () => {
+      const app = await buildApp();
+
+      await app.inject({ method: "GET", url: "/streaming?provider=netflix&region=GB" });
+
+      expect(discoverByProvider).toHaveBeenCalledWith("movie", 8, "GB");
+      expect(getRegionSetting).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it("keys the cache by provider, type and region", async () => {
+      const app = await buildApp();
+
+      await app.inject({ method: "GET", url: "/streaming?provider=netflix&type=series&region=GB" });
+
+      expect(trendingCacheSet).toHaveBeenCalledWith("streaming:netflix:series:GB", expect.anything());
+      await app.close();
+    });
+
+    it("serves a cache hit without calling TMDB", async () => {
+      trendingCacheGet.mockReturnValue({ data: [{ id: "tt9", type: "movie", name: "Cached" }] });
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/streaming?provider=netflix" });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().metas[0].name).toBe("Cached");
+      expect(getTmdb).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it("applies RPDB posters to a cached response too", async () => {
+      trendingCacheGet.mockReturnValue({ data: [{ id: "tt9", type: "movie", name: "Cached" }] });
+      getRpdbApiKey.mockResolvedValue("rpdb-key");
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/streaming?provider=netflix" });
+
+      expect(res.json().metas[0].poster).toBe("rpdb");
+      await app.close();
+    });
+
+    it("returns 500 when the discover call fails", async () => {
+      discoverByProvider.mockRejectedValue(new Error("upstream"));
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/streaming?provider=netflix" });
+
+      expect(res.statusCode).toBe(500);
+      expect(trendingCacheSet).not.toHaveBeenCalled();
+      await app.close();
+    });
+  });
+
+  describe("GET /streaming/providers", () => {
+    it("returns the provider catalogue", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/streaming/providers" });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().providers).toEqual(
+        expect.arrayContaining([expect.objectContaining({ key: "crunchyroll", name: "Crunchyroll" })])
+      );
+      await app.close();
+    });
+  });
+
+  describe("GET /anime", () => {
+    it("defaults to series", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/anime" });
+
+      expect(res.statusCode).toBe(200);
+      expect(discoverAnime).toHaveBeenCalledWith("series");
+      expect(trendingCacheSet).toHaveBeenCalledWith("anime:series", expect.anything());
+      await app.close();
+    });
+
+    it("supports anime films", async () => {
+      const app = await buildApp();
+
+      await app.inject({ method: "GET", url: "/anime?type=movie" });
+
+      expect(discoverAnime).toHaveBeenCalledWith("movie");
+      await app.close();
+    });
+
+    it("rejects an unsupported type", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/anime?type=episode" });
+
+      expect(res.statusCode).toBe(400);
+      await app.close();
+    });
+
+    it("returns 500 when the anime discover call fails", async () => {
+      discoverAnime.mockRejectedValue(new Error("upstream"));
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/anime" });
+
+      expect(res.statusCode).toBe(500);
+      await app.close();
+    });
+  });
+});

--- a/apps/api/src/routes/streaming.test.ts
+++ b/apps/api/src/routes/streaming.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import Fastify, { type FastifyInstance } from "fastify";
+import type { FastifyInstance } from "fastify";
+import { buildRouteApp } from "../lib/test-fixtures/route-app.js";
 
 const discoverByProvider = vi.fn();
 const discoverAnime = vi.fn();
@@ -23,14 +24,8 @@ vi.mock("../lib/cache.js", () => ({
   trendingCacheSet: (...a: unknown[]) => trendingCacheSet(...a),
 }));
 
-const buildApp = async (): Promise<FastifyInstance> => {
-  vi.resetModules();
-  const { default: streamingRoutes } = await import("./streaming.js");
-  const app = Fastify();
-  await app.register(streamingRoutes);
-  await app.ready();
-  return app;
-};
+const buildApp = (): Promise<FastifyInstance> =>
+  buildRouteApp(() => import("./streaming.js"));
 
 const payload = (over: Record<string, unknown> = {}) => ({
   imdbId: "tt1",
@@ -64,7 +59,6 @@ describe("streaming routes", () => {
       expect(res.statusCode).toBe(200);
       expect(discoverByProvider).toHaveBeenCalledWith("movie", 8, "US");
       expect(res.json()).toMatchObject({ provider: "Netflix" });
-      await app.close();
     });
 
     it("matches a provider key case-insensitively", async () => {
@@ -73,7 +67,6 @@ describe("streaming routes", () => {
       const res = await app.inject({ method: "GET", url: "/streaming?provider=NETFLIX" });
 
       expect(res.statusCode).toBe(200);
-      await app.close();
     });
 
     it("lists the available providers when none is given", async () => {
@@ -85,7 +78,6 @@ describe("streaming routes", () => {
       expect(res.json().available).toEqual(
         expect.arrayContaining([expect.objectContaining({ key: "netflix" })])
       );
-      await app.close();
     });
 
     it("rejects an unknown provider", async () => {
@@ -95,7 +87,6 @@ describe("streaming routes", () => {
 
       expect(res.statusCode).toBe(400);
       expect(discoverByProvider).not.toHaveBeenCalled();
-      await app.close();
     });
 
     it("rejects a type that is not movie or series", async () => {
@@ -104,7 +95,6 @@ describe("streaming routes", () => {
       const res = await app.inject({ method: "GET", url: "/streaming?provider=netflix&type=episode" });
 
       expect(res.statusCode).toBe(400);
-      await app.close();
     });
 
     it("prefers an explicit region over the stored setting", async () => {
@@ -114,7 +104,6 @@ describe("streaming routes", () => {
 
       expect(discoverByProvider).toHaveBeenCalledWith("movie", 8, "GB");
       expect(getRegionSetting).not.toHaveBeenCalled();
-      await app.close();
     });
 
     it("keys the cache by provider, type and region", async () => {
@@ -123,7 +112,6 @@ describe("streaming routes", () => {
       await app.inject({ method: "GET", url: "/streaming?provider=netflix&type=series&region=GB" });
 
       expect(trendingCacheSet).toHaveBeenCalledWith("streaming:netflix:series:GB", expect.anything());
-      await app.close();
     });
 
     it("serves a cache hit without calling TMDB", async () => {
@@ -135,7 +123,6 @@ describe("streaming routes", () => {
       expect(res.statusCode).toBe(200);
       expect(res.json().metas[0].name).toBe("Cached");
       expect(getTmdb).not.toHaveBeenCalled();
-      await app.close();
     });
 
     it("applies RPDB posters to a cached response too", async () => {
@@ -146,7 +133,6 @@ describe("streaming routes", () => {
       const res = await app.inject({ method: "GET", url: "/streaming?provider=netflix" });
 
       expect(res.json().metas[0].poster).toBe("rpdb");
-      await app.close();
     });
 
     it("returns 500 when the discover call fails", async () => {
@@ -157,7 +143,6 @@ describe("streaming routes", () => {
 
       expect(res.statusCode).toBe(500);
       expect(trendingCacheSet).not.toHaveBeenCalled();
-      await app.close();
     });
   });
 
@@ -171,7 +156,6 @@ describe("streaming routes", () => {
       expect(res.json().providers).toEqual(
         expect.arrayContaining([expect.objectContaining({ key: "crunchyroll", name: "Crunchyroll" })])
       );
-      await app.close();
     });
   });
 
@@ -184,7 +168,6 @@ describe("streaming routes", () => {
       expect(res.statusCode).toBe(200);
       expect(discoverAnime).toHaveBeenCalledWith("series");
       expect(trendingCacheSet).toHaveBeenCalledWith("anime:series", expect.anything());
-      await app.close();
     });
 
     it("supports anime films", async () => {
@@ -193,7 +176,6 @@ describe("streaming routes", () => {
       await app.inject({ method: "GET", url: "/anime?type=movie" });
 
       expect(discoverAnime).toHaveBeenCalledWith("movie");
-      await app.close();
     });
 
     it("rejects an unsupported type", async () => {
@@ -202,7 +184,6 @@ describe("streaming routes", () => {
       const res = await app.inject({ method: "GET", url: "/anime?type=episode" });
 
       expect(res.statusCode).toBe(400);
-      await app.close();
     });
 
     it("returns 500 when the anime discover call fails", async () => {
@@ -212,7 +193,6 @@ describe("streaming routes", () => {
       const res = await app.inject({ method: "GET", url: "/anime" });
 
       expect(res.statusCode).toBe(500);
-      await app.close();
     });
   });
 });

--- a/apps/api/src/routes/stremio-library.test.ts
+++ b/apps/api/src/routes/stremio-library.test.ts
@@ -1,0 +1,330 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import Fastify, { type FastifyInstance } from "fastify";
+
+const PROFILE_ID = "11111111-1111-4111-8111-111111111111";
+const DEFAULT_PROFILE_ID = "99999999-9999-4999-8999-999999999999";
+
+class StremioApiError extends Error {}
+
+const connectStremio = vi.fn();
+const disconnectStremio = vi.fn();
+const getStremioStatus = vi.fn();
+const isStremioConnected = vi.fn();
+const resetStremioClient = vi.fn();
+const syncStremioLibrary = vi.fn();
+const getPendingPlaySignals = vi.fn();
+const isPlayDetectionEnabled = vi.fn();
+const recordPlaySignal = vi.fn();
+
+vi.mock("../lib/stremio-library.js", () => ({
+  StremioApiError,
+  connectStremio: (...a: unknown[]) => connectStremio(...a),
+  disconnectStremio: (...a: unknown[]) => disconnectStremio(...a),
+  getStremioStatus: () => getStremioStatus(),
+  isStremioConnected: () => isStremioConnected(),
+  resetStremioClient: () => resetStremioClient(),
+  syncStremioLibrary: (...a: unknown[]) => syncStremioLibrary(...a),
+}));
+vi.mock("../lib/play-signal.js", () => ({
+  getPendingPlaySignals: (...a: unknown[]) => getPendingPlaySignals(...a),
+  isPlayDetectionEnabled: () => isPlayDetectionEnabled(),
+  recordPlaySignal: (...a: unknown[]) => recordPlaySignal(...a),
+}));
+vi.mock("../lib/profile.js", () => ({
+  getDefaultProfileId: async () => DEFAULT_PROFILE_ID,
+  resolveProfile: async (request: { profileId?: string }) => {
+    request.profileId = PROFILE_ID;
+  },
+}));
+
+const buildApp = async (): Promise<FastifyInstance> => {
+  vi.resetModules();
+  const { default: stremioLibraryRoutes } = await import("./stremio-library.js");
+  const app = Fastify({ logger: false });
+  await app.register(stremioLibraryRoutes);
+  await app.ready();
+  return app;
+};
+
+const playSignal = (over: Record<string, unknown> = {}) => ({
+  type: "movie",
+  imdbId: "tt1",
+  resource: "stream",
+  ...over,
+});
+
+describe("Stremio library routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getStremioStatus.mockResolvedValue({ connected: true, email: "a@example.com" });
+    isStremioConnected.mockResolvedValue(true);
+    syncStremioLibrary.mockResolvedValue({ imported: 3 });
+    connectStremio.mockResolvedValue(undefined);
+    disconnectStremio.mockResolvedValue(undefined);
+    isPlayDetectionEnabled.mockReturnValue(true);
+    recordPlaySignal.mockResolvedValue({ status: "pending" });
+    getPendingPlaySignals.mockResolvedValue([]);
+  });
+
+  describe("POST /stremio/library/connect", () => {
+    it("connects and takes a baseline without recording history", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({
+        method: "POST",
+        url: "/stremio/library/connect",
+        payload: { email: " a@example.com ", password: "pw" },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(connectStremio).toHaveBeenCalledWith("a@example.com", "pw", PROFILE_ID, expect.anything());
+      expect(syncStremioLibrary).toHaveBeenCalledWith(expect.anything(), PROFILE_ID, "baseline");
+      await app.close();
+    });
+
+    it("returns 401 with Stremio's own message on bad credentials", async () => {
+      connectStremio.mockRejectedValue(new StremioApiError("Wrong password"));
+      const app = await buildApp();
+
+      const res = await app.inject({
+        method: "POST",
+        url: "/stremio/library/connect",
+        payload: { email: "a@example.com", password: "wrong" },
+      });
+
+      expect(res.statusCode).toBe(401);
+      expect(res.json().error).toBe("Wrong password");
+      await app.close();
+    });
+
+    it("returns 502 when Stremio cannot be reached", async () => {
+      connectStremio.mockRejectedValue(new Error("ECONNREFUSED"));
+      const app = await buildApp();
+
+      const res = await app.inject({
+        method: "POST",
+        url: "/stremio/library/connect",
+        payload: { email: "a@example.com", password: "pw" },
+      });
+
+      expect(res.statusCode).toBe(502);
+      await app.close();
+    });
+
+    it("undoes the connection when the baseline sync fails", async () => {
+      // A connection with no baseline would make the next incremental pass
+      // treat the whole library as newly watched.
+      syncStremioLibrary.mockRejectedValue(new Error("library read failed"));
+      const app = await buildApp();
+
+      const res = await app.inject({
+        method: "POST",
+        url: "/stremio/library/connect",
+        payload: { email: "a@example.com", password: "pw" },
+      });
+
+      expect(res.statusCode).toBe(502);
+      expect(disconnectStremio).toHaveBeenCalled();
+      expect(resetStremioClient).toHaveBeenCalled();
+      expect(res.json().error).toMatch(/Nothing was saved/);
+      await app.close();
+    });
+
+    it("requires both an email and a password", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({
+        method: "POST",
+        url: "/stremio/library/connect",
+        payload: { email: "a@example.com" },
+      });
+
+      expect(res.statusCode).toBe(400);
+      expect(connectStremio).not.toHaveBeenCalled();
+      await app.close();
+    });
+  });
+
+  describe("POST /stremio/library/import and /sync", () => {
+    it("imports into the calling profile", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "POST", url: "/stremio/library/import" });
+
+      expect(res.statusCode).toBe(200);
+      expect(syncStremioLibrary).toHaveBeenCalledWith(expect.anything(), PROFILE_ID, "import");
+      await app.close();
+    });
+
+    it("runs the incremental pass on demand", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "POST", url: "/stremio/library/sync" });
+
+      expect(res.statusCode).toBe(200);
+      expect(syncStremioLibrary).toHaveBeenCalledWith(expect.anything(), PROFILE_ID, "incremental");
+      await app.close();
+    });
+
+    it("400s when no account is connected", async () => {
+      isStremioConnected.mockResolvedValue(false);
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "POST", url: "/stremio/library/import" });
+
+      expect(res.statusCode).toBe(400);
+      expect(syncStremioLibrary).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it("502s when the import throws", async () => {
+      syncStremioLibrary.mockRejectedValue(new Error("upstream"));
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "POST", url: "/stremio/library/import" });
+
+      expect(res.statusCode).toBe(502);
+      await app.close();
+    });
+  });
+
+  describe("POST /stremio/library/disconnect", () => {
+    it("clears the stored account and the cached client", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "POST", url: "/stremio/library/disconnect" });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual({ connected: false });
+      expect(resetStremioClient).toHaveBeenCalled();
+      await app.close();
+    });
+  });
+
+  describe("POST /stremio/play-signal", () => {
+    it("records a signal for the profile the addon reports", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({
+        method: "POST",
+        url: "/stremio/play-signal",
+        payload: playSignal({ profileId: PROFILE_ID }),
+      });
+
+      expect(res.statusCode).toBe(202);
+      expect(recordPlaySignal).toHaveBeenCalledWith(
+        expect.objectContaining({ profileId: PROFILE_ID, imdbId: "tt1", resource: "stream" })
+      );
+      await app.close();
+    });
+
+    it("falls back to the default profile when the reported one is not a UUID", async () => {
+      // The body is addon-supplied, so the id is validated rather than trusted.
+      const app = await buildApp();
+
+      await app.inject({
+        method: "POST",
+        url: "/stremio/play-signal",
+        payload: playSignal({ profileId: "../../etc/passwd" }),
+      });
+
+      expect(recordPlaySignal).toHaveBeenCalledWith(
+        expect.objectContaining({ profileId: DEFAULT_PROFILE_ID })
+      );
+      await app.close();
+    });
+
+    it("accepts but ignores signals when play detection is off", async () => {
+      isPlayDetectionEnabled.mockReturnValue(false);
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "POST", url: "/stremio/play-signal", payload: playSignal() });
+
+      expect(res.statusCode).toBe(202);
+      expect(res.json()).toEqual({ status: "disabled" });
+      expect(recordPlaySignal).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it("truncates an over-long client identifier", async () => {
+      const app = await buildApp();
+
+      await app.inject({
+        method: "POST",
+        url: "/stremio/play-signal",
+        payload: playSignal({ client: "x".repeat(500) }),
+      });
+
+      expect(recordPlaySignal.mock.calls[0][0].client).toHaveLength(200);
+      await app.close();
+    });
+
+    it("falls back to the request user-agent when no client is sent", async () => {
+      const app = await buildApp();
+
+      await app.inject({
+        method: "POST",
+        url: "/stremio/play-signal",
+        headers: { "user-agent": "Stremio/5.0" },
+        payload: playSignal(),
+      });
+
+      expect(recordPlaySignal.mock.calls[0][0].client).toBe("Stremio/5.0");
+      await app.close();
+    });
+
+    it("rejects an unknown resource", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({
+        method: "POST",
+        url: "/stremio/play-signal",
+        payload: playSignal({ resource: "meta" }),
+      });
+
+      expect(res.statusCode).toBe(400);
+      expect(recordPlaySignal).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it("rejects an unknown watch type", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({
+        method: "POST",
+        url: "/stremio/play-signal",
+        payload: playSignal({ type: "season" }),
+      });
+
+      expect(res.statusCode).toBe(400);
+      await app.close();
+    });
+
+    it("rejects a missing imdbId", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({
+        method: "POST",
+        url: "/stremio/play-signal",
+        payload: { type: "movie", resource: "stream" },
+      });
+
+      expect(res.statusCode).toBe(400);
+      await app.close();
+    });
+  });
+
+  describe("GET /stremio/play-signals", () => {
+    it("reports the calling profile's pending signals", async () => {
+      getPendingPlaySignals.mockResolvedValue([{ imdbId: "tt1" }]);
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/stremio/play-signals" });
+
+      expect(res.statusCode).toBe(200);
+      expect(getPendingPlaySignals).toHaveBeenCalledWith(PROFILE_ID);
+      expect(res.json()).toMatchObject({ enabled: true, signals: [{ imdbId: "tt1" }] });
+      await app.close();
+    });
+  });
+});

--- a/apps/api/src/routes/stremio-library.test.ts
+++ b/apps/api/src/routes/stremio-library.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import Fastify, { type FastifyInstance } from "fastify";
+import type { FastifyInstance } from "fastify";
+import { buildRouteApp } from "../lib/test-fixtures/route-app.js";
 
 const PROFILE_ID = "11111111-1111-4111-8111-111111111111";
 const DEFAULT_PROFILE_ID = "99999999-9999-4999-8999-999999999999";
@@ -37,14 +38,8 @@ vi.mock("../lib/profile.js", () => ({
   },
 }));
 
-const buildApp = async (): Promise<FastifyInstance> => {
-  vi.resetModules();
-  const { default: stremioLibraryRoutes } = await import("./stremio-library.js");
-  const app = Fastify({ logger: false });
-  await app.register(stremioLibraryRoutes);
-  await app.ready();
-  return app;
-};
+const buildApp = (): Promise<FastifyInstance> =>
+  buildRouteApp(() => import("./stremio-library.js"));
 
 const playSignal = (over: Record<string, unknown> = {}) => ({
   type: "movie",
@@ -79,7 +74,6 @@ describe("Stremio library routes", () => {
       expect(res.statusCode).toBe(200);
       expect(connectStremio).toHaveBeenCalledWith("a@example.com", "pw", PROFILE_ID, expect.anything());
       expect(syncStremioLibrary).toHaveBeenCalledWith(expect.anything(), PROFILE_ID, "baseline");
-      await app.close();
     });
 
     it("returns 401 with Stremio's own message on bad credentials", async () => {
@@ -94,7 +88,6 @@ describe("Stremio library routes", () => {
 
       expect(res.statusCode).toBe(401);
       expect(res.json().error).toBe("Wrong password");
-      await app.close();
     });
 
     it("returns 502 when Stremio cannot be reached", async () => {
@@ -108,7 +101,6 @@ describe("Stremio library routes", () => {
       });
 
       expect(res.statusCode).toBe(502);
-      await app.close();
     });
 
     it("undoes the connection when the baseline sync fails", async () => {
@@ -127,7 +119,6 @@ describe("Stremio library routes", () => {
       expect(disconnectStremio).toHaveBeenCalled();
       expect(resetStremioClient).toHaveBeenCalled();
       expect(res.json().error).toMatch(/Nothing was saved/);
-      await app.close();
     });
 
     it("requires both an email and a password", async () => {
@@ -141,7 +132,6 @@ describe("Stremio library routes", () => {
 
       expect(res.statusCode).toBe(400);
       expect(connectStremio).not.toHaveBeenCalled();
-      await app.close();
     });
   });
 
@@ -153,7 +143,6 @@ describe("Stremio library routes", () => {
 
       expect(res.statusCode).toBe(200);
       expect(syncStremioLibrary).toHaveBeenCalledWith(expect.anything(), PROFILE_ID, "import");
-      await app.close();
     });
 
     it("runs the incremental pass on demand", async () => {
@@ -163,7 +152,6 @@ describe("Stremio library routes", () => {
 
       expect(res.statusCode).toBe(200);
       expect(syncStremioLibrary).toHaveBeenCalledWith(expect.anything(), PROFILE_ID, "incremental");
-      await app.close();
     });
 
     it("400s when no account is connected", async () => {
@@ -174,7 +162,6 @@ describe("Stremio library routes", () => {
 
       expect(res.statusCode).toBe(400);
       expect(syncStremioLibrary).not.toHaveBeenCalled();
-      await app.close();
     });
 
     it("502s when the import throws", async () => {
@@ -184,7 +171,6 @@ describe("Stremio library routes", () => {
       const res = await app.inject({ method: "POST", url: "/stremio/library/import" });
 
       expect(res.statusCode).toBe(502);
-      await app.close();
     });
   });
 
@@ -197,7 +183,6 @@ describe("Stremio library routes", () => {
       expect(res.statusCode).toBe(200);
       expect(res.json()).toEqual({ connected: false });
       expect(resetStremioClient).toHaveBeenCalled();
-      await app.close();
     });
   });
 
@@ -215,7 +200,6 @@ describe("Stremio library routes", () => {
       expect(recordPlaySignal).toHaveBeenCalledWith(
         expect.objectContaining({ profileId: PROFILE_ID, imdbId: "tt1", resource: "stream" })
       );
-      await app.close();
     });
 
     it("falls back to the default profile when the reported one is not a UUID", async () => {
@@ -231,7 +215,6 @@ describe("Stremio library routes", () => {
       expect(recordPlaySignal).toHaveBeenCalledWith(
         expect.objectContaining({ profileId: DEFAULT_PROFILE_ID })
       );
-      await app.close();
     });
 
     it("accepts but ignores signals when play detection is off", async () => {
@@ -243,7 +226,6 @@ describe("Stremio library routes", () => {
       expect(res.statusCode).toBe(202);
       expect(res.json()).toEqual({ status: "disabled" });
       expect(recordPlaySignal).not.toHaveBeenCalled();
-      await app.close();
     });
 
     it("truncates an over-long client identifier", async () => {
@@ -256,7 +238,6 @@ describe("Stremio library routes", () => {
       });
 
       expect(recordPlaySignal.mock.calls[0][0].client).toHaveLength(200);
-      await app.close();
     });
 
     it("falls back to the request user-agent when no client is sent", async () => {
@@ -270,7 +251,6 @@ describe("Stremio library routes", () => {
       });
 
       expect(recordPlaySignal.mock.calls[0][0].client).toBe("Stremio/5.0");
-      await app.close();
     });
 
     it("rejects an unknown resource", async () => {
@@ -284,7 +264,6 @@ describe("Stremio library routes", () => {
 
       expect(res.statusCode).toBe(400);
       expect(recordPlaySignal).not.toHaveBeenCalled();
-      await app.close();
     });
 
     it("rejects an unknown watch type", async () => {
@@ -297,7 +276,6 @@ describe("Stremio library routes", () => {
       });
 
       expect(res.statusCode).toBe(400);
-      await app.close();
     });
 
     it("rejects a missing imdbId", async () => {
@@ -310,7 +288,6 @@ describe("Stremio library routes", () => {
       });
 
       expect(res.statusCode).toBe(400);
-      await app.close();
     });
   });
 
@@ -324,7 +301,6 @@ describe("Stremio library routes", () => {
       expect(res.statusCode).toBe(200);
       expect(getPendingPlaySignals).toHaveBeenCalledWith(PROFILE_ID);
       expect(res.json()).toMatchObject({ enabled: true, signals: [{ imdbId: "tt1" }] });
-      await app.close();
     });
   });
 });

--- a/apps/api/src/routes/stremio.test.ts
+++ b/apps/api/src/routes/stremio.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import Fastify, { type FastifyInstance } from "fastify";
+import type { FastifyInstance } from "fastify";
+import { buildRouteApp } from "../lib/test-fixtures/route-app.js";
 
 const PROFILE_ID = "11111111-1111-4111-8111-111111111111";
 const OTHER_PROFILE_ID = "22222222-2222-4222-8222-222222222222";
@@ -61,14 +62,8 @@ const resetMocks = () => {
   prismaMock.profile.findMany.mockResolvedValue([{ id: PROFILE_ID }, { id: OTHER_PROFILE_ID }]);
 };
 
-const buildApp = async (): Promise<FastifyInstance> => {
-  vi.resetModules();
-  const { default: stremioRoutes } = await import("./stremio.js");
-  const app = Fastify();
-  await app.register(stremioRoutes);
-  await app.ready();
-  return app;
-};
+const buildApp = (): Promise<FastifyInstance> =>
+  buildRouteApp(() => import("./stremio.js"));
 
 describe("stremio routes — addon config is per profile", () => {
   beforeEach(() => {
@@ -87,7 +82,6 @@ describe("stremio routes — addon config is per profile", () => {
       expect(prismaMock.list.findMany).toHaveBeenCalledWith(
         expect.objectContaining({ where: expect.objectContaining({ profileId: PROFILE_ID }) })
       );
-      await app.close();
     });
 
     it("reads the config row belonging to the requesting profile", async () => {
@@ -98,7 +92,6 @@ describe("stremio routes — addon config is per profile", () => {
       expect(prismaMock.kV.findUnique).toHaveBeenCalledWith({
         where: { key: `addon:config:${PROFILE_ID}` },
       });
-      await app.close();
     });
 
     it("falls back to the default catalogs when the profile has no config row", async () => {
@@ -107,7 +100,6 @@ describe("stremio routes — addon config is per profile", () => {
       const response = await app.inject({ method: "GET", url: "/addon/config" });
 
       expect(response.json().config.enabledCatalogs).toContain("cataloggy-trending-movie");
-      await app.close();
     });
   });
 
@@ -125,7 +117,6 @@ describe("stremio routes — addon config is per profile", () => {
       expect(prismaMock.kV.upsert).toHaveBeenCalledWith(
         expect.objectContaining({ where: { key: `addon:config:${PROFILE_ID}` } })
       );
-      await app.close();
     });
 
     it("drops a list catalog that belongs to another profile", async () => {
@@ -141,7 +132,6 @@ describe("stremio routes — addon config is per profile", () => {
       });
 
       expect(response.json().config.enabledCatalogs).toEqual([`list:${OWN_LIST_ID}`]);
-      await app.close();
     });
 
     it("rejects a body without an enabledCatalogs array", async () => {
@@ -149,7 +139,6 @@ describe("stremio routes — addon config is per profile", () => {
       const response = await app.inject({ method: "POST", url: "/addon/config", payload: {} });
       expect(response.statusCode).toBe(400);
       expect(prismaMock.kV.upsert).not.toHaveBeenCalled();
-      await app.close();
     });
   });
 
@@ -167,7 +156,6 @@ describe("stremio routes — addon config is per profile", () => {
       expect(prismaMock.kV.findUnique).toHaveBeenCalledWith({
         where: { key: `addon:config:${OTHER_PROFILE_ID}` },
       });
-      await app.close();
     });
 
     it("falls back to the default profile when no profileId is given", async () => {
@@ -178,7 +166,6 @@ describe("stremio routes — addon config is per profile", () => {
       expect(prismaMock.kV.findUnique).toHaveBeenCalledWith({
         where: { key: `addon:config:${PROFILE_ID}` },
       });
-      await app.close();
     });
 
     it("offers the app icon as the addon's logo once the web UI has a public address", async () => {
@@ -193,7 +180,6 @@ describe("stremio routes — addon config is per profile", () => {
         const app = await buildApp();
         const response = await app.inject({ method: "GET", url: "/addon/stremio/manifest.json" });
         expect(response.json().logo).toBe("https://cataloggy.example/icons/icon-192.png");
-        await app.close();
       } finally {
         delete process.env.CATALOGGY_WEB_PUBLIC;
       }
@@ -212,7 +198,6 @@ describe("stremio routes — addon config is per profile", () => {
 
       const catalogIds = (response.json().catalogs as { id: string }[]).map((c) => c.id);
       expect(catalogIds).not.toContain(`list:${OTHER_LIST_ID}`);
-      await app.close();
     });
   });
 });
@@ -236,7 +221,6 @@ describe("stremio routes — the legacy list route is profile-scoped", () => {
       where: { id: OWN_LIST_ID, profileId: PROFILE_ID },
       select: { id: true, kind: true },
     });
-    await app.close();
   });
 
   it("looks the list up under the profile named in the query string", async () => {
@@ -254,7 +238,6 @@ describe("stremio routes — the legacy list route is profile-scoped", () => {
       where: { id: OTHER_LIST_ID, profileId: OTHER_PROFILE_ID },
       select: { id: true, kind: true },
     });
-    await app.close();
   });
 
   it("404s a list belonging to a profile other than the resolved one", async () => {
@@ -270,7 +253,6 @@ describe("stremio routes — the legacy list route is profile-scoped", () => {
 
     expect(response.statusCode).toBe(404);
     expect(prismaMock.list.findUnique).not.toHaveBeenCalled();
-    await app.close();
   });
 });
 
@@ -291,7 +273,6 @@ describe("stremio routes — ?profileId names a profile, it does not unlock one"
 
     expect(response.statusCode).toBe(401);
     expect(response.json().code).toBe("profile_verification_required");
-    await app.close();
   });
 
   it("serves that same catalog once the PIN has been verified", async () => {
@@ -307,7 +288,6 @@ describe("stremio routes — ?profileId names a profile, it does not unlock one"
 
     expect(response.statusCode).toBe(200);
     expect(response.json().metas).toEqual([{ id: "tt0000001" }]);
-    await app.close();
   });
 
   it("does not accept another profile's token as verification for this one", async () => {
@@ -324,7 +304,6 @@ describe("stremio routes — ?profileId names a profile, it does not unlock one"
     });
 
     expect(response.statusCode).toBe(401);
-    await app.close();
   });
 
   it("401s the default-profile fallback when that profile is locked", async () => {
@@ -336,7 +315,6 @@ describe("stremio routes — ?profileId names a profile, it does not unlock one"
     const response = await app.inject({ method: "GET", url: "/continue" });
 
     expect(response.statusCode).toBe(401);
-    await app.close();
   });
 
   it("401s the legacy list route for a locked profile before it looks the list up", async () => {
@@ -350,7 +328,6 @@ describe("stremio routes — ?profileId names a profile, it does not unlock one"
 
     expect(response.statusCode).toBe(401);
     expect(prismaMock.list.findFirst).not.toHaveBeenCalled();
-    await app.close();
   });
 
   it("leaves the secret addon URL alone, which is the credential Stremio can actually send", async () => {
@@ -371,7 +348,6 @@ describe("stremio routes — ?profileId names a profile, it does not unlock one"
       if (originalToken === undefined) delete process.env.API_TOKEN;
       else process.env.API_TOKEN = originalToken;
     }
-    await app.close();
   });
 });
 
@@ -405,7 +381,6 @@ describe("stremio routes — the addon URL is gated by a per-profile secret", ()
     expect(prismaMock.kV.findUnique).toHaveBeenCalledWith({
       where: { key: `addon:config:${OTHER_PROFILE_ID}` },
     });
-    await app.close();
   });
 
   it("ignores ?profileId — the secret, not the query string, picks the profile", async () => {
@@ -423,7 +398,6 @@ describe("stremio routes — the addon URL is gated by a per-profile secret", ()
     expect(prismaMock.kV.findUnique).not.toHaveBeenCalledWith({
       where: { key: `addon:config:${OTHER_PROFILE_ID}` },
     });
-    await app.close();
   });
 
   it("404s a manifest request carrying an unknown secret", async () => {
@@ -433,7 +407,6 @@ describe("stremio routes — the addon URL is gated by a per-profile secret", ()
 
     expect(response.statusCode).toBe(404);
     expect(prismaMock.kV.findUnique).not.toHaveBeenCalled();
-    await app.close();
   });
 
   it("404s a configure request carrying an unknown secret", async () => {
@@ -445,7 +418,6 @@ describe("stremio routes — the addon URL is gated by a per-profile secret", ()
     // when CATALOGGY_WEB_PUBLIC is unset — the status code alone cannot.
     expect(response.statusCode).toBe(404);
     expect(response.json().error).toBe("Unknown addon URL");
-    await app.close();
   });
 
   it("serves a catalog for a valid secret and 404s the same catalog without one", async () => {
@@ -465,7 +437,6 @@ describe("stremio routes — the addon URL is gated by a per-profile secret", ()
     });
     expect(rejected.statusCode).toBe(404);
     expect(rejected.json().metas).toEqual([]);
-    await app.close();
   });
 
   it("only serves a custom list catalog to the profile that owns the list", async () => {
@@ -496,7 +467,6 @@ describe("stremio routes — the addon URL is gated by a per-profile secret", ()
       url: `/addon/stremio/${secret}/catalog/movie/list:${OTHER_LIST_ID}.json`,
     });
     expect(foreign.statusCode).toBe(404);
-    await app.close();
   });
 
   it("404s a list catalog the profile owns but has not enabled", async () => {
@@ -515,7 +485,6 @@ describe("stremio routes — the addon URL is gated by a per-profile secret", ()
 
     expect(response.statusCode).toBe(404);
     expect(prismaMock.list.findFirst).not.toHaveBeenCalled();
-    await app.close();
   });
 
   it("404s a list catalog whose id is not a UUID rather than failing the uuid cast", async () => {
@@ -529,7 +498,6 @@ describe("stremio routes — the addon URL is gated by a per-profile secret", ()
 
     expect(response.statusCode).toBe(404);
     expect(prismaMock.list.findFirst).not.toHaveBeenCalled();
-    await app.close();
   });
 
   it("hands the install URL for the requesting profile back from /addon/config", async () => {
@@ -540,6 +508,5 @@ describe("stremio routes — the addon URL is gated by a per-profile secret", ()
     expect(response.json().stremioManifestPath).toBe(
       `/addon/stremio/${await secretFor(PROFILE_ID)}/manifest.json`
     );
-    await app.close();
   });
 });

--- a/apps/api/src/routes/tags.test.ts
+++ b/apps/api/src/routes/tags.test.ts
@@ -134,6 +134,19 @@ describe("tags routes", () => {
         where: { id: TAG_ID, profileId: PROFILE_ID },
       });
     });
+
+    it("rejects an id that is not a UUID before it reaches the database", async () => {
+      // `Tag.id` is a uuid column: Postgres errors on a malformed value rather
+      // than matching nothing, so without this guard a bad request would
+      // surface as a 500.
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "DELETE", url: "/tags/not-a-uuid" });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error).toBe("tagId must be a valid UUID");
+      expect(prismaMock.tag.deleteMany).not.toHaveBeenCalled();
+    });
   });
 
   describe("POST /tags/assign", () => {
@@ -225,6 +238,21 @@ describe("tags routes", () => {
 
       expect(res.statusCode).toBe(404);
       expect(prismaMock.itemTag.deleteMany).not.toHaveBeenCalled();
+    });
+
+    it("rejects a tagId in the body that is not a UUID", async () => {
+      // Same uuid column, reached through the body rather than the path.
+      const app = await buildApp();
+
+      const res = await app.inject({
+        method: "DELETE",
+        url: "/tags/assign",
+        payload: { tagId: "not-a-uuid", type: "movie", imdbId: "tt1" },
+      });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error).toBe("tagId must be a valid UUID");
+      expect(prismaMock.tag.findFirst).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/routes/tags.test.ts
+++ b/apps/api/src/routes/tags.test.ts
@@ -1,0 +1,251 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import Fastify, { type FastifyInstance } from "fastify";
+
+const PROFILE_ID = "11111111-1111-4111-8111-111111111111";
+const TAG_ID = "22222222-2222-4222-8222-222222222222";
+
+const prismaMock = {
+  tag: { findMany: vi.fn(), findFirst: vi.fn(), upsert: vi.fn(), deleteMany: vi.fn() },
+  itemTag: { upsert: vi.fn(), deleteMany: vi.fn() },
+};
+
+vi.mock("../lib/prisma.js", () => ({ prisma: prismaMock }));
+vi.mock("../lib/profile.js", () => ({
+  resolveProfile: async (request: { profileId?: string }) => {
+    request.profileId = PROFILE_ID;
+  },
+}));
+
+const buildApp = async (): Promise<FastifyInstance> => {
+  vi.resetModules();
+  const { default: tagsRoutes } = await import("./tags.js");
+  const app = Fastify();
+  await app.register(tagsRoutes);
+  await app.ready();
+  return app;
+};
+
+const tagRow = (over: Record<string, unknown> = {}) => ({
+  id: TAG_ID,
+  name: "comfort",
+  createdAt: new Date("2026-01-01T00:00:00Z"),
+  ...over,
+});
+
+describe("tags routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("GET /tags", () => {
+    it("returns every tag of the profile with its item count", async () => {
+      prismaMock.tag.findMany.mockResolvedValue([{ ...tagRow(), _count: { items: 3 } }]);
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/tags" });
+
+      expect(res.statusCode).toBe(200);
+      expect(prismaMock.tag.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { profileId: PROFILE_ID } })
+      );
+      expect(res.json().tags[0]).toMatchObject({ name: "comfort", itemCount: 3 });
+      await app.close();
+    });
+
+    it("scopes to one item when type and imdbId are given", async () => {
+      prismaMock.tag.findMany.mockResolvedValue([tagRow()]);
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/tags?type=movie&imdbId=tt1" });
+
+      expect(res.statusCode).toBe(200);
+      expect(prismaMock.tag.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { profileId: PROFILE_ID, items: { some: { type: "movie", imdbId: "tt1" } } },
+        })
+      );
+      // The item-scoped shape has no count to report.
+      expect(res.json().tags[0]).not.toHaveProperty("itemCount");
+      await app.close();
+    });
+
+    it("rejects imdbId without a type", async () => {
+      // Half a filter would silently widen to every tag on the profile.
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/tags?imdbId=tt1" });
+
+      expect(res.statusCode).toBe(400);
+      expect(prismaMock.tag.findMany).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it("rejects a type that is not an item type", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "GET", url: "/tags?type=book&imdbId=tt1" });
+
+      expect(res.statusCode).toBe(400);
+      await app.close();
+    });
+  });
+
+  describe("POST /tags", () => {
+    it("returns the existing tag rather than failing on a duplicate name", async () => {
+      prismaMock.tag.upsert.mockResolvedValue(tagRow());
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "POST", url: "/tags", payload: { name: "  comfort  " } });
+
+      expect(res.statusCode).toBe(200);
+      expect(prismaMock.tag.upsert).toHaveBeenCalledWith({
+        where: { profileId_name: { profileId: PROFILE_ID, name: "comfort" } },
+        create: { profileId: PROFILE_ID, name: "comfort" },
+        update: {},
+      });
+      await app.close();
+    });
+
+    it("rejects an empty name", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "POST", url: "/tags", payload: { name: "   " } });
+
+      expect(res.statusCode).toBe(400);
+      await app.close();
+    });
+
+    it("caps the name at 50 characters", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "POST", url: "/tags", payload: { name: "a".repeat(51) } });
+
+      expect(res.statusCode).toBe(400);
+      expect(prismaMock.tag.upsert).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it("accepts a name of exactly 50 characters", async () => {
+      prismaMock.tag.upsert.mockResolvedValue(tagRow({ name: "a".repeat(50) }));
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "POST", url: "/tags", payload: { name: "a".repeat(50) } });
+
+      expect(res.statusCode).toBe(200);
+      await app.close();
+    });
+  });
+
+  describe("DELETE /tags/:tagId", () => {
+    it("only deletes within the calling profile", async () => {
+      prismaMock.tag.deleteMany.mockResolvedValue({ count: 1 });
+      const app = await buildApp();
+
+      const res = await app.inject({ method: "DELETE", url: `/tags/${TAG_ID}` });
+
+      expect(res.statusCode).toBe(204);
+      expect(prismaMock.tag.deleteMany).toHaveBeenCalledWith({
+        where: { id: TAG_ID, profileId: PROFILE_ID },
+      });
+      await app.close();
+    });
+  });
+
+  describe("POST /tags/assign", () => {
+    it("creates the tag by name and links it to the item", async () => {
+      prismaMock.tag.upsert.mockResolvedValue(tagRow());
+      prismaMock.itemTag.upsert.mockResolvedValue({});
+      const app = await buildApp();
+
+      const res = await app.inject({
+        method: "POST",
+        url: "/tags/assign",
+        payload: { tagName: " comfort ", type: "series", imdbId: " tt0903747 " },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(prismaMock.itemTag.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { tagId_type_imdbId: { tagId: TAG_ID, type: "series", imdbId: "tt0903747" } },
+        })
+      );
+      await app.close();
+    });
+
+    it("is idempotent — re-assigning does not error", async () => {
+      prismaMock.tag.upsert.mockResolvedValue(tagRow());
+      prismaMock.itemTag.upsert.mockResolvedValue({});
+      const app = await buildApp();
+
+      const payload = { tagName: "comfort", type: "movie", imdbId: "tt1" };
+      const first = await app.inject({ method: "POST", url: "/tags/assign", payload });
+      const second = await app.inject({ method: "POST", url: "/tags/assign", payload });
+
+      expect(first.statusCode).toBe(200);
+      expect(second.statusCode).toBe(200);
+      await app.close();
+    });
+
+    it("rejects a missing tagName", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({
+        method: "POST",
+        url: "/tags/assign",
+        payload: { type: "movie", imdbId: "tt1" },
+      });
+
+      expect(res.statusCode).toBe(400);
+      await app.close();
+    });
+
+    it("rejects an unknown item type", async () => {
+      const app = await buildApp();
+
+      const res = await app.inject({
+        method: "POST",
+        url: "/tags/assign",
+        payload: { tagName: "comfort", type: "book", imdbId: "tt1" },
+      });
+
+      expect(res.statusCode).toBe(400);
+      expect(prismaMock.tag.upsert).not.toHaveBeenCalled();
+      await app.close();
+    });
+  });
+
+  describe("DELETE /tags/assign", () => {
+    it("unlinks the tag from the item", async () => {
+      prismaMock.tag.findFirst.mockResolvedValue(tagRow());
+      prismaMock.itemTag.deleteMany.mockResolvedValue({ count: 1 });
+      const app = await buildApp();
+
+      const res = await app.inject({
+        method: "DELETE",
+        url: "/tags/assign",
+        payload: { tagId: TAG_ID, type: "movie", imdbId: "tt1" },
+      });
+
+      expect(res.statusCode).toBe(204);
+      expect(prismaMock.itemTag.deleteMany).toHaveBeenCalledWith({
+        where: { tagId: TAG_ID, type: "movie", imdbId: "tt1" },
+      });
+      await app.close();
+    });
+
+    it("404s on a tag owned by another profile", async () => {
+      prismaMock.tag.findFirst.mockResolvedValue(null);
+      const app = await buildApp();
+
+      const res = await app.inject({
+        method: "DELETE",
+        url: "/tags/assign",
+        payload: { tagId: TAG_ID, type: "movie", imdbId: "tt1" },
+      });
+
+      expect(res.statusCode).toBe(404);
+      expect(prismaMock.itemTag.deleteMany).not.toHaveBeenCalled();
+      await app.close();
+    });
+  });
+});

--- a/apps/api/src/routes/tags.test.ts
+++ b/apps/api/src/routes/tags.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import Fastify, { type FastifyInstance } from "fastify";
+import type { FastifyInstance } from "fastify";
+import { buildRouteApp } from "../lib/test-fixtures/route-app.js";
 
 const PROFILE_ID = "11111111-1111-4111-8111-111111111111";
 const TAG_ID = "22222222-2222-4222-8222-222222222222";
@@ -16,14 +17,7 @@ vi.mock("../lib/profile.js", () => ({
   },
 }));
 
-const buildApp = async (): Promise<FastifyInstance> => {
-  vi.resetModules();
-  const { default: tagsRoutes } = await import("./tags.js");
-  const app = Fastify();
-  await app.register(tagsRoutes);
-  await app.ready();
-  return app;
-};
+const buildApp = (): Promise<FastifyInstance> => buildRouteApp(() => import("./tags.js"));
 
 const tagRow = (over: Record<string, unknown> = {}) => ({
   id: TAG_ID,
@@ -49,7 +43,6 @@ describe("tags routes", () => {
         expect.objectContaining({ where: { profileId: PROFILE_ID } })
       );
       expect(res.json().tags[0]).toMatchObject({ name: "comfort", itemCount: 3 });
-      await app.close();
     });
 
     it("scopes to one item when type and imdbId are given", async () => {
@@ -66,7 +59,6 @@ describe("tags routes", () => {
       );
       // The item-scoped shape has no count to report.
       expect(res.json().tags[0]).not.toHaveProperty("itemCount");
-      await app.close();
     });
 
     it("rejects imdbId without a type", async () => {
@@ -77,7 +69,6 @@ describe("tags routes", () => {
 
       expect(res.statusCode).toBe(400);
       expect(prismaMock.tag.findMany).not.toHaveBeenCalled();
-      await app.close();
     });
 
     it("rejects a type that is not an item type", async () => {
@@ -86,7 +77,6 @@ describe("tags routes", () => {
       const res = await app.inject({ method: "GET", url: "/tags?type=book&imdbId=tt1" });
 
       expect(res.statusCode).toBe(400);
-      await app.close();
     });
   });
 
@@ -103,7 +93,6 @@ describe("tags routes", () => {
         create: { profileId: PROFILE_ID, name: "comfort" },
         update: {},
       });
-      await app.close();
     });
 
     it("rejects an empty name", async () => {
@@ -112,7 +101,6 @@ describe("tags routes", () => {
       const res = await app.inject({ method: "POST", url: "/tags", payload: { name: "   " } });
 
       expect(res.statusCode).toBe(400);
-      await app.close();
     });
 
     it("caps the name at 50 characters", async () => {
@@ -122,7 +110,6 @@ describe("tags routes", () => {
 
       expect(res.statusCode).toBe(400);
       expect(prismaMock.tag.upsert).not.toHaveBeenCalled();
-      await app.close();
     });
 
     it("accepts a name of exactly 50 characters", async () => {
@@ -132,7 +119,6 @@ describe("tags routes", () => {
       const res = await app.inject({ method: "POST", url: "/tags", payload: { name: "a".repeat(50) } });
 
       expect(res.statusCode).toBe(200);
-      await app.close();
     });
   });
 
@@ -147,7 +133,6 @@ describe("tags routes", () => {
       expect(prismaMock.tag.deleteMany).toHaveBeenCalledWith({
         where: { id: TAG_ID, profileId: PROFILE_ID },
       });
-      await app.close();
     });
   });
 
@@ -169,7 +154,6 @@ describe("tags routes", () => {
           where: { tagId_type_imdbId: { tagId: TAG_ID, type: "series", imdbId: "tt0903747" } },
         })
       );
-      await app.close();
     });
 
     it("is idempotent — re-assigning does not error", async () => {
@@ -183,7 +167,6 @@ describe("tags routes", () => {
 
       expect(first.statusCode).toBe(200);
       expect(second.statusCode).toBe(200);
-      await app.close();
     });
 
     it("rejects a missing tagName", async () => {
@@ -196,7 +179,6 @@ describe("tags routes", () => {
       });
 
       expect(res.statusCode).toBe(400);
-      await app.close();
     });
 
     it("rejects an unknown item type", async () => {
@@ -210,7 +192,6 @@ describe("tags routes", () => {
 
       expect(res.statusCode).toBe(400);
       expect(prismaMock.tag.upsert).not.toHaveBeenCalled();
-      await app.close();
     });
   });
 
@@ -230,7 +211,6 @@ describe("tags routes", () => {
       expect(prismaMock.itemTag.deleteMany).toHaveBeenCalledWith({
         where: { tagId: TAG_ID, type: "movie", imdbId: "tt1" },
       });
-      await app.close();
     });
 
     it("404s on a tag owned by another profile", async () => {
@@ -245,7 +225,6 @@ describe("tags routes", () => {
 
       expect(res.statusCode).toBe(404);
       expect(prismaMock.itemTag.deleteMany).not.toHaveBeenCalled();
-      await app.close();
     });
   });
 });

--- a/apps/api/src/routes/tags.ts
+++ b/apps/api/src/routes/tags.ts
@@ -2,6 +2,7 @@ import { ItemType } from "@prisma/client";
 import type { FastifyPluginAsync } from "fastify";
 import { prisma } from "../lib/prisma.js";
 import { resolveProfile } from "../lib/profile.js";
+import { UUID_V4_PATTERN } from "../lib/types.js";
 
 const isValidItemType = (v: unknown): v is ItemType => v === "movie" || v === "series" || v === "episode";
 
@@ -48,9 +49,16 @@ const tagsRoutes: FastifyPluginAsync = async (app) => {
     return reply.code(200).send({ tag: toTagPayload(tag) });
   });
 
+  // `Tag.id` is a uuid column, so a malformed id is rejected by Postgres rather
+  // than simply matching nothing — an unhandled driver error and a 500 where the
+  // caller sent a bad request. Guarded here as the sibling routes in lists.ts
+  // and games.ts already do.
   app.delete<{ Params: { tagId: string } }>("/tags/:tagId", async (request, reply) => {
     const profileId = request.profileId!;
     const { tagId } = request.params;
+    if (!UUID_V4_PATTERN.test(tagId)) {
+      return reply.code(400).send({ error: "tagId must be a valid UUID" });
+    }
     await prisma.tag.deleteMany({ where: { id: tagId, profileId } });
     return reply.code(204).send();
   });
@@ -90,6 +98,9 @@ const tagsRoutes: FastifyPluginAsync = async (app) => {
     const imdbId = typeof body?.imdbId === "string" ? body.imdbId.trim() : "";
 
     if (!tagId) return reply.code(400).send({ error: "tagId is required" });
+    if (!UUID_V4_PATTERN.test(tagId)) {
+      return reply.code(400).send({ error: "tagId must be a valid UUID" });
+    }
     if (!isValidItemType(type)) return reply.code(400).send({ error: "type must be one of: movie, series, episode" });
     if (!imdbId) return reply.code(400).send({ error: "imdbId is required" });
 

--- a/apps/api/src/routes/trakt.test.ts
+++ b/apps/api/src/routes/trakt.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import Fastify, { type FastifyInstance } from "fastify";
+import type { FastifyInstance } from "fastify";
+import { buildRouteApp } from "../lib/test-fixtures/route-app.js";
 
 const prismaMock = {
   kV: { create: vi.fn(), deleteMany: vi.fn() },
@@ -25,14 +26,8 @@ vi.mock("../lib/profile.js", () => ({
   resolveProfile: async () => {},
 }));
 
-const buildApp = async (): Promise<FastifyInstance> => {
-  vi.resetModules();
-  const { default: traktRoutes } = await import("./trakt.js");
-  const app = Fastify();
-  await app.register(traktRoutes);
-  await app.ready();
-  return app;
-};
+const buildApp = (): Promise<FastifyInstance> =>
+  buildRouteApp(() => import("./trakt.js"));
 
 const STATE = "a".repeat(64);
 const originalEnv = { ...process.env };
@@ -63,7 +58,6 @@ describe("trakt OAuth — the callback is bound to the flow that started it", ()
     expect(prismaMock.kV.create).toHaveBeenCalledWith(
       expect.objectContaining({ data: expect.objectContaining({ key: `trakt:oauth:state:${state}` }) })
     );
-    await app.close();
   });
 
   it("rejects a callback with no state at all, without exchanging the code", async () => {
@@ -74,7 +68,6 @@ describe("trakt OAuth — the callback is bound to the flow that started it", ()
     expect(response.statusCode).toBe(403);
     expect(globalThis.fetch).not.toHaveBeenCalled();
     expect(prismaMock.traktToken.upsert).not.toHaveBeenCalled();
-    await app.close();
   });
 
   it("rejects a callback whose state this install never issued (or already used)", async () => {
@@ -89,7 +82,6 @@ describe("trakt OAuth — the callback is bound to the flow that started it", ()
     expect(response.statusCode).toBe(403);
     expect(globalThis.fetch).not.toHaveBeenCalled();
     expect(prismaMock.traktToken.upsert).not.toHaveBeenCalled();
-    await app.close();
   });
 
   it("exchanges the code and stores the tokens when the state matches", async () => {
@@ -112,7 +104,6 @@ describe("trakt OAuth — the callback is bound to the flow that started it", ()
     expect(prismaMock.traktToken.upsert).toHaveBeenCalledWith(
       expect.objectContaining({ update: expect.objectContaining({ accessToken: "access" }) })
     );
-    await app.close();
   });
 
   it("still reports a denial from Trakt rather than a state failure", async () => {
@@ -125,6 +116,5 @@ describe("trakt OAuth — the callback is bound to the flow that started it", ()
 
     expect(response.statusCode).toBe(403);
     expect(response.body).toContain("User said no");
-    await app.close();
   });
 });

--- a/apps/api/src/routes/watch.test.ts
+++ b/apps/api/src/routes/watch.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import Fastify, { type FastifyInstance } from "fastify";
+import type { FastifyInstance } from "fastify";
+import { buildRouteApp } from "../lib/test-fixtures/route-app.js";
 
 const PROFILE_ID = "11111111-1111-4111-8111-111111111111";
 
@@ -33,14 +34,8 @@ vi.mock("../lib/profile.js", () => ({
 const watchEventMock = { recordWatchEvent: vi.fn() };
 vi.mock("../lib/watch-event.js", () => watchEventMock);
 
-const buildApp = async (): Promise<FastifyInstance> => {
-  vi.resetModules();
-  const { default: watchRoutes } = await import("./watch.js");
-  const app = Fastify();
-  await app.register(watchRoutes);
-  await app.ready();
-  return app;
-};
+const buildApp = (): Promise<FastifyInstance> =>
+  buildRouteApp(() => import("./watch.js"));
 
 // /watch/stats/detailed runs two aggregate queries against the same mock, so the
 // fixtures are dispatched on the SQL text rather than on call order.
@@ -87,14 +82,12 @@ describe("watch routes", () => {
       const app = await buildApp();
       const response = await app.inject({ method: "POST", url: "/watch", payload: { type: "bogus", imdbId: "tt1" } });
       expect(response.statusCode).toBe(400);
-      await app.close();
     });
 
     it("rejects a missing imdbId", async () => {
       const app = await buildApp();
       const response = await app.inject({ method: "POST", url: "/watch", payload: { type: "movie" } });
       expect(response.statusCode).toBe(400);
-      await app.close();
     });
 
     it("rejects a negative season", async () => {
@@ -105,7 +98,6 @@ describe("watch routes", () => {
         payload: { type: "episode", imdbId: "tt1", season: -1 },
       });
       expect(response.statusCode).toBe(400);
-      await app.close();
     });
 
     it("rejects an invalid watchedAt string", async () => {
@@ -116,7 +108,6 @@ describe("watch routes", () => {
         payload: { type: "movie", imdbId: "tt1", watchedAt: "not-a-date" },
       });
       expect(response.statusCode).toBe(400);
-      await app.close();
     });
 
     it("rejects a non-string note", async () => {
@@ -127,7 +118,6 @@ describe("watch routes", () => {
         payload: { type: "movie", imdbId: "tt1", note: 42 },
       });
       expect(response.statusCode).toBe(400);
-      await app.close();
     });
   });
 
@@ -149,7 +139,6 @@ describe("watch routes", () => {
       expect(watchEventMock.recordWatchEvent).toHaveBeenCalledWith(
         expect.objectContaining({ type: "movie", imdbId: "tt1", source: "manual" })
       );
-      await app.close();
     });
 
     it("returns 200 (not 201) when the event already existed (a replay)", async () => {
@@ -166,7 +155,6 @@ describe("watch routes", () => {
       });
 
       expect(response.statusCode).toBe(200);
-      await app.close();
     });
 
     it("serializes a bigint traktHistoryId to a string in the response", async () => {
@@ -179,7 +167,6 @@ describe("watch routes", () => {
       const response = await app.inject({ method: "POST", url: "/watch", payload: { type: "movie", imdbId: "tt1" } });
 
       expect(response.json().watchEvent.traktHistoryId).toBe("123456789012345");
-      await app.close();
     });
   });
 
@@ -189,7 +176,6 @@ describe("watch routes", () => {
       const app = await buildApp();
       const response = await app.inject({ method: "PATCH", url: "/watch/we-1", payload: { note: "hi" } });
       expect(response.statusCode).toBe(404);
-      await app.close();
     });
 
     it("updates the note", async () => {
@@ -204,14 +190,12 @@ describe("watch routes", () => {
         where: { id: "we-1" },
         data: { note: "great episode" },
       });
-      await app.close();
     });
 
     it("rejects a non-string, non-null note", async () => {
       const app = await buildApp();
       const response = await app.inject({ method: "PATCH", url: "/watch/we-1", payload: { note: 5 } });
       expect(response.statusCode).toBe(400);
-      await app.close();
     });
   });
 
@@ -221,7 +205,6 @@ describe("watch routes", () => {
       const app = await buildApp();
       const response = await app.inject({ method: "DELETE", url: "/watch/we-1" });
       expect(response.statusCode).toBe(404);
-      await app.close();
     });
 
     it("deletes a movie watch event without touching series progress", async () => {
@@ -233,7 +216,6 @@ describe("watch routes", () => {
       expect(txMock.watchEvent.delete).toHaveBeenCalledWith({ where: { id: "we-1" } });
       expect(txMock.seriesProgress.upsert).not.toHaveBeenCalled();
       expect(txMock.seriesProgress.deleteMany).not.toHaveBeenCalled();
-      await app.close();
     });
 
     it("rewinds series progress to the next-latest episode after deleting an episode event", async () => {
@@ -252,7 +234,6 @@ describe("watch routes", () => {
         })
       );
       expect(txMock.seriesProgress.deleteMany).not.toHaveBeenCalled();
-      await app.close();
     });
 
     it("clears series progress entirely when no earlier episode is left", async () => {
@@ -268,7 +249,6 @@ describe("watch routes", () => {
         where: { profileId: PROFILE_ID, seriesImdbId: "tt-series" },
       });
       expect(txMock.seriesProgress.upsert).not.toHaveBeenCalled();
-      await app.close();
     });
   });
 
@@ -278,7 +258,6 @@ describe("watch routes", () => {
       const app = await buildApp();
       const response = await app.inject({ method: "GET", url: "/watch/history" });
       expect(response.json()).toEqual({ history: [] });
-      await app.close();
     });
 
     it("attaches metadata name/poster and serializes traktHistoryId", async () => {
@@ -293,7 +272,6 @@ describe("watch routes", () => {
       expect(response.json().history[0]).toEqual(
         expect.objectContaining({ name: "Movie A", poster: "p.jpg", traktHistoryId: "42" })
       );
-      await app.close();
     });
 
     it("clamps an out-of-range limit query param to the 1-200 window", async () => {
@@ -304,7 +282,6 @@ describe("watch routes", () => {
       expect(prismaMock.watchEvent.findMany).toHaveBeenCalledWith(
         expect.objectContaining({ take: 200 })
       );
-      await app.close();
     });
 
     it("filters by type in the query, so paging doesn't hide older matches", async () => {
@@ -315,7 +292,6 @@ describe("watch routes", () => {
       expect(prismaMock.watchEvent.findMany).toHaveBeenCalledWith(
         expect.objectContaining({ where: expect.objectContaining({ type: "movie" }) })
       );
-      await app.close();
     });
 
     it("ignores an unrecognised type rather than rejecting the request", async () => {
@@ -327,7 +303,6 @@ describe("watch routes", () => {
       expect(prismaMock.watchEvent.findMany).toHaveBeenCalledWith(
         expect.objectContaining({ where: expect.not.objectContaining({ type: expect.anything() }) })
       );
-      await app.close();
     });
   });
 
@@ -347,7 +322,6 @@ describe("watch routes", () => {
         totalPlays: 45,
         playsThisWeek: 3,
       });
-      await app.close();
     });
   });
 
@@ -356,14 +330,12 @@ describe("watch routes", () => {
       const app = await buildApp();
       const response = await app.inject({ method: "GET", url: "/watch/stats/year/abcd" });
       expect(response.statusCode).toBe(400);
-      await app.close();
     });
 
     it("rejects a year before 1900", async () => {
       const app = await buildApp();
       const response = await app.inject({ method: "GET", url: "/watch/stats/year/1899" });
       expect(response.statusCode).toBe(400);
-      await app.close();
     });
 
     it("returns zeroed totals for a year with no events", async () => {
@@ -375,7 +347,6 @@ describe("watch routes", () => {
       expect(response.json()).toEqual(
         expect.objectContaining({ year: 2026, totalMovies: 0, totalEpisodes: 0, totalRuntimeMinutes: 0 })
       );
-      await app.close();
     });
   });
 
@@ -390,7 +361,6 @@ describe("watch routes", () => {
       expect(response.json()).toEqual(
         expect.objectContaining({ longestStreak: 12, currentStreak: 3 })
       );
-      await app.close();
     });
 
     it("aggregates in SQL — no per-event or per-metadata rows are pulled into Node", async () => {
@@ -401,7 +371,6 @@ describe("watch routes", () => {
       expect(prismaMock.$queryRaw).toHaveBeenCalledTimes(2);
       expect(prismaMock.watchEvent.findMany).not.toHaveBeenCalled();
       expect(prismaMock.metadata.findMany).not.toHaveBeenCalled();
-      await app.close();
     });
 
     it("pads the monthly series to 12 buckets and passes SQL rollups through", async () => {
@@ -422,7 +391,6 @@ describe("watch routes", () => {
       expect(body.monthly).toHaveLength(12);
       expect(body.monthly.at(-1)).toEqual({ month: thisMonth, movies: 4, episodes: 9 });
       expect(body.monthly[0]).toEqual(expect.objectContaining({ movies: 0, episodes: 0 }));
-      await app.close();
     });
 
     it("returns the genre histogram and top-rated list built by Postgres", async () => {
@@ -446,7 +414,6 @@ describe("watch routes", () => {
       expect(body.topRated).toEqual([
         { imdbId: "tt1", name: "A Film", type: "movie", rating: 8.4, poster: null },
       ]);
-      await app.close();
     });
   });
 });

--- a/apps/api/src/routes/watch.test.ts
+++ b/apps/api/src/routes/watch.test.ts
@@ -3,6 +3,9 @@ import type { FastifyInstance } from "fastify";
 import { buildRouteApp } from "../lib/test-fixtures/route-app.js";
 
 const PROFILE_ID = "11111111-1111-4111-8111-111111111111";
+// `WatchEvent.id` is a uuid column, so the id used here has to be one — a
+// placeholder like "we-1" is a shape the database could never return.
+const EVENT_ID = "44444444-4444-4444-8444-444444444444";
 
 const txMock = {
   watchEvent: { findFirst: vi.fn(), delete: vi.fn() },
@@ -124,7 +127,7 @@ describe("watch routes", () => {
   describe("POST /watch — success", () => {
     it("records a movie watch event and returns 201 when newly created", async () => {
       watchEventMock.recordWatchEvent.mockResolvedValue({
-        watchEvent: { id: "we-1", traktHistoryId: null },
+        watchEvent: { id: EVENT_ID, traktHistoryId: null },
         wasCreated: true,
       });
 
@@ -143,7 +146,7 @@ describe("watch routes", () => {
 
     it("returns 200 (not 201) when the event already existed (a replay)", async () => {
       watchEventMock.recordWatchEvent.mockResolvedValue({
-        watchEvent: { id: "we-1", traktHistoryId: null },
+        watchEvent: { id: EVENT_ID, traktHistoryId: null },
         wasCreated: false,
       });
 
@@ -159,7 +162,7 @@ describe("watch routes", () => {
 
     it("serializes a bigint traktHistoryId to a string in the response", async () => {
       watchEventMock.recordWatchEvent.mockResolvedValue({
-        watchEvent: { id: "we-1", traktHistoryId: 123456789012345n },
+        watchEvent: { id: EVENT_ID, traktHistoryId: 123456789012345n },
         wasCreated: true,
       });
 
@@ -174,28 +177,39 @@ describe("watch routes", () => {
     it("404s when the event doesn't belong to this profile", async () => {
       prismaMock.watchEvent.findFirst.mockResolvedValue(null);
       const app = await buildApp();
-      const response = await app.inject({ method: "PATCH", url: "/watch/we-1", payload: { note: "hi" } });
+      const response = await app.inject({ method: "PATCH", url: `/watch/${EVENT_ID}`, payload: { note: "hi" } });
       expect(response.statusCode).toBe(404);
     });
 
     it("updates the note", async () => {
-      prismaMock.watchEvent.findFirst.mockResolvedValue({ id: "we-1", traktHistoryId: null });
-      prismaMock.watchEvent.update.mockResolvedValue({ id: "we-1", note: "great episode", traktHistoryId: null });
+      prismaMock.watchEvent.findFirst.mockResolvedValue({ id: EVENT_ID, traktHistoryId: null });
+      prismaMock.watchEvent.update.mockResolvedValue({ id: EVENT_ID, note: "great episode", traktHistoryId: null });
 
       const app = await buildApp();
-      const response = await app.inject({ method: "PATCH", url: "/watch/we-1", payload: { note: "great episode" } });
+      const response = await app.inject({ method: "PATCH", url: `/watch/${EVENT_ID}`, payload: { note: "great episode" } });
 
       expect(response.statusCode).toBe(200);
       expect(prismaMock.watchEvent.update).toHaveBeenCalledWith({
-        where: { id: "we-1" },
+        where: { id: EVENT_ID },
         data: { note: "great episode" },
       });
     });
 
     it("rejects a non-string, non-null note", async () => {
       const app = await buildApp();
-      const response = await app.inject({ method: "PATCH", url: "/watch/we-1", payload: { note: 5 } });
+      const response = await app.inject({ method: "PATCH", url: `/watch/${EVENT_ID}`, payload: { note: 5 } });
       expect(response.statusCode).toBe(400);
+    });
+
+    it("rejects an eventId that is not a UUID before it reaches the database", async () => {
+      // Postgres errors on a malformed value for a uuid column rather than
+      // matching nothing, so without the guard this would be a 500.
+      const app = await buildApp();
+      const response = await app.inject({ method: "PATCH", url: "/watch/we-1", payload: { note: "hi" } });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json().error).toBe("eventId must be a valid UUID");
+      expect(prismaMock.watchEvent.findFirst).not.toHaveBeenCalled();
     });
   });
 
@@ -203,28 +217,28 @@ describe("watch routes", () => {
     it("404s when the event doesn't belong to this profile", async () => {
       txMock.watchEvent.findFirst.mockResolvedValue(null);
       const app = await buildApp();
-      const response = await app.inject({ method: "DELETE", url: "/watch/we-1" });
+      const response = await app.inject({ method: "DELETE", url: `/watch/${EVENT_ID}` });
       expect(response.statusCode).toBe(404);
     });
 
     it("deletes a movie watch event without touching series progress", async () => {
-      txMock.watchEvent.findFirst.mockResolvedValue({ id: "we-1", type: "movie", seriesImdbId: null });
+      txMock.watchEvent.findFirst.mockResolvedValue({ id: EVENT_ID, type: "movie", seriesImdbId: null });
       const app = await buildApp();
-      const response = await app.inject({ method: "DELETE", url: "/watch/we-1" });
+      const response = await app.inject({ method: "DELETE", url: `/watch/${EVENT_ID}` });
 
       expect(response.statusCode).toBe(204);
-      expect(txMock.watchEvent.delete).toHaveBeenCalledWith({ where: { id: "we-1" } });
+      expect(txMock.watchEvent.delete).toHaveBeenCalledWith({ where: { id: EVENT_ID } });
       expect(txMock.seriesProgress.upsert).not.toHaveBeenCalled();
       expect(txMock.seriesProgress.deleteMany).not.toHaveBeenCalled();
     });
 
     it("rewinds series progress to the next-latest episode after deleting an episode event", async () => {
       txMock.watchEvent.findFirst
-        .mockResolvedValueOnce({ id: "we-1", type: "episode", seriesImdbId: "tt-series" })
+        .mockResolvedValueOnce({ id: EVENT_ID, type: "episode", seriesImdbId: "tt-series" })
         .mockResolvedValueOnce({ season: 1, episode: 4, watchedAt: new Date("2026-01-01T00:00:00Z") });
 
       const app = await buildApp();
-      const response = await app.inject({ method: "DELETE", url: "/watch/we-1" });
+      const response = await app.inject({ method: "DELETE", url: `/watch/${EVENT_ID}` });
 
       expect(response.statusCode).toBe(204);
       expect(txMock.seriesProgress.upsert).toHaveBeenCalledWith(
@@ -238,17 +252,26 @@ describe("watch routes", () => {
 
     it("clears series progress entirely when no earlier episode is left", async () => {
       txMock.watchEvent.findFirst
-        .mockResolvedValueOnce({ id: "we-1", type: "episode", seriesImdbId: "tt-series" })
+        .mockResolvedValueOnce({ id: EVENT_ID, type: "episode", seriesImdbId: "tt-series" })
         .mockResolvedValueOnce(null);
 
       const app = await buildApp();
-      const response = await app.inject({ method: "DELETE", url: "/watch/we-1" });
+      const response = await app.inject({ method: "DELETE", url: `/watch/${EVENT_ID}` });
 
       expect(response.statusCode).toBe(204);
       expect(txMock.seriesProgress.deleteMany).toHaveBeenCalledWith({
         where: { profileId: PROFILE_ID, seriesImdbId: "tt-series" },
       });
       expect(txMock.seriesProgress.upsert).not.toHaveBeenCalled();
+    });
+
+    it("rejects an eventId that is not a UUID before opening a transaction", async () => {
+      const app = await buildApp();
+      const response = await app.inject({ method: "DELETE", url: "/watch/we-1" });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json().error).toBe("eventId must be a valid UUID");
+      expect(prismaMock.$transaction).not.toHaveBeenCalled();
     });
   });
 
@@ -262,7 +285,7 @@ describe("watch routes", () => {
 
     it("attaches metadata name/poster and serializes traktHistoryId", async () => {
       prismaMock.watchEvent.findMany.mockResolvedValue([
-        { id: "we-1", type: "movie", imdbId: "tt1", seriesImdbId: null, traktHistoryId: 42n },
+        { id: EVENT_ID, type: "movie", imdbId: "tt1", seriesImdbId: null, traktHistoryId: 42n },
       ]);
       prismaMock.metadata.findMany.mockResolvedValue([{ imdbId: "tt1", type: "movie", name: "Movie A", poster: "p.jpg" }]);
 

--- a/apps/api/src/routes/watch.ts
+++ b/apps/api/src/routes/watch.ts
@@ -3,6 +3,7 @@ import type { FastifyPluginAsync } from "fastify";
 import { prisma } from "../lib/prisma.js";
 import { resolveProfile } from "../lib/profile.js";
 import { recordWatchEvent } from "../lib/watch-event.js";
+import { UUID_V4_PATTERN } from "../lib/types.js";
 
 function serializeWatchEvent<T extends { traktHistoryId: bigint | null }>(event: T) {
   return { ...event, traktHistoryId: event.traktHistoryId != null ? event.traktHistoryId.toString() : null };
@@ -117,9 +118,15 @@ const watchRoutes: FastifyPluginAsync = async (app) => {
     return reply.code(wasCreated ? 201 : 200).send({ watchEvent: serializeWatchEvent(watchEvent) });
   });
 
+  // `WatchEvent.id` is a uuid column, so a malformed id is rejected by Postgres
+  // rather than simply matching nothing — an unhandled driver error and a 500
+  // where the caller sent a bad request.
   app.patch<{ Params: { eventId: string }; Body: unknown }>("/watch/:eventId", async (request, reply) => {
     const { eventId } = request.params;
     const profileId = request.profileId!;
+    if (!UUID_V4_PATTERN.test(eventId)) {
+      return reply.code(400).send({ error: "eventId must be a valid UUID" });
+    }
     const body = request.body as { note?: unknown } | null;
     if (!body || (body.note !== null && typeof body.note !== "string")) {
       return reply.code(400).send({ error: "note must be a string or null" });
@@ -136,6 +143,9 @@ const watchRoutes: FastifyPluginAsync = async (app) => {
   app.delete<{ Params: { eventId: string } }>("/watch/:eventId", async (request, reply) => {
     const { eventId } = request.params;
     const profileId = request.profileId!;
+    if (!UUID_V4_PATTERN.test(eventId)) {
+      return reply.code(400).send({ error: "eventId must be a valid UUID" });
+    }
     try {
       await prisma.$transaction(async (tx) => {
         const event = await tx.watchEvent.findFirst({ where: { id: eventId, profileId } });

--- a/apps/api/src/routes/webhooks/jellyfin.test.ts
+++ b/apps/api/src/routes/webhooks/jellyfin.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import Fastify, { type FastifyInstance } from "fastify";
+import type { FastifyInstance } from "fastify";
+import { buildRouteApp } from "../../lib/test-fixtures/route-app.js";
 
 const webhookAuthMock = { verifyWebhookSecret: vi.fn(() => true) };
 vi.mock("../../lib/webhook-auth.js", () => webhookAuthMock);
@@ -10,14 +11,8 @@ vi.mock("../../lib/watch-event.js", () => watchEventMock);
 const webhookProfileMock = { resolveWebhookProfile: vi.fn() };
 vi.mock("../../lib/webhook-profile.js", () => webhookProfileMock);
 
-const buildApp = async (): Promise<FastifyInstance> => {
-  vi.resetModules();
-  const { default: jellyfinWebhookRoutes } = await import("./jellyfin.js");
-  const app = Fastify();
-  await app.register(jellyfinWebhookRoutes);
-  await app.ready();
-  return app;
-};
+const buildApp = (): Promise<FastifyInstance> =>
+  buildRouteApp(() => import("./jellyfin.js"));
 
 describe("POST /webhooks/jellyfin", () => {
   beforeEach(() => {
@@ -39,7 +34,6 @@ describe("POST /webhooks/jellyfin", () => {
 
     expect(response.statusCode).toBe(403);
     expect(watchEventMock.recordWatchEvent).not.toHaveBeenCalled();
-    await app.close();
   });
 
   it("400s with the route's own error when the parsed body is null", async () => {
@@ -58,7 +52,6 @@ describe("POST /webhooks/jellyfin", () => {
 
     expect(response.statusCode).toBe(400);
     expect(response.json()).toEqual({ error: "Empty body" });
-    await app.close();
   });
 
   it("ignores notification types other than PlaybackStop", async () => {
@@ -73,7 +66,6 @@ describe("POST /webhooks/jellyfin", () => {
     expect(response.statusCode).toBe(200);
     expect(response.json()).toEqual({ status: "ignored", type: "PlaybackStart" });
     expect(watchEventMock.recordWatchEvent).not.toHaveBeenCalled();
-    await app.close();
   });
 
   it("skips PlaybackStop events with no IMDb provider id", async () => {
@@ -88,7 +80,6 @@ describe("POST /webhooks/jellyfin", () => {
     expect(response.statusCode).toBe(200);
     expect(response.json()).toEqual({ status: "skipped", reason: "no_imdb_id" });
     expect(watchEventMock.recordWatchEvent).not.toHaveBeenCalled();
-    await app.close();
   });
 
   it("records a movie watch event", async () => {
@@ -104,7 +95,6 @@ describe("POST /webhooks/jellyfin", () => {
     expect(watchEventMock.recordWatchEvent).toHaveBeenCalledWith(
       expect.objectContaining({ type: "movie", imdbId: "tt1111111", source: "Jellyfin" })
     );
-    await app.close();
   });
 
   it("records an episode watch event with season/episode", async () => {
@@ -133,7 +123,6 @@ describe("POST /webhooks/jellyfin", () => {
         source: "Jellyfin",
       })
     );
-    await app.close();
   });
 
   it("records against the profile resolved from the Jellyfin username", async () => {
@@ -156,7 +145,6 @@ describe("POST /webhooks/jellyfin", () => {
     expect(watchEventMock.recordWatchEvent).toHaveBeenCalledWith(
       expect.objectContaining({ imdbId: "tt3333333", profileId: "profile-sam" })
     );
-    await app.close();
   });
 
   it("falls back to the plain Username field when NotificationUsername is absent", async () => {
@@ -174,7 +162,6 @@ describe("POST /webhooks/jellyfin", () => {
     });
 
     expect(webhookProfileMock.resolveWebhookProfile).toHaveBeenCalledWith(expect.anything(), "Alex");
-    await app.close();
   });
 
   it("falls back to Username when NotificationUsername renders empty", async () => {
@@ -193,7 +180,6 @@ describe("POST /webhooks/jellyfin", () => {
     });
 
     expect(webhookProfileMock.resolveWebhookProfile).toHaveBeenCalledWith(expect.anything(), "Alex");
-    await app.close();
   });
 
   it("does not record anything when the profile can't be resolved", async () => {
@@ -213,6 +199,5 @@ describe("POST /webhooks/jellyfin", () => {
     expect(response.statusCode).toBe(400);
     expect(response.json()).toEqual({ error: "The profile query parameter must be a valid UUID" });
     expect(watchEventMock.recordWatchEvent).not.toHaveBeenCalled();
-    await app.close();
   });
 });

--- a/apps/api/src/routes/webhooks/plex.test.ts
+++ b/apps/api/src/routes/webhooks/plex.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import Fastify, { type FastifyInstance } from "fastify";
+import type { FastifyInstance } from "fastify";
+import { buildRouteApp } from "../../lib/test-fixtures/route-app.js";
 
 const webhookAuthMock = { verifyWebhookSecret: vi.fn(() => true) };
 vi.mock("../../lib/webhook-auth.js", () => webhookAuthMock);
@@ -10,14 +11,8 @@ vi.mock("../../lib/watch-event.js", () => watchEventMock);
 const webhookProfileMock = { resolveWebhookProfile: vi.fn() };
 vi.mock("../../lib/webhook-profile.js", () => webhookProfileMock);
 
-const buildApp = async (): Promise<FastifyInstance> => {
-  vi.resetModules();
-  const { default: plexWebhookRoutes } = await import("./plex.js");
-  const app = Fastify();
-  await app.register(plexWebhookRoutes);
-  await app.ready();
-  return app;
-};
+const buildApp = (): Promise<FastifyInstance> =>
+  buildRouteApp(() => import("./plex.js"));
 
 const buildMultipartBody = (payload: unknown, boundary = "boundary123") =>
   [
@@ -49,7 +44,6 @@ describe("POST /webhooks/plex", () => {
 
     expect(response.statusCode).toBe(403);
     expect(watchEventMock.recordWatchEvent).not.toHaveBeenCalled();
-    await app.close();
   });
 
   it("400s when no payload field is found in a multipart body", async () => {
@@ -63,7 +57,6 @@ describe("POST /webhooks/plex", () => {
     });
 
     expect(response.statusCode).toBe(400);
-    await app.close();
   });
 
   it("400s on malformed JSON inside the payload field", async () => {
@@ -77,7 +70,6 @@ describe("POST /webhooks/plex", () => {
     });
 
     expect(response.statusCode).toBe(400);
-    await app.close();
   });
 
   it("ignores non-scrobble events without recording a watch event", async () => {
@@ -93,7 +85,6 @@ describe("POST /webhooks/plex", () => {
     expect(response.statusCode).toBe(200);
     expect(response.json()).toEqual({ status: "ignored", event: "media.play" });
     expect(watchEventMock.recordWatchEvent).not.toHaveBeenCalled();
-    await app.close();
   });
 
   it("skips scrobble events with no resolvable IMDb ID", async () => {
@@ -109,7 +100,6 @@ describe("POST /webhooks/plex", () => {
     expect(response.statusCode).toBe(200);
     expect(response.json()).toEqual({ status: "skipped", reason: "no_imdb_id" });
     expect(watchEventMock.recordWatchEvent).not.toHaveBeenCalled();
-    await app.close();
   });
 
   it("records a movie watch event, extracting the IMDb id from the Guid array", async () => {
@@ -132,7 +122,6 @@ describe("POST /webhooks/plex", () => {
     expect(watchEventMock.recordWatchEvent).toHaveBeenCalledWith(
       expect.objectContaining({ type: "movie", imdbId: "tt9999999", source: "Plex" })
     );
-    await app.close();
   });
 
   it("records an episode watch event with season/episode from the legacy guid field", async () => {
@@ -162,7 +151,6 @@ describe("POST /webhooks/plex", () => {
         source: "Plex",
       })
     );
-    await app.close();
   });
 
   it("accepts a plain JSON body (no multipart wrapper)", async () => {
@@ -178,7 +166,6 @@ describe("POST /webhooks/plex", () => {
     expect(watchEventMock.recordWatchEvent).toHaveBeenCalledWith(
       expect.objectContaining({ imdbId: "tt5555555" })
     );
-    await app.close();
   });
 
   it("records against the profile resolved from the Plex account", async () => {
@@ -200,7 +187,6 @@ describe("POST /webhooks/plex", () => {
     expect(watchEventMock.recordWatchEvent).toHaveBeenCalledWith(
       expect.objectContaining({ imdbId: "tt7777777", profileId: "profile-sam" })
     );
-    await app.close();
   });
 
   it("does not record anything when the profile can't be resolved", async () => {
@@ -220,6 +206,5 @@ describe("POST /webhooks/plex", () => {
     expect(response.statusCode).toBe(404);
     expect(response.json()).toEqual({ error: "Profile not found" });
     expect(watchEventMock.recordWatchEvent).not.toHaveBeenCalled();
-    await app.close();
   });
 });

--- a/docs/api.md
+++ b/docs/api.md
@@ -120,7 +120,7 @@ row genuinely is not found.
 | `GET` | `/meta/:type/:imdbId/cast` | Cast and director. |
 | `GET` | `/meta/:type/:imdbId/providers` | Where to stream it, for the configured region. |
 | `GET` | `/meta/series/:imdbId/seasons` | Season list. |
-| `GET` | `/meta/series/:imdbId/season/:n/episodes` | Episodes for one season. Fetched on demand as a season is expanded. |
+| `GET` | `/meta/series/:imdbId/season/:seasonNumber/episodes` | Episodes for one season; `seasonNumber` must be a positive integer. Fetched on demand as a season is expanded. |
 | `POST` | `/metadata/sync` | `{ imdbId, type }` — refresh one title from TMDB. |
 | `POST` | `/metadata/refresh-all?limit=` | Re-fetch stored metadata in batches of 5. `limit` defaults to 50, caps at 500. |
 | `GET` | `/metadata/anime-search?q=` | AniList search. |
@@ -161,9 +161,9 @@ Discovery responses are cached in memory and returned as Stremio meta previews
 | `GET` | `/series/progress/:imdbId` | One show. |
 | `GET` | `/series/:imdbId/watched-episodes` | |
 | `POST` | `/series/:imdbId/watch-next` | Mark the next unwatched episode. |
-| `POST` | `/series/:imdbId/season/:s/episode/:e/watch` | |
-| `DELETE` | `/series/:imdbId/season/:s/episode/:e/watch` | |
-| `POST` | `/series/:imdbId/season/:s/watch-all` | |
+| `POST` | `/series/:imdbId/season/:seasonNumber/episode/:episodeNumber/watch` | |
+| `DELETE` | `/series/:imdbId/season/:seasonNumber/episode/:episodeNumber/watch` | |
+| `POST` | `/series/:imdbId/season/:seasonNumber/watch-all` | |
 | `GET` | `/show/:imdbId/dropped` | |
 | `POST` | `/show/:imdbId/drop` | Hide a show from Continue Watching without deleting its history. |
 | `DELETE` | `/show/:imdbId/drop` | Un-drop. |
@@ -176,8 +176,8 @@ Plex and Jellyfin webhooks drive.
 | Method | Path | Notes |
 | --- | --- | --- |
 | `GET` | `/checkin` | The current check-in, if any. |
-| `POST` | `/checkin` | `{ type, imdbId, name, seriesImdbId?, season?, episode?, runtime? }`. With `runtime`, it expires on its own. |
-| `DELETE` | `/checkin` | |
+| `POST` | `/checkin` | `{ type, imdbId, name, poster?, seriesImdbId?, season?, episode?, runtime? }`. `runtime` is in **minutes**, and sets an expiry that far ahead so an abandoned check-in clears itself. |
+| `DELETE` | `/checkin?log=` | Clears the check-in. `?log=true` records a watch event from it first — that is the "finished watching" action, where the bare call is "cancel". A failure to record still clears the check-in. |
 | `GET` | `/scrobble/now-playing` | |
 | `POST` | `/scrobble/start` \| `/scrobble/pause` \| `/scrobble/stop` | Stale sessions are swept periodically. |
 
@@ -187,7 +187,7 @@ Five stars, stored as 1–10 so half-stars survive a round trip.
 
 | Method | Path | Notes |
 | --- | --- | --- |
-| `GET` | `/ratings?type=&limit=&imdbId=` | |
+| `GET` | `/ratings?type=&limit=&imdbId=` | `limit` is 1–200, default 50. Filtering by `imdbId` drops the limit entirely, so a show's episode ratings come back whole rather than truncated to the most recent. |
 | `POST` | `/ratings` | `{ imdbId, type, rating, season?, episode?, note? }`. `type` is `movie`, `series`, `season` or `episode`. |
 | `GET` | `/ratings/:type/:imdbId?season=&episode=` | |
 | `DELETE` | `/ratings/:type/:imdbId?season=&episode=` | |
@@ -250,10 +250,10 @@ Needs `TWITCH_CLIENT_ID` / `TWITCH_CLIENT_SECRET` for search, and
 | Method | Path | Notes |
 | --- | --- | --- |
 | `GET` | `/profiles` | |
-| `POST` | `/profiles` | `{ name, avatar?, pin? }`. |
-| `PATCH` | `/profiles/:id` | |
+| `POST` | `/profiles` | `{ name, pin? }`. A PIN is 4–128 characters. |
+| `PATCH` | `/profiles/:id` | `{ name?, pin? }`. Changing or clearing an existing PIN also needs `currentPin`; `pin: null` removes it. |
 | `DELETE` | `/profiles/:id` | |
-| `POST` | `/profiles/:id/verify` | `{ pin }` → a profile token for `x-profile-token`. Rate limited. |
+| `POST` | `/profiles/:id/verify` | `{ pin }` → a profile token for `x-profile-token`. `401` on a wrong PIN, `429` once the profile is locked out after repeated failures — separate from the global rate limit. |
 
 ### Settings and API keys
 
@@ -268,8 +268,12 @@ rotated key doesn't mean editing `.env` and restarting.
 | `GET` | `/tmdb/status` | `{ configured, source }` where source is `db`, `env` or `none`. |
 | `POST` | `/tmdb/key` | Validated against TMDB before saving, so a typo can't overwrite a working key. |
 | `DELETE` | `/tmdb/key` | Reports the env fallback that remains, if any. |
-| `GET`/`POST`/`DELETE` | `/omdb/status`, `/omdb/key` | Validated against OMDb; its error text is passed through. |
-| `GET`/`POST`/`DELETE` | `/rpdb/status`, `/rpdb/key` | Not validated on save. |
+| `GET` | `/omdb/status` | `{ configured }`. |
+| `POST` | `/omdb/key` | Validated against OMDb before saving; its own error text is passed through. Posting an empty key deletes the stored one and returns `{ configured: false }`. |
+| `DELETE` | `/omdb/key` | |
+| `GET` | `/rpdb/status` | `{ configured, hasKey }`. |
+| `POST` | `/rpdb/key` | Not validated on save — RPDB has no cheap check, so a bad key shows up as missing posters rather than an error here. Posting an empty key deletes the stored one. |
+| `DELETE` | `/rpdb/key` | |
 | `GET` | `/rpdb/poster/:imdbId` | `404` when no key is set. |
 | `GET` | `/rpdb/config` | Used by the add-on service, which needs the key to build poster URLs itself. |
 
@@ -296,7 +300,7 @@ before each outbound request — records can change after a config is saved.
 | `GET` | `/trakt/status` | |
 | `GET` | `/trakt/oauth/authorize` | Starts the flow. |
 | `GET` | `/trakt/oauth/callback` | The redirect target. No bearer token; bound to the flow by `state`. |
-| `POST` | `/trakt/import` | One-time history import. |
+| `POST` | `/trakt/import` | One-time history import. `409` if an import is already running. |
 | `POST` | `/trakt/poll` | Run the scheduled poll now. |
 | `POST` | `/trakt/disconnect` | |
 
@@ -343,15 +347,16 @@ Catalog data also has plain-JSON equivalents used by the web UI: `/watchlist`,
 
 | Method | Path | Notes |
 | --- | --- | --- |
-| `GET` | `/export` | The profile's data as JSON: lists and their items, watch events, series progress, and ratings. |
-| `POST` | `/import` | Restores an `/export` payload. |
+| `GET` | `/export` | The profile's data as JSON: lists and their items, watch events, series progress, and ratings. Carries a `version` field. |
+| `POST` | `/import` | Restores an `/export` payload. The body's `version` must be exactly `1`; anything else is a `400` rather than a partial restore. |
 | `POST` | `/import/csv` | Header must include `imdbId,type,watchedAt`; `season,episode` optional. |
 | `POST` | `/import/external` | `{ format, csv }` where format is `letterboxd-diary`, `letterboxd-ratings`, `imdb-ratings` or `simkl`. |
 
 Letterboxd exports carry no IMDb ids, so each unique title costs a TMDB search.
-Those two formats are capped at 10,000 rows; the id-carrying formats get the
-higher `MAX_IMPORT_ROWS` ceiling. Over the cap is a `413` with
-`code: "too_many_rows"`.
+Those two formats are capped at 10,000 rows; the id-carrying formats allow
+200,000 per collection. Over the cap is a `413` with
+`code: "too_many_rows"` — a row limit, not a byte limit, so raising
+`MAX_BODY_SIZE_MB` does not affect it.
 
 ### Webhooks
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -218,9 +218,9 @@ Trakt.
 | `GET` | `/tags` | All tags with counts. |
 | `GET` | `/tags?type=&imdbId=` | Tags on one item. Both params or neither. |
 | `POST` | `/tags` | `{ name }`, max 50 chars. Returns the existing tag if the name is taken. |
-| `DELETE` | `/tags/:tagId` | |
+| `DELETE` | `/tags/:tagId` | `400` if `tagId` isn't a UUID. Deleting a tag that doesn't exist is a no-op, not a `404`. |
 | `POST` | `/tags/assign` | `{ tagName, type, imdbId }`. Creates the tag if needed; idempotent. |
-| `DELETE` | `/tags/assign` | `{ tagId, type, imdbId }`. |
+| `DELETE` | `/tags/assign` | `{ tagId, type, imdbId }`. `400` if `tagId` isn't a UUID. |
 
 ### Calendar
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -91,7 +91,9 @@ row genuinely is not found.
 - **Types** are `movie` and `series` almost everywhere. Watch events use `movie`
   and `episode`; tags additionally accept `episode`.
 - **IDs** are IMDb ids (`tt0111161`) for films and shows, UUIDs for
-  Cataloggy's own rows (lists, games, profiles, watch events).
+  Cataloggy's own rows (lists, games, profiles, tags, watch events). Those are
+  uuid columns, so a malformed id is a `400` before any query runs rather than
+  an empty result.
 - **Caching**: `GET` responses carry an ETag. Send `If-None-Match` and you get a
   `304` with no body. Responses over 1 KB are compressed (`br`, `gzip`,
   `deflate`).
@@ -143,10 +145,10 @@ Discovery responses are cached in memory and returned as Stremio meta previews
 
 | Method | Path | Notes |
 | --- | --- | --- |
-| `POST` | `/watch` | Record a watch. `{ type: "movie" \| "episode", imdbId, seriesImdbId?, season?, episode?, watchedAt? }`. |
+| `POST` | `/watch` | Record a watch. `{ type: "movie" \| "episode", imdbId, seriesImdbId?, season?, episode?, watchedAt?, dateUnknown?, note? }`. |
 | `GET` | `/watch/history?limit=&offset=&imdbId=` | `limit` is 1–200, default 50. Filtering happens server-side so it searches every row, not just the loaded page. |
-| `PATCH` | `/watch/:eventId` | Change a watch date. |
-| `DELETE` | `/watch/:eventId` | |
+| `PATCH` | `/watch/:eventId` | `{ note }` — sets or clears the note on an existing watch (`null`, or a blank string, clears it). It does not move the watch date. |
+| `DELETE` | `/watch/:eventId` | Deleting an episode rewinds series progress to the next-latest episode watched, or clears the progress row when none is left. |
 | `GET` | `/watch/stats` | Headline counts. |
 | `GET` | `/watch/stats/detailed` | Genres, runtime, patterns over time. |
 | `GET` | `/watch/stats/year/:year` | Year in Review. |
@@ -218,9 +220,9 @@ Trakt.
 | `GET` | `/tags` | All tags with counts. |
 | `GET` | `/tags?type=&imdbId=` | Tags on one item. Both params or neither. |
 | `POST` | `/tags` | `{ name }`, max 50 chars. Returns the existing tag if the name is taken. |
-| `DELETE` | `/tags/:tagId` | `400` if `tagId` isn't a UUID. Deleting a tag that doesn't exist is a no-op, not a `404`. |
+| `DELETE` | `/tags/:tagId` | Deleting a tag that doesn't exist is a no-op, not a `404`. |
 | `POST` | `/tags/assign` | `{ tagName, type, imdbId }`. Creates the tag if needed; idempotent. |
-| `DELETE` | `/tags/assign` | `{ tagId, type, imdbId }`. `400` if `tagId` isn't a UUID. |
+| `DELETE` | `/tags/assign` | `{ tagId, type, imdbId }`. |
 
 ### Calendar
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -95,8 +95,10 @@ row genuinely is not found.
 - **Caching**: `GET` responses carry an ETag. Send `If-None-Match` and you get a
   `304` with no body. Responses over 1 KB are compressed (`br`, `gzip`,
   `deflate`).
-- **Body size** is capped by `MAX_BODY_SIZE_MB` (default 10). Restoring a large
-  backup is the case that hits it; the `413` says so.
+- **Body size** is capped by `MAX_BODY_SIZE_MB` (default 32, allowed range
+  1–1024). This is the whole request body, so restoring a large backup is the
+  case that hits it; the `413` says so. Row counts are a separate, per-route
+  limit — see [Export and import](#export-and-import).
 
 ## Endpoints
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,365 @@
+# API reference
+
+The Cataloggy API is a Fastify service on port `7000`. Everything the web UI
+does goes through it, so anything here is fair game for a script, a shortcut, a
+Home Assistant automation, or your own client.
+
+This is a reference for the endpoints as they behave today. It is not a
+stability promise — Cataloggy is a self-hosted app with one supported client, and
+routes do change between versions. Pin `CATALOGGY_IMAGE_TAG` if you build
+something on top of it.
+
+- [Authentication](#authentication)
+- [Profiles](#profiles)
+- [Conventions](#conventions)
+- [Endpoints](#endpoints)
+  - [Health](#health)
+  - [Search and metadata](#search-and-metadata)
+  - [Discovery](#discovery)
+  - [Watch history](#watch-history)
+  - [Series progress](#series-progress)
+  - [Check-in and scrobbling](#check-in-and-scrobbling)
+  - [Ratings](#ratings)
+  - [Lists](#lists)
+  - [Tags](#tags)
+  - [Calendar](#calendar)
+  - [Games](#games)
+  - [Profiles API](#profiles-api)
+  - [Settings and API keys](#settings-and-api-keys)
+  - [AI recommendations](#ai-recommendations)
+  - [Trakt](#trakt)
+  - [Stremio library](#stremio-library)
+  - [Stremio add-on](#stremio-add-on)
+  - [Push notifications](#push-notifications)
+  - [Export and import](#export-and-import)
+  - [Webhooks](#webhooks)
+
+## Authentication
+
+Every endpoint needs `API_TOKEN` as a bearer token:
+
+```bash
+curl -H "Authorization: Bearer $API_TOKEN" http://192.168.1.25:7000/watch/stats
+```
+
+A missing or wrong token gets `401` with a `WWW-Authenticate: Bearer` header.
+That header is how the web client tells "your API token is wrong" apart from
+other 401s (an incorrect profile PIN, for instance), so keep it in mind if you
+write your own client.
+
+Five paths are exempt, because they cannot carry a bearer token by construction:
+
+| Path | Why it is exempt | What guards it instead |
+| --- | --- | --- |
+| `GET /health` | Container health probe | Nothing — it reports no data |
+| `/addon/stremio/*` | Stremio sends no credentials | An unguessable per-profile secret in the path |
+| `GET /addon` | Add-on discovery | As above |
+| `/trakt/oauth/callback` | Browser redirect from trakt.tv | The `state` value that started the flow |
+| `/webhooks/*` | Plex and Jellyfin post directly | `WEBHOOK_SECRET`, plus optional `WEBHOOK_ALLOWED_IPS` |
+
+## Profiles
+
+Most endpoints act on one profile's data. The profile comes from the
+`x-profile-id` header:
+
+```bash
+curl -H "Authorization: Bearer $API_TOKEN" \
+     -H "x-profile-id: 3f1c…" \
+     http://192.168.1.25:7000/lists
+```
+
+Omit it and the default profile is used. A malformed value is a `400`, not a
+silent fallback — a typo'd profile id should not quietly write to someone else's
+history.
+
+Profiles protected by a PIN also need `x-profile-token`, which
+`POST /profiles/:id/verify` returns.
+
+Anything scoped to a profile only ever sees that profile's rows. Asking for
+another profile's list returns `404`, not `403` — the lookup is scoped, so the
+row genuinely is not found.
+
+## Conventions
+
+- **Errors** are always `{ "error": "<human-readable message>" }`. Some also
+  carry a `code` (`body_too_large`, `too_many_rows`) for cases where the fix is
+  a specific config change.
+- **Rate limits** are 200 requests/minute per IP, and 1000/minute for the add-on
+  service, which authenticates with a derived service token. Credential-taking
+  routes (profile PIN verification, Stremio connect, the Trakt OAuth pair) are
+  limited to 10/minute on top of that.
+- **Types** are `movie` and `series` almost everywhere. Watch events use `movie`
+  and `episode`; tags additionally accept `episode`.
+- **IDs** are IMDb ids (`tt0111161`) for films and shows, UUIDs for
+  Cataloggy's own rows (lists, games, profiles, watch events).
+- **Caching**: `GET` responses carry an ETag. Send `If-None-Match` and you get a
+  `304` with no body. Responses over 1 KB are compressed (`br`, `gzip`,
+  `deflate`).
+- **Body size** is capped by `MAX_BODY_SIZE_MB` (default 10). Restoring a large
+  backup is the case that hits it; the `413` says so.
+
+## Endpoints
+
+### Health
+
+| Method | Path | Notes |
+| --- | --- | --- |
+| `GET` | `/health` | `{ status, service }`. No auth, no database. |
+
+### Search and metadata
+
+| Method | Path | Notes |
+| --- | --- | --- |
+| `GET` | `/search?q=&type=` | `type` is `movie`, `series` or `all` (default). `query` works as an alias for `q`. Max 20 results, each flagged with `inWatchlist` / `inCollection` / `lists`. |
+| `GET` | `/meta/:type/:imdbId` | Full metadata for one title. |
+| `GET` | `/meta/:type/:imdbId/bundle` | Everything the detail panel needs — meta, cast, providers, recommendations, seasons, dropped state — in one round trip. Optional sections degrade to empty rather than failing the response. |
+| `GET` | `/meta/:type/:imdbId/cast` | Cast and director. |
+| `GET` | `/meta/:type/:imdbId/providers` | Where to stream it, for the configured region. |
+| `GET` | `/meta/series/:imdbId/seasons` | Season list. |
+| `GET` | `/meta/series/:imdbId/season/:n/episodes` | Episodes for one season. Fetched on demand as a season is expanded. |
+| `POST` | `/metadata/sync` | `{ imdbId, type }` — refresh one title from TMDB. |
+| `POST` | `/metadata/refresh-all?limit=` | Re-fetch stored metadata in batches of 5. `limit` defaults to 50, caps at 500. |
+| `GET` | `/metadata/anime-search?q=` | AniList search. |
+| `GET` | `/genres` | Every genre present in your stored metadata. |
+
+### Discovery
+
+| Method | Path | Notes |
+| --- | --- | --- |
+| `GET` | `/trending?type=&window=` | `window` is `day` or `week` (default). |
+| `GET` | `/popular?type=` | |
+| `GET` | `/streaming?provider=&type=&region=` | Provider key from `/streaming/providers`. `region` falls back to the stored setting. |
+| `GET` | `/streaming/providers` | The nine supported providers and their TMDB ids. |
+| `GET` | `/anime?type=` | Anime discovery, `series` by default. |
+| `GET` | `/recommendations?imdbId=&type=` | Similar titles to one title. |
+| `GET` | `/recommendations/personal?type=&limit=` | Seeded from your recent watches. Uses the AI provider when one is configured, TMDB otherwise. `limit` caps at 40. |
+
+Discovery responses are cached in memory and returned as Stremio meta previews
+(`{ id, type, name, poster, year, description, genres, rating }`).
+
+### Watch history
+
+| Method | Path | Notes |
+| --- | --- | --- |
+| `POST` | `/watch` | Record a watch. `{ type: "movie" \| "episode", imdbId, seriesImdbId?, season?, episode?, watchedAt? }`. |
+| `GET` | `/watch/history?limit=&offset=&imdbId=` | `limit` is 1–200, default 50. Filtering happens server-side so it searches every row, not just the loaded page. |
+| `PATCH` | `/watch/:eventId` | Change a watch date. |
+| `DELETE` | `/watch/:eventId` | |
+| `GET` | `/watch/stats` | Headline counts. |
+| `GET` | `/watch/stats/detailed` | Genres, runtime, patterns over time. |
+| `GET` | `/watch/stats/year/:year` | Year in Review. |
+
+### Series progress
+
+| Method | Path | Notes |
+| --- | --- | --- |
+| `GET` | `/series/progress` | Every show in flight. |
+| `GET` | `/series/progress/:imdbId` | One show. |
+| `GET` | `/series/:imdbId/watched-episodes` | |
+| `POST` | `/series/:imdbId/watch-next` | Mark the next unwatched episode. |
+| `POST` | `/series/:imdbId/season/:s/episode/:e/watch` | |
+| `DELETE` | `/series/:imdbId/season/:s/episode/:e/watch` | |
+| `POST` | `/series/:imdbId/season/:s/watch-all` | |
+| `GET` | `/show/:imdbId/dropped` | |
+| `POST` | `/show/:imdbId/drop` | Hide a show from Continue Watching without deleting its history. |
+| `DELETE` | `/show/:imdbId/drop` | Un-drop. |
+
+### Check-in and scrobbling
+
+Check-ins are manual ("I'm watching this now"); scrobble sessions are what the
+Plex and Jellyfin webhooks drive.
+
+| Method | Path | Notes |
+| --- | --- | --- |
+| `GET` | `/checkin` | The current check-in, if any. |
+| `POST` | `/checkin` | `{ type, imdbId, name, seriesImdbId?, season?, episode?, runtime? }`. With `runtime`, it expires on its own. |
+| `DELETE` | `/checkin` | |
+| `GET` | `/scrobble/now-playing` | |
+| `POST` | `/scrobble/start` \| `/scrobble/pause` \| `/scrobble/stop` | Stale sessions are swept periodically. |
+
+### Ratings
+
+Five stars, stored as 1–10 so half-stars survive a round trip.
+
+| Method | Path | Notes |
+| --- | --- | --- |
+| `GET` | `/ratings?type=&limit=&imdbId=` | |
+| `POST` | `/ratings` | `{ imdbId, type, rating, season?, episode?, note? }`. `type` is `movie`, `series`, `season` or `episode`. |
+| `GET` | `/ratings/:type/:imdbId?season=&episode=` | |
+| `DELETE` | `/ratings/:type/:imdbId?season=&episode=` | |
+
+Seasons are their own rating type rather than a series row carrying a season
+number — otherwise a Specials (season 0) rating would overwrite the show's own.
+
+### Lists
+
+Three kinds: `watchlist`, `collection`, `custom`. A default watchlist and
+collection are created on first start; the watchlist is the one that mirrors to
+Trakt.
+
+| Method | Path | Notes |
+| --- | --- | --- |
+| `GET` | `/lists` | Each list with its item count. |
+| `POST` | `/lists` | `{ name, kind }`. |
+| `PATCH` | `/lists/:id` | `{ name }`. |
+| `DELETE` | `/lists/:id` | |
+| `GET` | `/lists/:listId/items` | Items with metadata joined; anything still missing metadata falls back to the title captured when it was added, and a backfill is queued. |
+| `POST` | `/lists/:listId/items` | `{ type, imdbId, title? }`. `409` if already present. |
+| `DELETE` | `/lists/:listId/items/:type/:imdbId` | |
+| `DELETE` | `/lists/:listId/items/:imdbId?type=` | Infers the type when only one item matches; `400` asking for `?type=` when a movie and a series share the id. |
+| `GET` | `/items/:imdbId/lists?type=` | Which of your lists hold this title. |
+
+### Tags
+
+| Method | Path | Notes |
+| --- | --- | --- |
+| `GET` | `/tags` | All tags with counts. |
+| `GET` | `/tags?type=&imdbId=` | Tags on one item. Both params or neither. |
+| `POST` | `/tags` | `{ name }`, max 50 chars. Returns the existing tag if the name is taken. |
+| `DELETE` | `/tags/:tagId` | |
+| `POST` | `/tags/assign` | `{ tagName, type, imdbId }`. Creates the tag if needed; idempotent. |
+| `DELETE` | `/tags/assign` | `{ tagId, type, imdbId }`. |
+
+### Calendar
+
+| Method | Path | Notes |
+| --- | --- | --- |
+| `GET` | `/calendar?days=` | Upcoming episodes for shows you follow. `days` is 1–90, default 30. Respects the spoiler-protection setting. |
+
+### Games
+
+Needs `TWITCH_CLIENT_ID` / `TWITCH_CLIENT_SECRET` for search, and
+`STEAM_API_KEY` / `STEAM_ID` for library sync.
+
+| Method | Path | Notes |
+| --- | --- | --- |
+| `GET` | `/games?sort=` | `recent` (default), `playtime` or `rating`. |
+| `GET` | `/games/search?q=` | IGDB search, each result flagged `inLibrary`. |
+| `POST` | `/games` | `{ igdbId, title, coverUrl?, releaseDate?, genres? }`. `409` if already held. |
+| `PATCH` | `/games/:id` | `{ rating?, notes?, finished?, finishedAt? }`. Marking `finished` stamps today unless a date is given; un-marking clears it. |
+| `DELETE` | `/games/:id` | |
+| `GET` | `/games/steam/status` | Reports `configured: true` even if the player-summary lookup fails — the summary is display only. |
+| `POST` | `/games/steam/sync` | Syncs into the calling profile. |
+
+### Profiles API
+
+| Method | Path | Notes |
+| --- | --- | --- |
+| `GET` | `/profiles` | |
+| `POST` | `/profiles` | `{ name, avatar?, pin? }`. |
+| `PATCH` | `/profiles/:id` | |
+| `DELETE` | `/profiles/:id` | |
+| `POST` | `/profiles/:id/verify` | `{ pin }` → a profile token for `x-profile-token`. Rate limited. |
+
+### Settings and API keys
+
+Keys saved here take precedence over the matching environment variable, so a
+rotated key doesn't mean editing `.env` and restarting.
+
+| Method | Path | Notes |
+| --- | --- | --- |
+| `GET` | `/settings/preferences` | Language, region, spoiler protection, and the provider catalogue. |
+| `POST` | `/settings/preferences` | `{ language?, region?, spoilerProtection? }`. Language is `en` or `en-US` shaped; region is two letters. Both are normalized. Clears the discovery cache. |
+| `GET` | `/settings/job-status` | Background jobs that are currently failing — the Steam sync, Trakt poll, episode notifications, AI refresh. Otherwise these are only visible in the logs. |
+| `GET` | `/tmdb/status` | `{ configured, source }` where source is `db`, `env` or `none`. |
+| `POST` | `/tmdb/key` | Validated against TMDB before saving, so a typo can't overwrite a working key. |
+| `DELETE` | `/tmdb/key` | Reports the env fallback that remains, if any. |
+| `GET`/`POST`/`DELETE` | `/omdb/status`, `/omdb/key` | Validated against OMDb; its error text is passed through. |
+| `GET`/`POST`/`DELETE` | `/rpdb/status`, `/rpdb/key` | Not validated on save. |
+| `GET` | `/rpdb/poster/:imdbId` | `404` when no key is set. |
+| `GET` | `/rpdb/config` | Used by the add-on service, which needs the key to build poster URLs itself. |
+
+### AI recommendations
+
+Any OpenAI-compatible chat-completions endpoint, including a local one.
+
+| Method | Path | Notes |
+| --- | --- | --- |
+| `GET` | `/ai/config` | Headers are redacted. Includes `lastGeneratedAt`. |
+| `POST` | `/ai/config` | `{ config: { url, headers, payload: { model, max_tokens? } } }`. `max_tokens` below 2048 is clamped up — under that, responses truncate mid-JSON. |
+| `DELETE` | `/ai/config` | |
+| `POST` | `/ai/test` | Sends one trivial prompt. Reports the status code on failure and never the upstream body, so it can't be used as an SSRF probe. Redirects are not followed. |
+| `GET` | `/recommendations/ai?type=&limit=` | With reasons per title. Falls back to TMDB seeds when no provider is configured. `limit` caps at 20. |
+| `POST` | `/recommendations/ai/refresh` | Drops the cached set; the next request regenerates. |
+
+URLs are checked twice: syntactically on save, and against DNS immediately
+before each outbound request — records can change after a config is saved.
+
+### Trakt
+
+| Method | Path | Notes |
+| --- | --- | --- |
+| `GET` | `/trakt/status` | |
+| `GET` | `/trakt/oauth/authorize` | Starts the flow. |
+| `GET` | `/trakt/oauth/callback` | The redirect target. No bearer token; bound to the flow by `state`. |
+| `POST` | `/trakt/import` | One-time history import. |
+| `POST` | `/trakt/poll` | Run the scheduled poll now. |
+| `POST` | `/trakt/disconnect` | |
+
+### Stremio library
+
+| Method | Path | Notes |
+| --- | --- | --- |
+| `GET` | `/stremio/library/status` | |
+| `POST` | `/stremio/library/connect` | `{ email, password }`. Takes a baseline without recording history, so connecting an account with years of history doesn't backdate a flood of watch events. If the baseline fails the connection is undone — a connection with no baseline would make the next incremental pass treat the whole library as newly watched. |
+| `POST` | `/stremio/library/import` | The opt-in backfill, dated from Stremio's own `lastWatched`. |
+| `POST` | `/stremio/library/sync` | The incremental pass, on demand. |
+| `POST` | `/stremio/library/disconnect` | |
+| `POST` | `/stremio/play-signal` | Written by the add-on service. The profile id in the body is validated, not trusted. |
+| `GET` | `/stremio/play-signals` | Diagnostics: what the add-on has seen but not yet acted on. |
+
+### Stremio add-on
+
+These serve Stremio clients directly. The `:secret` variants are the per-profile
+URLs; the unprefixed ones use the default profile.
+
+| Method | Path |
+| --- | --- |
+| `GET` | `/addon/stremio/manifest.json` |
+| `GET` | `/addon/stremio/catalog/:type/:id.json` |
+| `GET` | `/addon/stremio/configure` |
+| `GET` | `/addon/stremio/:secret/manifest.json` |
+| `GET` | `/addon/stremio/:secret/catalog/:type/:id.json` |
+| `GET` | `/addon/stremio/:secret/configure` |
+| `GET`/`POST` | `/addon/config` |
+
+Catalog data also has plain-JSON equivalents used by the web UI: `/watchlist`,
+`/continue`, `/recent`, `/stremio/list/:listId`, and
+`/stremio/catalog/my_{watchlist_movies,watchlist_series,continue_series,recent_movies}`.
+
+### Push notifications
+
+| Method | Path | Notes |
+| --- | --- | --- |
+| `GET` | `/push/public-key` | VAPID public key. |
+| `POST` | `/push/subscribe` | `{ endpoint, keys: { p256dh, auth } }`. The endpoint must resolve to a real push service over https — including its DNS result — so a stolen API token can't turn the notification job into an SSRF proxy. |
+| `POST` | `/push/unsubscribe` | `{ endpoint }`. |
+
+### Export and import
+
+| Method | Path | Notes |
+| --- | --- | --- |
+| `GET` | `/export` | The profile's data as JSON: lists and their items, watch events, series progress, and ratings. |
+| `POST` | `/import` | Restores an `/export` payload. |
+| `POST` | `/import/csv` | Header must include `imdbId,type,watchedAt`; `season,episode` optional. |
+| `POST` | `/import/external` | `{ format, csv }` where format is `letterboxd-diary`, `letterboxd-ratings`, `imdb-ratings` or `simkl`. |
+
+Letterboxd exports carry no IMDb ids, so each unique title costs a TMDB search.
+Those two formats are capped at 10,000 rows; the id-carrying formats get the
+higher `MAX_IMPORT_ROWS` ceiling. Over the cap is a `413` with
+`code: "too_many_rows"`.
+
+### Webhooks
+
+No bearer token. Authenticated by `WEBHOOK_SECRET`, in a header where the
+sender supports one and in a query parameter where it doesn't (Plex). Secrets
+in query parameters are redacted from the logs.
+
+| Method | Path |
+| --- | --- |
+| `POST` | `/webhooks/plex` |
+| `POST` | `/webhooks/jellyfin` |
+
+Set `WEBHOOK_ALLOWED_IPS` to also restrict them by source address. See the
+[webhook secret placement](../README.md#webhook-secret-placement) section of the
+README for which field each server can actually send.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,340 @@
+# Troubleshooting
+
+Things that go wrong when self-hosting Cataloggy, and what they actually mean.
+Most are configuration rather than bugs — if something here doesn't match what
+you're seeing, [open an issue](https://github.com/TheShield2594/cataloggy/issues).
+
+Two things to check before anything else:
+
+```bash
+docker compose ps          # is everything actually up?
+docker compose logs api    # the API logs the reason it refused to start
+pnpm smoke                 # end-to-end check of the health and catalog endpoints
+```
+
+- [Startup](#startup)
+- [Nothing loads in the browser](#nothing-loads-in-the-browser)
+- [Posters and metadata are missing](#posters-and-metadata-are-missing)
+- [Watch history isn't appearing](#watch-history-isnt-appearing)
+- [The Stremio add-on](#the-stremio-add-on)
+- [Trakt](#trakt)
+- [Import and export](#import-and-export)
+- [Notifications](#notifications)
+- [Games](#games)
+- [AI recommendations](#ai-recommendations)
+- [Database and migrations](#database-and-migrations)
+- [Still stuck](#still-stuck)
+
+## Startup
+
+### "Refusing to start in production due to configuration problems"
+
+The API checks four things before it will start in production, and names the
+ones that failed:
+
+| Message | Fix |
+| --- | --- |
+| `API_TOKEN is not set` | `openssl rand -hex 32` into `.env` |
+| `API_TOKEN is set to the development default "dev-token"` | As above — `dev-token` is fine locally, never in production |
+| `DATABASE_URL is not set` | Set it, or let compose build it from `POSTGRES_PASSWORD` |
+| `DATABASE_URL uses the development default Postgres password` | Change `POSTGRES_PASSWORD` from `postgres` |
+
+This is deliberate. All four leave the API reachable by anyone who can route to
+it, and every one of them is easy to leave behind after a local trial run.
+
+### "WEBHOOK_SECRET not set — webhook endpoints will reject all requests"
+
+A warning, not a failure. Everything else works; only the Plex and Jellyfin
+webhooks are disabled. Set `WEBHOOK_SECRET` if you use them.
+
+### The `api` container restarts in a loop
+
+It waits on `migrate` completing and Postgres being healthy. Check those first:
+
+```bash
+docker compose logs migrate
+docker compose logs db
+```
+
+A failed migration is the usual cause — see
+[Database and migrations](#database-and-migrations).
+
+### Compose refuses to start at all
+
+`API_TOKEN` and `POSTGRES_PASSWORD` are required and have no defaults. Compose
+fails rather than silently starting an unauthenticated stack.
+
+## Nothing loads in the browser
+
+### Works on the server, not from your phone
+
+The most common setup problem. `localhost` in the URLs means "this device", so a
+phone loading the page tries to reach *itself*.
+
+Every public URL in `.env` has to be the LAN IP (or domain) the client actually
+uses:
+
+```
+CATALOGGY_API_PUBLIC=http://192.168.1.25:7000
+CATALOGGY_WEB_PUBLIC=http://192.168.1.25:7002
+ADDON_PUBLIC_BASE=http://192.168.1.25:7001
+VITE_API_BASE=http://192.168.1.25:7000
+VITE_ADDON_BASE=http://192.168.1.25:7001
+CATALOGGY_ALLOWED_ORIGINS=http://192.168.1.25:7002
+```
+
+`VITE_*` are baked in at build time, so rebuild after changing them:
+
+```bash
+docker compose up -d --build web
+```
+
+The internal ones (`CATALOGGY_API_BASE`, pointing at `http://api:7000`) stay as
+they are — that's service-to-service traffic inside the Docker network, and it
+doesn't go via your LAN.
+
+### Blocked by CORS
+
+The browser's origin has to be in `CATALOGGY_ALLOWED_ORIGINS`. Scheme, host and
+port all have to match — `http://192.168.1.25:7002` and
+`http://cataloggy.local` are two different origins, so list both if you use
+both.
+
+### Blank page behind a reverse proxy
+
+Add the hostname to `ALLOWED_HOSTS` on the `web` service. Without it, the web
+server only answers to IPs and localhost.
+
+If the API is reachable at a different address than `VITE_API_BASE` — a
+per-browser override under Settings, say — add that origin to
+`CSP_CONNECT_SRC_EXTRA` too, or the Content-Security-Policy blocks the request.
+
+### 401 on every request
+
+The browser's stored API token doesn't match `API_TOKEN`. Re-enter it in
+Settings. A bearer-token failure carries a `WWW-Authenticate: Bearer` header,
+which is how the client distinguishes it from other 401s such as a wrong
+profile PIN.
+
+### "Too many requests"
+
+200 requests/minute per IP. Behind a reverse proxy without `TRUST_PROXY` set
+correctly, every client looks like the proxy and shares one budget — that's the
+usual cause of this appearing out of nowhere.
+
+## Posters and metadata are missing
+
+Cataloggy needs a TMDB API key for essentially all metadata. Without one, search
+returns `500` with "TMDB integration is not configured".
+
+Set it in **Settings → TMDB Metadata** (the setup wizard also asks). A key saved
+there beats the `TMDB_API_KEY` environment variable, so a rotated key doesn't
+mean editing `.env` and restarting. The key is validated against TMDB before it
+saves, so a typo can't overwrite a working one.
+
+- **Some titles have no poster** — TMDB has no image for them. Adding an RPDB
+  key gives rating-badge posters instead.
+- **Metadata is stale** — `POST /metadata/refresh-all` re-fetches in batches. It
+  is rate-limit friendly by design and caps at 500 titles per call.
+- **Posters don't load offline** — the service worker caches them as they're
+  first fetched, so a title you've never opened online won't be there.
+
+## Watch history isn't appearing
+
+Cataloggy doesn't play anything, so history has to come from somewhere else.
+Check which source you expect:
+
+### Stremio play detection
+
+Off by default. Set `STREMIO_PLAY_DETECTION=true` and install the add-on.
+
+It works by inference: the add-on sees a stream or subtitle request and records
+a *signal*, which becomes a watch once the title's runtime has elapsed. So:
+
+- A watch appears roughly one runtime after you start, not immediately.
+- Something you started and abandoned won't count. That's intentional.
+- `GET /stremio/play-signals` shows what the add-on has seen but not yet acted
+  on — the fastest way to tell "my client isn't reaching the add-on" apart from
+  "it is, and the timer hasn't elapsed".
+
+### Stremio library sync
+
+Also off by default (`STREMIO_POLL_INTERVAL_SEC=0`). It reads Stremio's own
+watched state rather than inferring it.
+
+Connecting an account takes a *baseline* — it learns the current state without
+recording it, so years of history don't land as a flood of backdated watch
+events. `POST /stremio/library/import` is the opt-in backfill.
+
+One known limitation: Stremio reports the episode you're *on*, so several
+episodes finished within a single poll interval collapse into the latest one.
+Two minutes is a reasonable interval; the default of `0` disables it entirely.
+
+### Plex / Jellyfin webhooks
+
+1. `WEBHOOK_SECRET` must be set (the API warns at startup if it isn't).
+2. The webhook URL must be reachable from the media server — the LAN IP, not
+   `localhost`.
+3. Plex can't send custom headers, so its secret goes in a query parameter.
+   Jellyfin can use a header. See
+   [webhook secret placement](../README.md#webhook-secret-placement).
+4. If you set `WEBHOOK_ALLOWED_IPS`, `TRUST_PROXY` has to be right or every
+   request appears to come from the proxy.
+
+Query-parameter secrets are redacted from the logs, so you won't see the token
+echoed back when debugging — that's deliberate, not a truncated log line.
+
+### A show won't leave Continue Watching
+
+Drop it: `POST /show/:imdbId/drop`, or the control in the detail panel. This
+hides it without deleting history, and `DELETE` on the same path undoes it.
+
+## The Stremio add-on
+
+- **Manifest won't install** — `ADDON_PUBLIC_BASE` has to be the address the
+  *client* can reach, not the internal one. An Apple TV cannot resolve
+  `http://addon:7001`.
+- **Catalogs are empty** — they're per-profile. Check you installed the URL for
+  the profile whose data you expect; each profile has its own secret path.
+- **"Configure" goes nowhere** — that link is built from
+  `CATALOGGY_WEB_PUBLIC`.
+- **Add-on can't reach the API** — that one *is* internal:
+  `CATALOGGY_API_BASE=http://api:7000`. Only change it if you renamed the
+  service.
+
+## Trakt
+
+- **OAuth fails** — the redirect URI registered on trakt.tv has to match exactly
+  what Cataloggy builds from `CATALOGGY_API_PUBLIC`. A trailing slash counts as
+  a mismatch.
+- **The callback 400s** — the `state` value expired or didn't match. Start the
+  flow again; it's bound to the browser session that began it.
+- **History isn't syncing** — `TRAKT_POLL_INTERVAL_SEC=0` disables the scheduled
+  poll. `POST /trakt/poll` runs it once, on demand.
+- **Removals don't propagate** — mirroring deletes to Trakt is opt-in:
+  `TRAKT_WATCHLIST_MIRROR_DELETES=true`. Adds always mirror.
+- **A sync failed and you didn't notice** — **Settings → Sync Status**
+  surfaces failing scheduled jobs, which otherwise only appear in the logs.
+
+## Import and export
+
+- **413 with `code: "body_too_large"`** — raise `MAX_BODY_SIZE_MB` (default 10).
+  A large backup restore is the usual cause.
+- **413 with `code: "too_many_rows"`** — Letterboxd formats cap at 10,000 rows
+  because each unique title costs a TMDB search; the id-carrying formats
+  (`imdb-ratings`, `simkl`, native JSON) allow far more. Split the file.
+- **Letterboxd rows are skipped** — those exports carry no IMDb ids, so titles
+  are resolved against TMDB by name and year. Ambiguous or obscure titles won't
+  match. Rows that do match are still imported; the response summary counts both.
+- **"Unrecognized IMDb ratings export header"** — the file has to be IMDb's own
+  export, which has a `Const` column. A spreadsheet re-save can drop it.
+
+## Notifications
+
+- **Nothing arrives** — push needs VAPID keys and https (or localhost); browsers
+  refuse service-worker push over plain http on a LAN IP. This is a browser
+  rule, not something Cataloggy can work around.
+- **Subscribing returns 400** — the endpoint must be a real push service over
+  https, and it's checked by DNS as well as by name. That check exists so a
+  stolen API token can't point the notification job at an internal address.
+- **Nothing on iOS** — the site has to be added to the home screen first. Safari
+  doesn't deliver push to a tab.
+- **Set `NOTIFICATION_CHECK_INTERVAL_SEC=0`** and the episode check is disabled
+  entirely; the API logs this at startup.
+
+## Games
+
+The Games tab needs at least one integration to be useful, and they do different
+jobs:
+
+- **Adding a game** is an IGDB search — needs `TWITCH_CLIENT_ID` and
+  `TWITCH_CLIENT_SECRET`.
+- **Library and playtime sync** needs `STEAM_API_KEY` and `STEAM_ID`.
+
+With neither, the tab has no way to populate itself. `502` from search means
+IGDB is unreachable; `500` means the credentials are missing.
+
+`STEAM_ID` is the 64-bit numeric id, not the vanity URL name. Your Steam profile
+must also be public for the API to return anything.
+
+If `STEAM_SYNC_INTERVAL_SEC` is out of range the API refuses to start and says
+so — timer delays are a 32-bit value underneath, and a too-large one fires
+immediately instead of waiting, hammering the sync in a loop.
+
+## AI recommendations
+
+Optional. Without a provider configured, recommendations fall back to TMDB's
+own similar-titles data.
+
+- **Test fails with just "HTTP 500"** — that's on purpose. Echoing the provider's
+  response body back would make the endpoint an SSRF probe, so only the status
+  code is reported. Check the provider's own logs.
+- **"url resolves to an address that is not an allowed outbound target"** — the
+  hostname resolves somewhere blocked (cloud metadata, link-local). A LAN LLM on
+  a normal private address is fine.
+- **Recommendations are truncated or empty** — `max_tokens` was too low. Values
+  under 2048 are clamped up automatically, since below that the model reliably
+  truncates its JSON mid-response.
+- **Results feel stale** — they're cached and refreshed daily.
+  `POST /recommendations/ai/refresh` drops the cache.
+
+## Database and migrations
+
+### A migration failed
+
+```bash
+docker compose logs migrate
+```
+
+Restore from a backup and retry, rather than editing the schema by hand:
+
+```bash
+./scripts/restore.sh backups/cataloggy-<timestamp>.sql.gz
+```
+
+Take a backup before every update — `./scripts/backup.sh`. See
+[Updating safely](../README.md#updating-safely--if-a-migration-fails).
+
+### Images are on mismatched versions
+
+Keep all four (`api`, `addon`, `web`, `migrate`) on one `CATALOGGY_IMAGE_TAG`.
+The `migrate` image applies the schema the `api` image expects; mixing them is
+how you get a running API against a schema it doesn't understand.
+
+Unset, the tag means `latest`, which follows the most recent build of `main` —
+`docker compose pull` can move you onto an untested build with nothing to fall
+back to. Pin it:
+
+```
+CATALOGGY_IMAGE_TAG=v1.2.0
+```
+
+Rolling back is the same two commands with the previous tag.
+
+### Resetting everything
+
+Destroys all data:
+
+```bash
+docker compose down -v
+docker compose up --build
+```
+
+## Still stuck
+
+Useful things to gather first:
+
+```bash
+docker compose ps
+docker compose logs --tail=100 api
+curl -sS -H "Authorization: Bearer $API_TOKEN" http://localhost:7000/health
+pnpm smoke
+```
+
+Also worth a look: **Settings → Sync Status**, which surfaces scheduled jobs
+that are currently failing. If you've set `SENTRY_DSN`, unhandled errors are
+there too — it's off by default, and no error data leaves your server without it.
+
+When opening an issue, include the logs above, your Cataloggy version
+(`CATALOGGY_IMAGE_TAG`), and a redacted `.env` — please strip `API_TOKEN`,
+`POSTGRES_PASSWORD`, `WEBHOOK_SECRET`, and every API key before posting.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -218,11 +218,14 @@ hides it without deleting history, and `DELETE` on the same path undoes it.
 
 ## Import and export
 
-- **413 with `code: "body_too_large"`** — raise `MAX_BODY_SIZE_MB` (default 10).
-  A large backup restore is the usual cause.
-- **413 with `code: "too_many_rows"`** — Letterboxd formats cap at 10,000 rows
-  because each unique title costs a TMDB search; the id-carrying formats
-  (`imdb-ratings`, `simkl`, native JSON) allow far more. Split the file.
+- **413 with `code: "body_too_large"`** — the request body outgrew
+  `MAX_BODY_SIZE_MB` (default 32, allowed range 1–1024). A large backup restore
+  is the usual cause. Raise it and restart the API.
+- **413 with `code: "too_many_rows"`** — a different limit, counted in rows
+  rather than bytes, so raising `MAX_BODY_SIZE_MB` won't help. Letterboxd
+  formats cap at 10,000 rows because each unique title costs a TMDB search; the
+  id-carrying formats (`imdb-ratings`, `simkl`, native JSON) cap at 200,000 per
+  collection. Split the file.
 - **Letterboxd rows are skipped** — those exports carry no IMDb ids, so titles
   are resolved against TMDB by name and year. Ambiguous or obscure titles won't
   match. Rows that do match are still imported; the response summary counts both.


### PR DESCRIPTION
Thirteen route modules had no test file at all — among them lists and tags
(the core of organising anything), settings (where every API key is saved),
and ai (which reaches an outbound provider on the user's behalf). Between
them roughly 1,800 lines of request handling had nothing pinning its
behaviour down, so a refactor could quietly change a status code, drop a
profile scope, or start echoing an upstream body and no test would notice.

These follow the pattern the existing route tests already use: register the
plugin against a bare Fastify instance, mock at the lib boundary, and assert
on what the handler did rather than on how it did it. The cases worth having
are the ones that encode a decision — a watchlist mirrors to Trakt but a
custom list does not, an ambiguous imdbId is a 400 rather than a double
delete, /ai/test reports a status code and never the upstream body, a
Stremio baseline failure undoes the connection instead of leaving it to
flood on the next pass.

706 API tests, up from 486.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive API reference covering authentication, profiles, endpoints, validation, caching, errors, and security.
  * Added a self-hosting troubleshooting guide for configuration, networking, integrations, migrations, and recovery.
  * Added links to the new documentation and highlighted common localhost setup issues.

* **Tests**
  * Expanded automated coverage across health, metadata, discovery, games, lists, settings, streaming, notifications, integrations, search, tags, AI features, and other API routes.
  * Added validation for error handling, authorization, profile scoping, caching, fallback behavior, and security protections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->