### PR TITLE
Make the web app pass WCAG 2.2 AA

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -57,6 +57,36 @@ const LoadingFallback = ({ label = "Loading…" }: { label?: string }) => (
   <GhostLoader label={label} className="items-center py-24" />
 );
 
+/**
+ * What each route calls itself in the tab strip and the history menu.
+ *
+ * `index.html` ships one <title> for the whole app, which is right for the
+ * document the server sends and wrong for every screen after it: a router that
+ * never touches document.title leaves nine destinations all announcing
+ * "Cataloggy", so the tab strip, the back-button menu and a screen reader's
+ * page-title announcement carry no information at all.
+ *
+ * Kept beside the <Routes> below rather than on each page, so a new route can't
+ * be added without the omission being visible here.
+ */
+const ROUTE_TITLES: Record<string, string> = {
+  "/": "Dashboard",
+  "/search": "Search",
+  "/lists": "Lists",
+  "/games": "Games",
+  "/calendar": "Calendar",
+  "/history": "Watch History",
+  "/stats": "Watch Statistics",
+  "/settings": "Settings",
+};
+
+const APP_NAME = "Cataloggy";
+
+export function routeTitle(pathname: string): string {
+  const name = ROUTE_TITLES[pathname];
+  return name ? `${name} · ${APP_NAME}` : `Page not found · ${APP_NAME}`;
+}
+
 // The switcher is a full-screen modal, so suspending it to nothing would blank the
 // screen between the click and the chunk arriving. Hold the overlay instead.
 const ProfileSwitcherFallback = () => (
@@ -179,6 +209,12 @@ function AppShell({
     mainRef.current?.focus();
   }, [location.pathname]);
 
+  // Runs on the first render too, unlike the focus move above: the landing
+  // route needs a title as much as a navigated-to one does.
+  useEffect(() => {
+    document.title = routeTitle(location.pathname);
+  }, [location.pathname]);
+
   useEffect(() => {
     let cancelled = false;
     const currentId = runtimeConfig.getProfileId();
@@ -208,7 +244,7 @@ function AppShell({
         href="#main-content"
         // `not-sr-only` zeroes the padding it restores, so the box has to be
         // rebuilt under the same variant rather than set unconditionally.
-        className="sr-only rounded-xl text-sm font-semibold shadow-e2 focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-[200] focus:px-4 focus:py-2.5 focus:outline-none focus:ring-2 focus:ring-claw-400"
+        className="sr-only rounded-xl text-sm font-semibold shadow-e2 focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-[200] focus:px-4 focus:py-2.5 focus:outline-none focus:ring-2 focus:ring-focus"
         style={{ background: "var(--bg-1)", color: "var(--text)", border: "1px solid var(--border-strong)" }}
       >
         Skip to main content
@@ -275,7 +311,7 @@ function AppShell({
               onClick={openSwitcher}
               aria-label={profile ? `Switch profile (currently ${profile.name})` : "Switch profile"}
               title={profile?.name}
-              className="flex h-11 w-11 flex-none items-center justify-center rounded-full transition-colors hover:bg-[var(--surface-strong)] focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-400 focus-ring-offset sm:hidden"
+              className="flex h-11 w-11 flex-none items-center justify-center rounded-full transition-colors hover:bg-[var(--surface-strong)] focus:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-ring-offset sm:hidden"
               style={{ color: "var(--text-mute)" }}
             >
               <User className="h-5 w-5" />

--- a/apps/web/src/components/CommandPalette.test.tsx
+++ b/apps/web/src/components/CommandPalette.test.tsx
@@ -192,6 +192,71 @@ describe("CommandPalette", () => {
     }
   });
 
+  // Whatever aria-activedescendant names has to be in the document. Two ways it
+  // could stop being: a search that leaves the previous titles in state while it
+  // runs (the title rows come off screen, but the row count they contributed
+  // doesn't), and a list that empties under a highlight the arrow keys have
+  // already moved.
+  const activeDescendantIsRendered = (input: HTMLElement) => {
+    const id = input.getAttribute("aria-activedescendant");
+    if (id === null) return;
+    const target = document.getElementById(id);
+    expect(target).not.toBeNull();
+    expect(target).toHaveAttribute("role", "option");
+  };
+
+  it("never points at a row that isn't rendered", async () => {
+    const user = userEvent.setup();
+    search.mockImplementation(async (type) => (type === "movie" ? [result("Solaris")] : []));
+    renderPalette();
+
+    const input = screen.getByLabelText("Search everything");
+    await user.type(input, "se");
+    await screen.findByRole("option", { name: /Solaris/ });
+    activeDescendantIsRendered(input);
+
+    // A second search, held open. The Solaris row is gone from the screen while
+    // it runs, but it is still in `results`. One shared promise, so releasing it
+    // settles every call the debounce made rather than only the last.
+    let release: () => void = () => {};
+    const pending = new Promise<SearchResult[]>((r) => { release = () => r([]); });
+    search.mockImplementation((type) => (type === "movie" ? pending : Promise.resolve([])));
+    await user.type(input, "a");
+
+    // The visible line spells it with three dots; the live region uses an
+    // ellipsis, so an exact string picks out the one on screen.
+    await waitFor(() => {
+      expect(screen.getByText("Searching...")).toBeInTheDocument();
+      expect(screen.queryByRole("option", { name: /Solaris/ })).not.toBeInTheDocument();
+    });
+    activeDescendantIsRendered(input);
+
+    await user.keyboard("{ArrowDown}");
+    activeDescendantIsRendered(input);
+
+    release();
+    await waitFor(() => expect(screen.queryByText("Searching...")).not.toBeInTheDocument());
+    activeDescendantIsRendered(input);
+  });
+
+  it("points at nothing when there are no options to point at", async () => {
+    const user = userEvent.setup();
+    search.mockResolvedValue([]);
+    renderPalette();
+
+    const input = screen.getByLabelText("Search everything");
+    // A query no title and no action label matches, so the listbox is empty.
+    await user.type(input, "zzzz");
+
+    await waitFor(() => expect(screen.queryAllByRole("option")).toHaveLength(0));
+    expect(input).not.toHaveAttribute("aria-activedescendant");
+    expect(input).toHaveAttribute("aria-expanded", "false");
+
+    await user.keyboard("{ArrowDown}");
+    expect(input).not.toHaveAttribute("aria-activedescendant");
+    activeDescendantIsRendered(input);
+  });
+
   it("says search is unavailable instead of reporting no matches", async () => {
     const user = userEvent.setup();
     search.mockRejectedValue(new Error("TMDB is not configured"));

--- a/apps/web/src/components/CommandPalette.test.tsx
+++ b/apps/web/src/components/CommandPalette.test.tsx
@@ -120,7 +120,7 @@ describe("CommandPalette", () => {
 
     await user.type(screen.getByLabelText("Search everything"), "settings");
 
-    expect(screen.getByRole("button", { name: /go to settings/i })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: /go to settings/i })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /go to lists/i })).not.toBeInTheDocument();
   });
 
@@ -130,7 +130,7 @@ describe("CommandPalette", () => {
     renderPalette();
 
     await user.type(screen.getByLabelText("Search everything"), "sol");
-    await user.click(await screen.findByRole("button", { name: /Solaris/ }));
+    await user.click(await screen.findByRole("option", { name: /Solaris/ }));
 
     expect(await screen.findByText("Detail panel: Solaris")).toBeInTheDocument();
     expect(path()).toBe("/");
@@ -142,11 +142,11 @@ describe("CommandPalette", () => {
     renderPalette();
 
     await user.type(screen.getByLabelText("Search everything"), "sol");
-    await user.click(await screen.findByRole("button", { name: /Solaris/ }));
+    await user.click(await screen.findByRole("option", { name: /Solaris/ }));
     await user.click(screen.getByRole("button", { name: "close panel" }));
 
     expect(await screen.findByLabelText("Search everything")).toHaveValue("sol");
-    expect(screen.getByRole("button", { name: /Solaris/ })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: /Solaris/ })).toBeInTheDocument();
   });
 
   it("Enter on the highlighted title opens it rather than running an action", async () => {
@@ -155,10 +155,41 @@ describe("CommandPalette", () => {
     renderPalette();
 
     await user.type(screen.getByLabelText("Search everything"), "sol");
-    await screen.findByRole("button", { name: /Solaris/ });
+    await screen.findByRole("option", { name: /Solaris/ });
     await user.keyboard("{Enter}");
 
     expect(await screen.findByText("Detail panel: Solaris")).toBeInTheDocument();
+  });
+
+  // Arrow keys move a highlight that decides what Enter does, while focus stays
+  // in the input so typing keeps working. Which means the highlight has to be
+  // published as `aria-activedescendant` — a background colour is not a state.
+  it("publishes the highlighted row, not just its background", async () => {
+    const user = userEvent.setup();
+    search.mockImplementation(async (type) => (type === "movie" ? [result("Solaris")] : []));
+    renderPalette();
+
+    const input = screen.getByLabelText("Search everything");
+    // "se" so the list holds the title *and* the actions it matches — with a
+    // single option there is nowhere for ArrowDown to go.
+    await user.type(input, "se");
+    const solaris = await screen.findByRole("option", { name: /Solaris/ });
+
+    expect(input).toHaveAttribute("role", "combobox");
+    expect(input).toHaveAttribute("aria-expanded", "true");
+    expect(solaris).toHaveAttribute("aria-selected", "true");
+    expect(input).toHaveAttribute("aria-activedescendant", solaris.id);
+
+    await user.keyboard("{ArrowDown}");
+
+    await waitFor(() => {
+      expect(solaris).toHaveAttribute("aria-selected", "false");
+      expect(input.getAttribute("aria-activedescendant")).not.toBe(solaris.id);
+    });
+    // The options are reached through the input, so none of them is a tab stop.
+    for (const option of screen.getAllByRole("option")) {
+      expect(option).toHaveAttribute("tabindex", "-1");
+    }
   });
 
   it("says search is unavailable instead of reporting no matches", async () => {

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -126,7 +126,16 @@ export function CommandPalette({ open, onClose }: { open: boolean; onClose: () =
     ? actions.filter((a) => a.label.toLowerCase().includes(query.toLowerCase()))
     : actions;
 
-  const totalItems = results.length + visibleActions.length;
+  /*
+   * The titles actually on screen, which is not the same as `results`: a newer
+   * search leaves the previous results in state while it is in flight, and the
+   * title group is not rendered during one. Everything that indexes rows —
+   * the option ids, the count the arrow keys clamp to, what Enter opens — has
+   * to agree with what was rendered, or `aria-activedescendant` names an
+   * element that isn't in the document.
+   */
+  const shownResults = searching ? [] : results;
+  const totalItems = shownResults.length + visibleActions.length;
 
   /*
    * The palette is a combobox over a list, and it was none of that in the
@@ -144,6 +153,9 @@ export function CommandPalette({ open, onClose }: { open: boolean; onClose: () =
   const listId = useId();
   const optionId = (index: number) => `${listId}-option-${index}`;
   const hasList = totalItems > 0;
+  // `activeIndex` is only clamped when an arrow key moves it, so a list that
+  // shrinks underneath it can leave it past the end until the next keypress.
+  const activeOptionId = hasList && activeIndex < totalItems ? optionId(activeIndex) : undefined;
 
   // Empty until a query has been typed — an announcement on open would be
   // "10 commands" before the user has asked anything.
@@ -166,11 +178,11 @@ export function CommandPalette({ open, onClose }: { open: boolean; onClose: () =
       setActiveIndex((i) => Math.max(i - 1, 0));
     } else if (e.key === "Enter") {
       e.preventDefault();
-      if (activeIndex < results.length) {
-        const r = results[activeIndex];
+      if (activeIndex < shownResults.length) {
+        const r = shownResults[activeIndex];
         if (r) openDetail(r);
       } else {
-        const action = visibleActions[activeIndex - results.length];
+        const action = visibleActions[activeIndex - shownResults.length];
         if (action) action.run();
         else if (query.trim()) goToSearch(query);
       }
@@ -238,7 +250,7 @@ export function CommandPalette({ open, onClose }: { open: boolean; onClose: () =
             role="combobox"
             aria-expanded={hasList}
             aria-controls={hasList ? listId : undefined}
-            aria-activedescendant={hasList ? optionId(activeIndex) : undefined}
+            aria-activedescendant={activeOptionId}
             aria-autocomplete="list"
           />
           <kbd
@@ -271,12 +283,12 @@ export function CommandPalette({ open, onClose }: { open: boolean; onClose: () =
           )}
 
           <div id={listId} role="listbox" aria-label="Suggestions">
-            {!searching && results.length > 0 && (
+            {shownResults.length > 0 && (
               <div className="px-2 pb-2" role="group" aria-label="Titles">
                 <p aria-hidden="true" className={`px-2 pb-1 ${MICRO_LABEL}`} style={{ color: "var(--text-mute)" }}>
                   Titles
                 </p>
-                {results.map((r, i) => (
+                {shownResults.map((r, i) => (
                   <button
                     key={r.imdbId}
                     id={optionId(i)}
@@ -317,7 +329,7 @@ export function CommandPalette({ open, onClose }: { open: boolean; onClose: () =
                 </p>
               )}
               {visibleActions.map((action, i) => {
-                const idx = results.length + i;
+                const idx = shownResults.length + i;
                 return (
                   <button
                     key={action.id}

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
 import { useNavigate } from "react-router";
 import { BarChart3, CalendarDays, Clapperboard, Film, Gamepad2, List, Search, Settings, Tv } from "lucide-react";
 import { api, SearchResult } from "../api";
@@ -128,6 +128,35 @@ export function CommandPalette({ open, onClose }: { open: boolean; onClose: () =
 
   const totalItems = results.length + visibleActions.length;
 
+  /*
+   * The palette is a combobox over a list, and it was none of that in the
+   * markup: an <input> beside a stack of <button>s, with the highlighted row
+   * marked by a background colour and nothing else. Arrow keys moved
+   * `activeIndex`, which changed what Enter would do — with no way for a screen
+   * reader to know either the highlight had moved or what it had moved to.
+   *
+   * Focus stays in the input (typing has to keep working), so the highlight is
+   * published with `aria-activedescendant` pointing at the active option's id
+   * rather than by moving focus. That is also why every option carries
+   * `tabIndex={-1}`: they are still <button>s so a pointer user can click them,
+   * but a listbox's options must not be tab stops of their own.
+   */
+  const listId = useId();
+  const optionId = (index: number) => `${listId}-option-${index}`;
+  const hasList = totalItems > 0;
+
+  // Empty until a query has been typed — an announcement on open would be
+  // "10 commands" before the user has asked anything.
+  const listStatus = !query.trim()
+    ? ""
+    : searching
+      ? "Searching…"
+      : searchError
+        ? "Search is unavailable."
+        : totalItems === 0
+          ? `Nothing matches “${query.trim()}”.`
+          : `${totalItems} suggestion${totalItems === 1 ? "" : "s"}.`;
+
   const onKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "ArrowDown") {
       e.preventDefault();
@@ -206,6 +235,11 @@ export function CommandPalette({ open, onClose }: { open: boolean; onClose: () =
             className="w-full bg-transparent text-sm outline-none"
             style={{ color: "var(--text)" }}
             aria-label="Search everything"
+            role="combobox"
+            aria-expanded={hasList}
+            aria-controls={hasList ? listId : undefined}
+            aria-activedescendant={hasList ? optionId(activeIndex) : undefined}
+            aria-autocomplete="list"
           />
           <kbd
             className="rounded px-1.5 py-0.5 text-2xs font-medium"
@@ -214,6 +248,12 @@ export function CommandPalette({ open, onClose }: { open: boolean; onClose: () =
             Esc
           </kbd>
         </div>
+
+        {/* Stays mounted across every state below, which come and go as whole
+            subtrees — a live region that unmounts announces nothing. */}
+        <p className="sr-only" role="status" aria-live="polite" aria-label="Palette results">
+          {listStatus}
+        </p>
 
         <div className="min-h-0 flex-auto overflow-y-auto py-2 sm:max-h-[60vh]">
           {searching && (
@@ -230,58 +270,74 @@ export function CommandPalette({ open, onClose }: { open: boolean; onClose: () =
             <p className="px-4 py-3 text-xs" style={{ color: "var(--text-dim)" }}>No results for "{query}".</p>
           )}
 
-          {!searching && results.length > 0 && (
-            <div className="px-2 pb-2">
-              <p className={`px-2 pb-1 ${MICRO_LABEL}`} style={{ color: "var(--text-mute)" }}>
-                Titles
-              </p>
-              {results.map((r, i) => (
-                <button
-                  key={r.imdbId}
-                  ref={activeIndex === i ? activeRowRef : undefined}
-                  type="button"
-                  onClick={() => openDetail(r)}
-                  onMouseEnter={() => setActiveIndex(i)}
-                  className="flex w-full items-center gap-3 rounded-lg px-2 py-2 text-left transition-colors"
-                  style={{ background: activeIndex === i ? "var(--surface-strong)" : "transparent" }}
-                >
-                  <div className="h-9 w-7 flex-none overflow-hidden rounded" style={{ boxShadow: "0 0 0 1px var(--border)" }}>
-                    <Poster src={r.poster ?? undefined} alt={r.name} className="h-full w-full" sizes="28px" />
-                  </div>
-                  <div className="min-w-0 flex-1">
-                    <p className="truncate text-sm font-medium" style={{ color: "var(--text)" }}>{r.name}</p>
-                    <p className="text-2xs" style={{ color: "var(--text-mute)" }}>
-                      {r.year ?? ""} {r.type === "movie" ? <Film className="inline h-3 w-3" /> : <Tv className="inline h-3 w-3" />}
-                    </p>
-                  </div>
-                </button>
-              ))}
-            </div>
-          )}
-
-          <div className="px-2">
-            {visibleActions.length > 0 && (
-              <p className={`px-2 pb-1 pt-1 ${MICRO_LABEL}`} style={{ color: "var(--text-mute)" }}>
-                Navigate
-              </p>
+          <div id={listId} role="listbox" aria-label="Suggestions">
+            {!searching && results.length > 0 && (
+              <div className="px-2 pb-2" role="group" aria-label="Titles">
+                <p aria-hidden="true" className={`px-2 pb-1 ${MICRO_LABEL}`} style={{ color: "var(--text-mute)" }}>
+                  Titles
+                </p>
+                {results.map((r, i) => (
+                  <button
+                    key={r.imdbId}
+                    id={optionId(i)}
+                    ref={activeIndex === i ? activeRowRef : undefined}
+                    type="button"
+                    role="option"
+                    aria-selected={activeIndex === i}
+                    tabIndex={-1}
+                    onClick={() => openDetail(r)}
+                    onMouseEnter={() => setActiveIndex(i)}
+                    className="flex w-full items-center gap-3 rounded-lg px-2 py-2 text-left transition-colors"
+                    style={{ background: activeIndex === i ? "var(--surface-strong)" : "transparent" }}
+                  >
+                    <div aria-hidden="true" className="h-9 w-7 flex-none overflow-hidden rounded" style={{ boxShadow: "0 0 0 1px var(--border)" }}>
+                      <Poster src={r.poster ?? undefined} alt="" className="h-full w-full" sizes="28px" />
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-sm font-medium" style={{ color: "var(--text)" }}>{r.name}</p>
+                      {/* The type is a bare icon on screen, so the option's name
+                          would otherwise end at the year. */}
+                      <p className="text-2xs" style={{ color: "var(--text-mute)" }}>
+                        {r.year ?? ""}{" "}
+                        {r.type === "movie"
+                          ? <Film aria-hidden="true" className="inline h-3 w-3" />
+                          : <Tv aria-hidden="true" className="inline h-3 w-3" />}
+                        <span className="sr-only">{r.type === "movie" ? "Movie" : "Series"}</span>
+                      </p>
+                    </div>
+                  </button>
+                ))}
+              </div>
             )}
-            {visibleActions.map((action, i) => {
-              const idx = results.length + i;
-              return (
-                <button
-                  key={action.id}
-                  ref={activeIndex === idx ? activeRowRef : undefined}
-                  type="button"
-                  onClick={action.run}
-                  onMouseEnter={() => setActiveIndex(idx)}
-                  className="flex w-full items-center gap-3 rounded-lg px-2 py-2.5 text-left transition-colors"
-                  style={{ background: activeIndex === idx ? "var(--surface-strong)" : "transparent" }}
-                >
-                  <action.icon className="h-4 w-4 flex-none" style={{ color: "var(--text-dim)" }} />
-                  <span className="text-sm" style={{ color: "var(--text)" }}>{action.label}</span>
-                </button>
-              );
-            })}
+
+            <div className="px-2" role="group" aria-label="Navigate">
+              {visibleActions.length > 0 && (
+                <p aria-hidden="true" className={`px-2 pb-1 pt-1 ${MICRO_LABEL}`} style={{ color: "var(--text-mute)" }}>
+                  Navigate
+                </p>
+              )}
+              {visibleActions.map((action, i) => {
+                const idx = results.length + i;
+                return (
+                  <button
+                    key={action.id}
+                    id={optionId(idx)}
+                    ref={activeIndex === idx ? activeRowRef : undefined}
+                    type="button"
+                    role="option"
+                    aria-selected={activeIndex === idx}
+                    tabIndex={-1}
+                    onClick={action.run}
+                    onMouseEnter={() => setActiveIndex(idx)}
+                    className="flex w-full items-center gap-3 rounded-lg px-2 py-2.5 text-left transition-colors"
+                    style={{ background: activeIndex === idx ? "var(--surface-strong)" : "transparent" }}
+                  >
+                    <action.icon aria-hidden="true" className="h-4 w-4 flex-none" style={{ color: "var(--text-dim)" }} />
+                    <span className="text-sm" style={{ color: "var(--text)" }}>{action.label}</span>
+                  </button>
+                );
+              })}
+            </div>
           </div>
         </div>
       </div>

--- a/apps/web/src/components/GameDetailPanel.tsx
+++ b/apps/web/src/components/GameDetailPanel.tsx
@@ -186,7 +186,7 @@ export function GameDetailPanel({
               </span>
               {releaseYear && <span className="text-sm" style={{ color: "var(--text-mute)" }}>{releaseYear}</span>}
               {game.finished && (
-                <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-2.5 py-1 text-xs font-semibold text-emerald-600 ring-1 ring-emerald-500/20">
+                <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-2.5 py-1 text-xs font-semibold text-success ring-1 ring-emerald-500/20">
                   <Check className="h-3 w-3" /> Finished
                 </span>
               )}
@@ -269,7 +269,7 @@ export function GameDetailPanel({
               <button
                 type="button"
                 onClick={() => setConfirmDelete(true)}
-                className="flex items-center gap-1.5 text-xs font-medium text-rose-500 hover:text-rose-600"
+                className="flex items-center gap-1.5 text-xs font-medium text-danger hover:text-danger"
               >
                 <Trash2 className="h-3.5 w-3.5" /> Remove from library
               </button>

--- a/apps/web/src/components/MobileTabBar.tsx
+++ b/apps/web/src/components/MobileTabBar.tsx
@@ -40,7 +40,7 @@ const isItemActive = (item: NavItem, pathname: string) =>
   item.end ? pathname === item.to : pathname.startsWith(item.to);
 
 const TAB_CLASSES =
-  "relative flex min-w-0 flex-1 flex-col items-center gap-0.5 py-2.5 text-2xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-400 focus-ring-offset";
+  "relative flex min-w-0 flex-1 flex-col items-center gap-0.5 py-2.5 text-2xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-ring-offset";
 
 const TAB_COUNT = PRIMARY_NAV_ITEMS.length + 1;
 
@@ -184,7 +184,7 @@ function MoreSheet({ pathname, onClose }: { pathname: string; onClose: () => voi
                   onTouchStart={() => prefetchRoute(item.to)}
                   onPointerEnter={() => prefetchRoute(item.to)}
                   aria-current={isActive ? "page" : undefined}
-                  className={`flex min-h-11 items-center gap-3 rounded-xl px-4 py-3 text-sm font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-400 ${isActive ? "text-claw-text" : ""}`}
+                  className={`flex min-h-11 items-center gap-3 rounded-xl px-4 py-3 text-sm font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-focus ${isActive ? "text-claw-text" : ""}`}
                   style={isActive ? { background: "var(--surface)" } : { color: "var(--text-dim)" }}
                 >
                   <Icon className="h-5 w-5 flex-none" />

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -132,6 +132,9 @@ export function Sidebar({
 
   return (
     <aside
+      // Named because the Lists page has a complementary landmark of its own,
+      // and two unnamed ones are indistinguishable in a landmark list.
+      aria-label="Sidebar"
       className="fixed inset-y-0 left-0 z-40 hidden sm:flex"
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
@@ -175,7 +178,7 @@ export function Sidebar({
               to={item.to}
               end={item.end}
               className={({ isActive }) =>
-                `group relative flex items-center gap-3 rounded-lg px-2.5 py-2.5 text-sm font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-400 focus-ring-offset ${
+                `group relative flex items-center gap-3 rounded-lg px-2.5 py-2.5 text-sm font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-ring-offset ${
                   isActive ? "" : "hover:bg-[var(--surface-strong)]"
                 }`
               }
@@ -202,7 +205,7 @@ export function Sidebar({
             <button
               type="button"
               onClick={onSwitchProfile}
-              className="flex w-full items-center gap-3 rounded-lg px-2.5 py-2.5 text-sm font-medium transition-colors hover:bg-[var(--surface-strong)] focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-400 focus-ring-offset"
+              className="flex w-full items-center gap-3 rounded-lg px-2.5 py-2.5 text-sm font-medium transition-colors hover:bg-[var(--surface-strong)] focus:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-ring-offset"
               style={{ color: "var(--text-dim)" }}
               aria-label={profile ? `Switch profile (currently ${profile.name})` : "Switch profile"}
               title={expanded ? undefined : (profile?.name ?? "Switch profile")}
@@ -218,7 +221,7 @@ export function Sidebar({
           <button
             type="button"
             onClick={togglePin}
-            className="flex w-full items-center gap-3 rounded-lg px-2.5 py-2.5 text-sm font-medium transition-colors hover:bg-[var(--surface-strong)] focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-400 focus-ring-offset"
+            className="flex w-full items-center gap-3 rounded-lg px-2.5 py-2.5 text-sm font-medium transition-colors hover:bg-[var(--surface-strong)] focus:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-ring-offset"
             style={{ color: "var(--text-dim)" }}
             aria-label={pinned ? "Unpin sidebar" : "Pin sidebar open"}
             title={expanded ? undefined : pinned ? "Unpin sidebar" : "Pin sidebar open"}

--- a/apps/web/src/components/StarPicker.tsx
+++ b/apps/web/src/components/StarPicker.tsx
@@ -21,6 +21,19 @@ import { STARS_MAX, formatStars } from "../utils/rating";
  * between them: a seasons list holds a picker per season and per episode, and
  * ten tab stops apiece would put hundreds of them between the top of the panel
  * and anything below it.
+ *
+ * The cell a star is drawn in is wider than the star. Two buttons split a cell,
+ * so a cell narrower than 48px puts both of them under the 24x24 SC 2.5.8 asks
+ * of a pointer target — the 28px star this used measured 14x28 per half, and
+ * 10x20 at the mobile `md` size. Ten targets in a row can't fall back on the
+ * spacing exception either, since each one's neighbour is the thing crowding
+ * it. So the cell is fixed at 48px wide and the glyph is centred in it at
+ * whatever size the caller asked for; the extra width lands between stars,
+ * where it reads as air rather than as bigger stars.
+ *
+ * Cells are 48px wide at both sizes, which makes the whole row 240px. That is
+ * wider than a dense episode row can spare beside a title, so the rows that
+ * hold a `sm` picker wrap it onto its own line when it doesn't fit.
  */
 export function StarPicker({
   value,
@@ -51,13 +64,18 @@ export function StarPicker({
     if (next === from) return;
     buttonsRef.current[next - 1]?.focus();
   };
+  // The glyph, unchanged in size.
   const starClass = size === "sm" ? "h-4 w-4" : "h-5 w-5 sm:h-7 sm:w-7";
-  const boxClass = size === "sm" ? "h-4 w-4" : "h-5 w-5 sm:h-7 sm:w-7";
+  // The cell the glyph is centred in, and the two half-buttons split. 48px wide
+  // so each half clears 24px; height is the glyph's, floored at 24px.
+  const boxClass = size === "sm" ? "h-6 w-12" : "h-8 w-12";
 
   const half = (index: number, side: 0 | 1) => index * 2 + side + 1;
 
   return (
-    <div className="flex items-center gap-0 sm:gap-0.5" onMouseLeave={() => setHover(null)}>
+    // No gap: a gap between cells is dead space between two targets, and the
+    // cells are already wide enough to separate the stars visually.
+    <div className="flex flex-none items-center" onMouseLeave={() => setHover(null)}>
       {Array.from({ length: STARS_MAX }, (_, i) => {
         // 0, 0.5 or 1 of this star's width, for both the committed rating and
         // the hover preview — a preview below the saved rating has to empty the
@@ -68,19 +86,23 @@ export function StarPicker({
 
         return (
           <span key={i} className={`relative grid flex-none place-items-center ${boxClass}`}>
-            <Star className={`absolute ${starClass}`} style={{ color: "var(--text-mute)" }} />
-            {fill > 0 && (
-              <span
-                className="pointer-events-none absolute inset-0 overflow-hidden"
-                style={{ width: `${fill * 100}%` }}
-              >
-                <span className={`grid place-items-center ${boxClass}`}>
+            {/* Glyph-sized, and the clipping context for the fill below. The
+                cell is wider than the star now, so a fill measured against the
+                cell would put "half a star" 24px from the cell's edge — which
+                is short of the glyph's own midpoint. */}
+            <span className={`relative grid place-items-center ${starClass}`}>
+              <Star className={`absolute ${starClass}`} style={{ color: "var(--text-mute)" }} />
+              {fill > 0 && (
+                <span
+                  className="pointer-events-none absolute inset-y-0 left-0 overflow-hidden"
+                  style={{ width: `${fill * 100}%` }}
+                >
                   <Star
-                    className={`star-shake-target absolute fill-amber-400 text-amber-400 ${starClass} ${popping ? "star-pop" : ""}`}
+                    className={`star-shake-target absolute left-0 top-0 fill-warning text-warning ${starClass} ${popping ? "star-pop" : ""}`}
                   />
                 </span>
-              </span>
-            )}
+              )}
+            </span>
             {([0, 1] as const).map((side) => {
               const target = half(i, side);
               const stars = formatStars(target);
@@ -107,7 +129,14 @@ export function StarPicker({
                       moveFocus(target, -1);
                     }
                   }}
-                  className={`absolute inset-y-0 ${side === 0 ? "left-0" : "right-0"} w-1/2 disabled:cursor-not-allowed`}
+                  // Half the cell, which is 24px of the 48 — the SC 2.5.8
+                  // minimum, and the reason the cell is that wide.
+                  //
+                  // The ring matters more here than on a labelled control: the
+                  // buttons are transparent, so without it the only sign of
+                  // keyboard focus is the fill preview `onFocus` sets, which
+                  // looks exactly like a hover.
+                  className={`absolute inset-y-0 ${side === 0 ? "left-0" : "right-0"} w-1/2 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-focus disabled:cursor-not-allowed`}
                   // The current rating's button does the opposite of every
                   // other one — it clears the rating — and saying so only in
                   // `title` leaves out screen readers and touch users entirely.
@@ -125,7 +154,7 @@ export function StarPicker({
         );
       })}
       <span
-        className={`ml-1.5 font-semibold tabular-nums text-amber-500 ${size === "sm" ? "text-2xs" : "text-xs sm:text-sm"}`}
+        className={`ml-1.5 font-semibold tabular-nums text-warning ${size === "sm" ? "text-2xs" : "text-xs sm:text-sm"}`}
       >
         {shown > 0 ? `${formatStars(shown)}/${STARS_MAX}` : ""}
       </span>

--- a/apps/web/src/components/media-detail/CheckInModal.tsx
+++ b/apps/web/src/components/media-detail/CheckInModal.tsx
@@ -90,7 +90,7 @@ export function CheckInModal({
               />
             </div>
           </div>
-          {error && <p className="text-xs text-rose-400">{error}</p>}
+          {error && <p role="alert" className="text-xs text-danger">{error}</p>}
           <div className="flex gap-3 pt-1">
             <button
               type="button" onClick={requestClose}

--- a/apps/web/src/components/media-detail/DetailPanel.tsx
+++ b/apps/web/src/components/media-detail/DetailPanel.tsx
@@ -394,8 +394,8 @@ export function DetailPanel({
             {(hasRating || hasRuntime) && (
               <div className="mt-2 flex flex-wrap items-center gap-2">
                 {hasRating && (
-                  <span className="inline-flex items-center gap-1 rounded-full bg-amber-500/10 px-2.5 py-1 text-sm font-semibold text-amber-600 ring-1 ring-amber-500/20" title={ratingLabel(item.rating!)}>
-                    <Star className="h-3.5 w-3.5 fill-amber-500" />{formatRating(item.rating!)}
+                  <span className="inline-flex items-center gap-1 rounded-full bg-amber-500/10 px-2.5 py-1 text-sm font-semibold text-warning ring-1 ring-amber-500/20" title={ratingLabel(item.rating!)}>
+                    <Star className="h-3.5 w-3.5 fill-warning" />{formatRating(item.rating!)}
                     <span className="text-xs font-normal" style={{ color: "var(--text-mute)" }}>/{RATING_MAX}</span>
                   </span>
                 )}

--- a/apps/web/src/components/media-detail/ListsSection.tsx
+++ b/apps/web/src/components/media-detail/ListsSection.tsx
@@ -124,7 +124,7 @@ export function ListsSection({
           onClick={() => void toggle(list)}
           disabled={pending[list.id]}
           aria-label={`Remove from ${list.name}`}
-          className="inline-flex items-center gap-1.5 rounded-full bg-emerald-500/10 px-3 py-1.5 text-xs font-medium text-emerald-400 ring-1 ring-emerald-500/20 transition-colors hover:bg-emerald-500/20 disabled:opacity-50"
+          className="inline-flex items-center gap-1.5 rounded-full bg-emerald-500/10 px-3 py-1.5 text-xs font-medium text-success ring-1 ring-emerald-500/20 transition-colors hover:bg-emerald-500/20 disabled:opacity-50"
         >
           <Check className="h-3 w-3" />{list.name}
           <X className="h-3 w-3" />
@@ -177,7 +177,7 @@ export function ListsSection({
                   className="flex w-full items-center gap-2 px-3 py-2.5 text-left text-sm transition-colors hover:bg-[var(--surface)] disabled:opacity-50"
                 >
                   {already ? (
-                    <Check className="h-3.5 w-3.5 text-emerald-500" />
+                    <Check className="h-3.5 w-3.5 text-success" />
                   ) : (
                     <Plus className="h-3.5 w-3.5" style={{ color: "var(--text-mute)" }} />
                   )}

--- a/apps/web/src/components/media-detail/RatingsSection.tsx
+++ b/apps/web/src/components/media-detail/RatingsSection.tsx
@@ -87,7 +87,7 @@ export function ExternalRatings({
         {rtScore != null && (
           <div className="flex items-center gap-1.5">
             <RtLogo score={rtScore} />
-            <span className={`text-sm font-semibold ${rtScore >= 60 ? "text-green-600" : "text-rose-500"}`}>{rtScore}%</span>
+            <span className={`text-sm font-semibold ${rtScore >= 60 ? "text-success" : "text-danger"}`}>{rtScore}%</span>
           </div>
         )}
         {mcScore != null && (
@@ -188,9 +188,9 @@ export function StarRating({
         <p className="mt-1 text-2xs" style={{ color: "var(--text-mute)" }}>Click your current rating again to remove it.</p>
       )}
       {loadError && (
-        <p className="mt-1 flex items-center gap-2 text-xs text-rose-400">
+        <p role="alert" className="mt-1 flex items-center gap-2 text-xs text-danger">
           {loadError}
-          <button type="button" onClick={retryLoadRating} className="underline hover:text-rose-300">Retry</button>
+          <button type="button" onClick={retryLoadRating} className="underline underline-offset-2 hover:no-underline">Retry</button>
         </p>
       )}
     </div>

--- a/apps/web/src/components/media-detail/RecommendationsSection.tsx
+++ b/apps/web/src/components/media-detail/RecommendationsSection.tsx
@@ -79,7 +79,7 @@ export function RecommendationsSection({
             key={`${item.type}:${item.id}`}
             type="button"
             onClick={() => onSelect(item)}
-            className="group flex-none text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-400 focus-ring-offset"
+            className="group flex-none text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-ring-offset"
             style={{ width: "7rem" }}
             aria-label={`View details for ${item.name}`}
           >

--- a/apps/web/src/components/media-detail/SeasonsSection.tsx
+++ b/apps/web/src/components/media-detail/SeasonsSection.tsx
@@ -241,11 +241,14 @@ export function SeasonsSection({
 
           return (
             <div key={s.seasonNumber} className="overflow-hidden rounded-xl border" style={{ borderColor: "var(--border)" }}>
-              <div className="flex items-center gap-2 px-3 py-2.5" style={{ background: "var(--surface)" }}>
+              {/* Wraps because the star picker is 240px wide — the width ten
+                  24px pointer targets need — which a narrow panel can't spare
+                  beside a season name and a "Mark watched" button. */}
+              <div className="flex flex-wrap items-center gap-2 px-3 py-2.5" style={{ background: "var(--surface)" }}>
                 <button
                   type="button"
                   onClick={() => toggleExpand(s.seasonNumber)}
-                  className="flex min-w-0 flex-1 items-center gap-2.5 text-left"
+                  className="flex min-w-40 flex-1 items-center gap-2.5 text-left"
                   aria-expanded={isExpanded}
                   aria-label={`${isExpanded ? "Collapse" : "Expand"} ${s.name}`}
                 >
@@ -305,14 +308,14 @@ export function SeasonsSection({
                         // watched toggle.
                         <div
                           key={ep.episodeNumber}
-                          className="flex w-full items-center gap-3 px-3 py-2"
+                          className="flex w-full flex-wrap items-center gap-x-3 gap-y-1 px-3 py-2"
                           style={{ borderTop: i > 0 ? "1px solid var(--border)" : undefined }}
                         >
                           <button
                             type="button"
                             onClick={() => void toggleEpisode(s.seasonNumber, ep.episodeNumber)}
                             disabled={pendingEpisode[k]}
-                            className="flex min-w-0 flex-1 items-center gap-3 rounded-lg text-left transition-opacity hover:opacity-75 disabled:opacity-50"
+                            className="flex min-w-40 flex-1 items-center gap-3 rounded-lg text-left transition-opacity hover:opacity-75 disabled:opacity-50"
                             aria-pressed={isWatched}
                             aria-label={`${isWatched ? "Unmark" : "Mark"} ${ep.name} watched`}
                           >

--- a/apps/web/src/components/media-detail/WatchDateModal.tsx
+++ b/apps/web/src/components/media-detail/WatchDateModal.tsx
@@ -174,7 +174,7 @@ export function WatchDateModal({
           </div>
         )}
 
-        {error && <p className="mt-3 text-xs text-rose-400">{error}</p>}
+        {error && <p role="alert" className="mt-3 text-xs text-danger">{error}</p>}
       </div>
     </div>
   );

--- a/apps/web/src/components/media-detail/WatchHistorySection.tsx
+++ b/apps/web/src/components/media-detail/WatchHistorySection.tsx
@@ -79,7 +79,7 @@ export function WatchHistorySection({
               <button
                 type="button"
                 onClick={() => onDeleteEvent(event)}
-                className="shrink-0 rounded p-1 text-[var(--text-mute)] opacity-100 sm:opacity-0 sm:group-hover:opacity-100 focus-visible:opacity-100 hover:bg-rose-500/10 hover:text-rose-500 transition-all duration-fast"
+                className="shrink-0 rounded p-1 text-[var(--text-mute)] opacity-100 sm:opacity-0 sm:group-hover:opacity-100 focus-visible:opacity-100 hover:bg-rose-500/10 hover:text-danger transition-all duration-fast"
                 aria-label="Remove watch event"
               >
                 <Trash2 className="h-3.5 w-3.5" />

--- a/apps/web/src/components/settings/AddonSettings.tsx
+++ b/apps/web/src/components/settings/AddonSettings.tsx
@@ -69,9 +69,9 @@ function AddonManifestUrl({ profileName, multiProfile }: { profileName: string |
           onClick={copy}
           className={`flex-none inline-flex items-center gap-1.5 rounded-lg px-3 py-2 text-xs font-semibold transition-all duration-base ${
             copied
-              ? "bg-emerald-500/15 text-emerald-600 ring-1 ring-emerald-500/20"
+              ? "bg-emerald-500/15 text-success ring-1 ring-emerald-500/20"
               : copyError
-                ? "bg-rose-500/15 text-rose-600 ring-1 ring-rose-500/20"
+                ? "bg-rose-500/15 text-danger ring-1 ring-rose-500/20"
                 : "hover:bg-[var(--surface-strong)] border"
           }`}
           style={!copied && !copyError ? { color: "var(--text-dim)", borderColor: "var(--border)", background: "var(--bg-0)" } : undefined}
@@ -236,7 +236,7 @@ export function AddonSettings() {
       >
         {saved ? <><Check size={16} /> Saved</> : saving ? <><Loader2 size={16} className="animate-spin" /> Saving...</> : "Save Configuration"}
       </button>
-      {error && <p className="flex items-center gap-2 text-sm text-rose-600"><AlertCircle size={16} /> {error}</p>}
+      {error && <p role="alert" className="flex items-center gap-2 text-sm text-danger"><AlertCircle size={16} /> {error}</p>}
     </div>
   );
 }

--- a/apps/web/src/components/settings/AiSettings.tsx
+++ b/apps/web/src/components/settings/AiSettings.tsx
@@ -375,9 +375,11 @@ export function AiSettings() {
                 background: "var(--bg-1)",
               }}
               placeholder="https://api.example.com/v1/chat/completions"
+              aria-invalid={fieldErrors.url ? true : undefined}
+              aria-describedby={fieldErrors.url ? "ai-url-error" : undefined}
             />
             {fieldErrors.url && (
-              <p className="mt-1 text-xs text-rose-600">{fieldErrors.url}</p>
+              <p id="ai-url-error" role="alert" className="mt-1 text-xs text-danger">{fieldErrors.url}</p>
             )}
           </div>
 
@@ -411,9 +413,11 @@ export function AiSettings() {
               }}
               placeholder="sk-..."
               autoComplete="off"
+              aria-invalid={fieldErrors.apiKey ? true : undefined}
+              aria-describedby={fieldErrors.apiKey ? "ai-key-error" : undefined}
             />
             {fieldErrors.apiKey && (
-              <p className="mt-1 text-xs text-rose-600">{fieldErrors.apiKey}</p>
+              <p id="ai-key-error" role="alert" className="mt-1 text-xs text-danger">{fieldErrors.apiKey}</p>
             )}
           </div>
 
@@ -441,9 +445,11 @@ export function AiSettings() {
                   color: "var(--text)",
                   background: "var(--bg-1)",
                 }}
+                aria-invalid={fieldErrors.model ? true : undefined}
+                aria-describedby={fieldErrors.model ? "ai-model-error" : undefined}
               />
               {fieldErrors.model && (
-                <p className="mt-1 text-xs text-rose-600">
+                <p id="ai-model-error" role="alert" className="mt-1 text-xs text-danger">
                   {fieldErrors.model}
                 </p>
               )}
@@ -531,14 +537,14 @@ export function AiSettings() {
             spellCheck={false}
           />
           {advancedJsonError && (
-            <p className="mt-1 text-xs text-rose-600">{advancedJsonError}</p>
+            <p role="alert" className="mt-1 text-xs text-danger">{advancedJsonError}</p>
           )}
         </div>
       )}
 
       {testStatus && (
         <p
-          className={`flex items-center gap-2 text-sm ${testStatus === "ok" ? "text-emerald-600" : "text-rose-600"}`}
+          className={`flex items-center gap-2 text-sm ${testStatus === "ok" ? "text-success" : "text-danger"}`}
         >
           {testStatus === "ok" ? (
             <Check size={14} />
@@ -575,7 +581,7 @@ export function AiSettings() {
           disabled={saving}
           className={`inline-flex items-center gap-2 rounded-xl px-4 py-2 text-sm font-semibold transition-all duration-base ${
             saved
-              ? "bg-emerald-500/15 text-emerald-600 ring-1 ring-emerald-500/20"
+              ? "bg-emerald-500/15 text-success ring-1 ring-emerald-500/20"
               : "bg-plum-500 text-white hover:bg-plum-600 disabled:opacity-40 disabled:cursor-not-allowed"
           }`}
         >
@@ -596,7 +602,11 @@ export function AiSettings() {
             type="button"
             onClick={handleRemove}
             disabled={removing}
-            className="inline-flex items-center gap-2 rounded-xl border border-rose-200 bg-rose-50 px-4 py-2 text-sm font-semibold text-rose-600 transition-all duration-base hover:bg-rose-100 disabled:opacity-40 disabled:cursor-not-allowed"
+            // Tints of rose-500 rather than the rose-50/100/200 steps this
+            // carried: those are near-white fixed values, so on the four dark
+            // themes the button was a white slab and its own label sat at
+            // 2.18:1 on it. A tint tracks whatever it is laid over.
+            className="inline-flex items-center gap-2 rounded-xl border border-rose-500/30 bg-rose-500/10 px-4 py-2 text-sm font-semibold text-danger transition-all duration-base hover:bg-rose-500/15 disabled:opacity-40 disabled:cursor-not-allowed"
           >
             {removing ? (
               <>
@@ -609,7 +619,7 @@ export function AiSettings() {
         )}
       </div>
       {error && (
-        <p className="flex items-center gap-2 text-sm text-rose-600">
+        <p role="alert" className="flex items-center gap-2 text-sm text-danger">
           <AlertCircle size={16} /> {error}
         </p>
       )}

--- a/apps/web/src/components/settings/AiSettings.tsx
+++ b/apps/web/src/components/settings/AiSettings.tsx
@@ -535,25 +535,39 @@ export function AiSettings() {
               background: "var(--bg-1)",
             }}
             spellCheck={false}
+            aria-invalid={advancedJsonError ? true : undefined}
+            aria-describedby={advancedJsonError ? "ai-advanced-json-error" : undefined}
           />
           {advancedJsonError && (
-            <p role="alert" className="mt-1 text-xs text-danger">{advancedJsonError}</p>
+            <p id="ai-advanced-json-error" role="alert" className="mt-1 text-xs text-danger">{advancedJsonError}</p>
           )}
         </div>
       )}
 
-      {testStatus && (
-        <p
-          className={`flex items-center gap-2 text-sm ${testStatus === "ok" ? "text-success" : "text-danger"}`}
-        >
-          {testStatus === "ok" ? (
-            <Check size={14} />
-          ) : (
-            <AlertCircle size={14} />
-          )}
-          {testMessage}
-        </p>
-      )}
+      {/* The result of a connection test the user asked for, and until now it
+          arrived silently. Kept mounted rather than rendered under `testStatus`
+          so the region exists before it has anything to say — a live region
+          inserted together with its text is announced unreliably. Empty it has
+          no children and so no height.
+
+          A failure is assertive, a success polite: one of them means the thing
+          the user just tried did not work. */}
+      <p
+        role={testStatus === "error" ? "alert" : "status"}
+        aria-live={testStatus === "error" ? "assertive" : "polite"}
+        className={`flex items-center gap-2 text-sm ${testStatus === "ok" ? "text-success" : "text-danger"}`}
+      >
+        {testStatus && (
+          <>
+            {testStatus === "ok" ? (
+              <Check aria-hidden="true" size={14} />
+            ) : (
+              <AlertCircle aria-hidden="true" size={14} />
+            )}
+            {testMessage}
+          </>
+        )}
+      </p>
 
       <div className="flex flex-wrap gap-2">
         <button

--- a/apps/web/src/components/settings/ApiTokenSettings.tsx
+++ b/apps/web/src/components/settings/ApiTokenSettings.tsx
@@ -43,7 +43,7 @@ export function ApiTokenSettings() {
           {showToken ? <EyeOff size={16} /> : <Eye size={16} />}
         </button>
       </div>
-      <p className="text-xs text-amber-600">Only use this on trusted devices.</p>
+      <p className="text-xs text-warning">Only use this on trusted devices.</p>
       <button
         type="submit"
         className={`btn-primary ${saved ? "btn-saved" : ""}`}

--- a/apps/web/src/components/settings/DataSettings.tsx
+++ b/apps/web/src/components/settings/DataSettings.tsx
@@ -121,8 +121,8 @@ export function DataSettings() {
         >
           {syncing ? <><Loader2 size={16} className="animate-spin" /> Syncing...</> : "Sync all metadata"}
         </button>
-        {result && <p className="flex items-center gap-2 text-sm text-emerald-600"><Check size={16} /> {result}</p>}
-        {error && <p className="flex items-center gap-2 text-sm text-rose-600"><AlertCircle size={16} /> {error}</p>}
+        {result && <p className="flex items-center gap-2 text-sm text-success"><Check size={16} /> {result}</p>}
+        {error && <p role="alert" className="flex items-center gap-2 text-sm text-danger"><AlertCircle size={16} /> {error}</p>}
       </div>
 
       <div className="space-y-4 pt-5" style={{ borderTop: "1px solid var(--border)" }}>
@@ -188,8 +188,8 @@ export function DataSettings() {
             {importingCsv ? <><Loader2 size={16} className="animate-spin" /> Importing...</> : <><Upload size={16} /> Import CSV history</>}
           </button>
         </div>
-        {importResult && <p className="flex items-center gap-2 text-sm text-emerald-600"><Check size={16} /> {importResult}</p>}
-        {importError && <p className="flex items-center gap-2 text-sm text-rose-600"><AlertCircle size={16} /> {importError}</p>}
+        {importResult && <p className="flex items-center gap-2 text-sm text-success"><Check size={16} /> {importResult}</p>}
+        {importError && <p role="alert" className="flex items-center gap-2 text-sm text-danger"><AlertCircle size={16} /> {importError}</p>}
       </div>
 
       <div className="space-y-4 pt-5" style={{ borderTop: "1px solid var(--border)" }}>
@@ -231,8 +231,8 @@ export function DataSettings() {
             {importingExternal ? <><Loader2 size={16} className="animate-spin" /> Importing...</> : <><Upload size={16} /> Import CSV</>}
           </button>
         </div>
-        {externalResult && <p className="flex items-center gap-2 text-sm text-emerald-600"><Check size={16} /> {externalResult}</p>}
-        {externalError && <p className="flex items-center gap-2 text-sm text-rose-600"><AlertCircle size={16} /> {externalError}</p>}
+        {externalResult && <p className="flex items-center gap-2 text-sm text-success"><Check size={16} /> {externalResult}</p>}
+        {externalError && <p role="alert" className="flex items-center gap-2 text-sm text-danger"><AlertCircle size={16} /> {externalError}</p>}
       </div>
     </div>
   );

--- a/apps/web/src/components/settings/JobStatusSettings.tsx
+++ b/apps/web/src/components/settings/JobStatusSettings.tsx
@@ -45,7 +45,7 @@ export function JobStatusSettings() {
   }
 
   if (error) {
-    return <p className="text-sm text-rose-600">{error}</p>;
+    return <p role="alert" className="text-sm text-danger">{error}</p>;
   }
 
   if (failures.length === 0) {
@@ -68,7 +68,7 @@ export function JobStatusSettings() {
           style={{ borderColor: "var(--border)", background: "var(--bg-1)" }}
         >
           <div className="flex items-center gap-2 font-semibold" style={{ color: "var(--text)" }}>
-            <AlertTriangle size={16} className="flex-none text-amber-500" />
+            <AlertTriangle size={16} className="flex-none text-warning" />
             {JOB_LABELS[failure.job] ?? failure.job}
             <span className="ml-auto text-xs font-normal" style={{ color: "var(--text-mute)" }}>
               {timeAgo(failure.failedAt)}

--- a/apps/web/src/components/settings/NotificationChannelsSettings.tsx
+++ b/apps/web/src/components/settings/NotificationChannelsSettings.tsx
@@ -187,7 +187,7 @@ export function NotificationChannelsSettings() {
           <Loader2 size={16} className="animate-spin" /> Loading channels...
         </div>
       ) : loadError ? (
-        <p className="flex items-center gap-2 text-sm text-rose-600">
+        <p role="alert" className="flex items-center gap-2 text-sm text-danger">
           <AlertCircle size={16} /> {loadError}
         </p>
       ) : channels.length === 0 ? (
@@ -238,7 +238,7 @@ export function NotificationChannelsSettings() {
                       type="button"
                       onClick={() => remove(channel)}
                       disabled={busyId === channel.id}
-                      className="rounded-lg p-1.5 text-rose-600 hover:bg-[var(--surface-strong)] disabled:opacity-50"
+                      className="rounded-lg p-1.5 text-danger hover:bg-[var(--surface-strong)] disabled:opacity-50"
                       title="Remove channel"
                       aria-label={`Remove ${channel.name}`}
                     >
@@ -251,7 +251,7 @@ export function NotificationChannelsSettings() {
                 </p>
                 {result && (
                   <p
-                    className={`mt-2 flex items-center gap-2 text-xs ${result.ok ? "text-emerald-600" : "text-rose-600"}`}
+                    className={`mt-2 flex items-center gap-2 text-xs ${result.ok ? "text-success" : "text-danger"}`}
                     role="status"
                   >
                     {result.ok ? <Check size={14} /> : <AlertCircle size={14} />} {result.message}
@@ -345,7 +345,7 @@ export function NotificationChannelsSettings() {
         </button>
 
         {addError && (
-          <p className="flex items-center gap-2 text-sm text-rose-600" role="alert">
+          <p className="flex items-center gap-2 text-sm text-danger" role="alert">
             <AlertCircle size={16} /> {addError}
           </p>
         )}

--- a/apps/web/src/components/settings/OmdbSettings.tsx
+++ b/apps/web/src/components/settings/OmdbSettings.tsx
@@ -117,7 +117,7 @@ export function OmdbSettings() {
         </form>
       )}
 
-      {error && <p className="flex items-center gap-2 text-sm text-rose-600"><AlertCircle size={16} /> {error}</p>}
+      {error && <p role="alert" className="flex items-center gap-2 text-sm text-danger"><AlertCircle size={16} /> {error}</p>}
     </div>
   );
 }

--- a/apps/web/src/components/settings/PlayDetectionSettings.tsx
+++ b/apps/web/src/components/settings/PlayDetectionSettings.tsx
@@ -136,7 +136,7 @@ export function PlayDetectionSettings() {
 
       {error && (
         <div className="space-y-2">
-          <p className="flex items-center gap-2 text-sm text-rose-600">
+          <p role="alert" className="flex items-center gap-2 text-sm text-danger">
             <AlertCircle size={16} /> {error}
           </p>
           {/* Reachable whatever `enabled` is: when the request failed there is

--- a/apps/web/src/components/settings/PreferencesSettings.tsx
+++ b/apps/web/src/components/settings/PreferencesSettings.tsx
@@ -178,7 +178,7 @@ export function PreferencesSettings() {
           button it was announced as that button's own new label. */}
       <p className="flex min-h-5 items-center gap-2 text-xs" aria-live="polite" style={{ color: "var(--text-mute)" }}>
         {error ? (
-          <span className="flex items-center gap-2 text-rose-400"><AlertCircle size={14} /> {error}</span>
+          <span className="flex items-center gap-2 text-danger"><AlertCircle size={14} /> {error}</span>
         ) : saving ? (
           <><Loader2 size={14} className="animate-spin" /> Saving...</>
         ) : saved ? (

--- a/apps/web/src/components/settings/ProfileSettings.tsx
+++ b/apps/web/src/components/settings/ProfileSettings.tsx
@@ -48,13 +48,13 @@ function RenameForm({ profile, onSaved, onCancel }: { profile: Profile; onSaved:
         className="w-full min-w-0 rounded-lg border px-2.5 py-1.5 text-sm focus:border-claw-500 focus:outline-none focus:ring-2 focus:ring-claw-500/15"
         style={{ borderColor: "var(--border)", color: "var(--text)", background: "var(--bg-1)" }}
       />
-      <button type="submit" disabled={saving} aria-label="Save name" className="flex-none rounded-lg p-1.5 text-emerald-600 hover:bg-[var(--surface-strong)]">
+      <button type="submit" disabled={saving} aria-label="Save name" className="flex-none rounded-lg p-1.5 text-success hover:bg-[var(--surface-strong)]">
         {saving ? <Loader2 size={16} className="animate-spin" /> : <Check size={16} />}
       </button>
       <button type="button" onClick={onCancel} aria-label="Cancel rename" className="flex-none rounded-lg p-1.5 hover:bg-[var(--surface-strong)]" style={{ color: "var(--text-mute)" }}>
         <X size={16} />
       </button>
-      {error && <p className="w-full text-xs text-rose-600">{error}</p>}
+      {error && <p role="alert" className="w-full text-xs text-danger">{error}</p>}
     </form>
   );
 }
@@ -125,14 +125,14 @@ function PinForm({ profile, onSaved, onCancel }: { profile: Profile; onSaved: (p
         type="submit"
         disabled={saving || !pin.trim() || (profile.hasPin && !currentPin.trim())}
         aria-label="Save PIN"
-        className="flex-none rounded-lg p-1.5 text-emerald-600 hover:bg-[var(--surface-strong)] disabled:opacity-50"
+        className="flex-none rounded-lg p-1.5 text-success hover:bg-[var(--surface-strong)] disabled:opacity-50"
       >
         {saving ? <Loader2 size={16} className="animate-spin" /> : <Check size={16} />}
       </button>
       <button type="button" onClick={onCancel} aria-label="Cancel" className="flex-none rounded-lg p-1.5 hover:bg-[var(--surface-strong)]" style={{ color: "var(--text-mute)" }}>
         <X size={16} />
       </button>
-      {error && <p className="w-full text-xs text-rose-600">{error}</p>}
+      {error && <p role="alert" className="w-full text-xs text-danger">{error}</p>}
     </form>
   );
 }
@@ -175,13 +175,13 @@ function RemovePinForm({ profile, onSaved, onCancel }: { profile: Profile; onSav
         className="w-full min-w-0 rounded-lg border px-2.5 py-1.5 text-sm focus:border-claw-500 focus:outline-none focus:ring-2 focus:ring-claw-500/15"
         style={{ borderColor: "var(--border)", color: "var(--text)", background: "var(--bg-1)" }}
       />
-      <button type="submit" disabled={saving || !currentPin.trim()} aria-label="Confirm PIN removal" className="flex-none rounded-lg p-1.5 text-emerald-600 hover:bg-[var(--surface-strong)] disabled:opacity-50">
+      <button type="submit" disabled={saving || !currentPin.trim()} aria-label="Confirm PIN removal" className="flex-none rounded-lg p-1.5 text-success hover:bg-[var(--surface-strong)] disabled:opacity-50">
         {saving ? <Loader2 size={16} className="animate-spin" /> : <Check size={16} />}
       </button>
       <button type="button" onClick={onCancel} aria-label="Cancel" className="flex-none rounded-lg p-1.5 hover:bg-[var(--surface-strong)]" style={{ color: "var(--text-mute)" }}>
         <X size={16} />
       </button>
-      {error && <p className="w-full text-xs text-rose-600">{error}</p>}
+      {error && <p role="alert" className="w-full text-xs text-danger">{error}</p>}
     </form>
   );
 }
@@ -231,14 +231,14 @@ function DeleteConfirmForm({ profile, onDeleted, onCancel }: { profile: Profile;
         type="submit"
         disabled={deleting || !pin.trim()}
         aria-label={`Confirm deletion of ${profile.name}`}
-        className="flex-none rounded-lg p-1.5 text-rose-600 hover:bg-rose-500/10 disabled:opacity-50"
+        className="flex-none rounded-lg p-1.5 text-danger hover:bg-rose-500/10 disabled:opacity-50"
       >
         {deleting ? <Loader2 size={16} className="animate-spin" /> : <Trash2 size={16} />}
       </button>
       <button type="button" onClick={onCancel} aria-label="Cancel deletion" className="flex-none rounded-lg p-1.5 hover:bg-[var(--surface-strong)]" style={{ color: "var(--text-mute)" }}>
         <X size={16} />
       </button>
-      {error && <p className="w-full text-xs text-rose-600">{error}</p>}
+      {error && <p role="alert" className="w-full text-xs text-danger">{error}</p>}
     </form>
   );
 }
@@ -366,7 +366,7 @@ function ProfileRow({
               disabled={deleting || isOnlyProfile}
               title={isOnlyProfile ? "Can't delete the only profile" : "Delete profile"}
               aria-label={`Delete ${profile.name}`}
-              className="flex-none rounded-lg p-1.5 transition-colors hover:bg-rose-500/10 hover:text-rose-600 disabled:opacity-30 disabled:hover:bg-transparent disabled:hover:text-[var(--text-mute)]"
+              className="flex-none rounded-lg p-1.5 transition-colors hover:bg-rose-500/10 hover:text-danger disabled:opacity-30 disabled:hover:bg-transparent disabled:hover:text-[var(--text-mute)]"
               style={{ color: "var(--text-mute)" }}
             >
               {deleting ? <Loader2 size={14} className="animate-spin" /> : <Trash2 size={14} />}
@@ -374,7 +374,7 @@ function ProfileRow({
           </>
         )}
       </div>
-      {error && <p className="mt-1.5 flex items-center gap-1.5 text-xs text-rose-600"><AlertCircle size={13} /> {error}</p>}
+      {error && <p role="alert" className="mt-1.5 flex items-center gap-1.5 text-xs text-danger"><AlertCircle size={13} /> {error}</p>}
     </div>
   );
 }
@@ -434,7 +434,7 @@ export function ProfileSettings() {
           <Loader2 size={16} className="animate-spin" /> Loading profiles...
         </div>
       ) : error ? (
-        <p className="flex items-center gap-2 text-sm text-rose-600"><AlertCircle size={16} /> {error}</p>
+        <p role="alert" className="flex items-center gap-2 text-sm text-danger"><AlertCircle size={16} /> {error}</p>
       ) : (
         <div className="space-y-2">
           {profiles.map((profile) => (

--- a/apps/web/src/components/settings/PushSettings.tsx
+++ b/apps/web/src/components/settings/PushSettings.tsx
@@ -95,7 +95,7 @@ export function PushSettings() {
         )}
       </button>
 
-      {error && <p className="flex items-center gap-2 text-sm text-rose-400"><AlertCircle size={16} /> {error}</p>}
+      {error && <p role="alert" className="flex items-center gap-2 text-sm text-danger"><AlertCircle size={16} /> {error}</p>}
     </div>
   );
 }

--- a/apps/web/src/components/settings/RpdbSettings.tsx
+++ b/apps/web/src/components/settings/RpdbSettings.tsx
@@ -119,7 +119,7 @@ export function RpdbSettings() {
         </form>
       )}
 
-      {error && <p className="flex items-center gap-2 text-sm text-rose-600"><AlertCircle size={16} /> {error}</p>}
+      {error && <p role="alert" className="flex items-center gap-2 text-sm text-danger"><AlertCircle size={16} /> {error}</p>}
     </div>
   );
 }

--- a/apps/web/src/components/settings/Section.tsx
+++ b/apps/web/src/components/settings/Section.tsx
@@ -87,22 +87,36 @@ export function Section({
 
   return (
     <div className="glass-panel rounded-2xl border shadow-e1 overflow-hidden" style={{ borderColor: "var(--border)", background: "var(--surface)" }}>
-      {alwaysOpen ? (
-        <div id={headerId} className="flex w-full items-center gap-3 px-5 py-[1.125rem]">
-          {header}
-        </div>
-      ) : (
-        <button
-          id={headerId}
-          type="button"
-          aria-expanded={open}
-          aria-controls={panelId}
-          onClick={toggle}
-          className="flex w-full items-center gap-3 px-5 py-[1.125rem] text-left transition-colors hover:bg-[var(--surface)]"
-        >
-          {header}
-        </button>
-      )}
+      {/* The disclosure pattern, wrapped in a real heading.
+
+          These sections are what the Settings page is made of — a dozen and a
+          half of them, each the size of a small page — and their titles were
+          <span>s. The page's outline was one <h1> and nothing else, so the
+          usual way of moving around a long page with a screen reader (jump by
+          heading) had nowhere to land, and the only way down was to tab
+          through every control on the way.
+
+          <h2> holds the button rather than the other way round: the heading
+          has to be an ancestor of the control for the two to be one entry in
+          the outline, and a button inside a heading keeps its own role. */}
+      <h2 className="m-0">
+        {alwaysOpen ? (
+          <div id={headerId} className="flex w-full items-center gap-3 px-5 py-[1.125rem]">
+            {header}
+          </div>
+        ) : (
+          <button
+            id={headerId}
+            type="button"
+            aria-expanded={open}
+            aria-controls={panelId}
+            onClick={toggle}
+            className="flex w-full items-center gap-3 px-5 py-[1.125rem] text-left transition-colors hover:bg-[var(--surface)]"
+          >
+            {header}
+          </button>
+        )}
+      </h2>
       <div
         id={panelId}
         ref={contentRef}

--- a/apps/web/src/components/settings/Section.tsx
+++ b/apps/web/src/components/settings/Section.tsx
@@ -101,9 +101,12 @@ export function Section({
           the outline, and a button inside a heading keeps its own role. */}
       <h2 className="m-0">
         {alwaysOpen ? (
-          <div id={headerId} className="flex w-full items-center gap-3 px-5 py-[1.125rem]">
+          // A span, not a div: a heading's content model is phrasing content,
+          // and the button in the other branch already qualifies. `flex` comes
+          // from the class either way, so this renders identically.
+          <span id={headerId} className="flex w-full items-center gap-3 px-5 py-[1.125rem]">
             {header}
-          </div>
+          </span>
         ) : (
           <button
             id={headerId}

--- a/apps/web/src/components/settings/StatusBadge.tsx
+++ b/apps/web/src/components/settings/StatusBadge.tsx
@@ -2,7 +2,7 @@ export function StatusBadge({ ok, label }: { ok: boolean; label: string }) {
   return (
     <span
       className={`inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-medium ${
-        ok ? "bg-emerald-500/10 text-emerald-600 ring-1 ring-emerald-500/20" : "ring-1"
+        ok ? "bg-emerald-500/10 text-success ring-1 ring-emerald-500/20" : "ring-1"
       }`}
       style={ok ? undefined : { background: "var(--surface-strong)", color: "var(--text-mute)", boxShadow: "inset 0 0 0 1px var(--border-strong)" }}
     >

--- a/apps/web/src/components/settings/StremioSyncSettings.tsx
+++ b/apps/web/src/components/settings/StremioSyncSettings.tsx
@@ -202,12 +202,12 @@ export function StremioSyncSettings() {
       )}
 
       {result && (
-        <p className="flex items-center gap-2 text-sm text-emerald-600">
+        <p className="flex items-center gap-2 text-sm text-success">
           <Check size={16} /> {result}
         </p>
       )}
       {error && (
-        <p className="flex items-center gap-2 text-sm text-rose-600">
+        <p role="alert" className="flex items-center gap-2 text-sm text-danger">
           <AlertCircle size={16} /> {error}
         </p>
       )}

--- a/apps/web/src/components/settings/TmdbSettings.tsx
+++ b/apps/web/src/components/settings/TmdbSettings.tsx
@@ -133,7 +133,7 @@ export function TmdbSettings() {
         </div>
       </form>
 
-      {error && <p className="flex items-center gap-2 text-sm text-rose-600"><AlertCircle size={16} /> {error}</p>}
+      {error && <p role="alert" className="flex items-center gap-2 text-sm text-danger"><AlertCircle size={16} /> {error}</p>}
     </div>
   );
 }

--- a/apps/web/src/components/settings/TraktSettings.tsx
+++ b/apps/web/src/components/settings/TraktSettings.tsx
@@ -106,7 +106,7 @@ export function TraktSettings() {
       <div className="flex items-center gap-3">
         <StatusBadge ok={!!status?.connected} label={status?.connected ? "Connected" : "Not connected"} />
         {status && !status.configured && (
-          <span className="text-xs text-amber-600">Trakt credentials not configured on the server</span>
+          <span className="text-xs text-warning">Trakt credentials not configured on the server</span>
         )}
       </div>
 
@@ -170,12 +170,12 @@ export function TraktSettings() {
       )}
 
       {importResult && (
-        <p role="status" aria-live="polite" className="flex items-start gap-2 text-sm text-emerald-600">
+        <p role="status" aria-live="polite" className="flex items-start gap-2 text-sm text-success">
           <Check size={16} className="shrink-0 mt-0.5" /> {importResult}
         </p>
       )}
       {error && (
-        <p role="alert" className="flex items-center gap-2 text-sm text-rose-600">
+        <p role="alert" className="flex items-center gap-2 text-sm text-danger">
           <AlertCircle size={16} /> {error}
         </p>
       )}

--- a/apps/web/src/hooks/useToast.tsx
+++ b/apps/web/src/hooks/useToast.tsx
@@ -105,9 +105,9 @@ function ToastContainer({
           style={{ borderLeftWidth: "4px", background: "var(--bg-1)" }}
         >
           {toast.type === "success" ? (
-            <Check aria-hidden="true" className="h-5 w-5 flex-none text-emerald-500" />
+            <Check aria-hidden="true" className="h-5 w-5 flex-none text-success" />
           ) : toast.type === "error" ? (
-            <X aria-hidden="true" className="h-5 w-5 flex-none text-rose-500" />
+            <X aria-hidden="true" className="h-5 w-5 flex-none text-danger" />
           ) : (
             <Heart aria-hidden="true" className="h-5 w-5 flex-none text-claw-text" />
           )}
@@ -127,7 +127,7 @@ function ToastContainer({
                 toast.action?.onAction();
                 onDismiss(toast.id);
               }}
-              className="ml-1 flex flex-none items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs font-semibold text-claw-text transition-colors hover:bg-claw-500/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-400 focus-ring-offset"
+              className="ml-1 flex flex-none items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs font-semibold text-claw-text transition-colors hover:bg-claw-500/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-ring-offset"
             >
               <Undo2 aria-hidden="true" className="h-3.5 w-3.5" />
               {toast.action.label}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -12,9 +12,21 @@
  *                 themes need it darker than --accent, dark themes lighter.
  *
  * Every pairing below is measured at >= 4.5:1 (WCAG AA, normal text) against
- * --bg-0, --bg-1 and accent tints up to bg-claw-500/20. --accent-strong-rgb —
- * the `hover:bg-claw-600` fill — is tuned to stay above 4.5:1 against
- * --on-accent too, so hover states don't quietly drop below the threshold.
+ * --bg-0, --bg-1, the --surface / --surface-strong tints, and accent tints up
+ * to bg-claw-500/20. --accent-strong-rgb — the `hover:bg-claw-600` fill — is
+ * tuned to stay above 4.5:1 against --on-accent too, so hover states don't
+ * quietly drop below the threshold.
+ *
+ * Status colours are the --status-* trio further down, reachable from Tailwind
+ * as text-danger / text-success / text-warning. Everything that used a fixed
+ * ramp step instead now reads from them: `text-rose-600` measured 4.20:1 on
+ * light and 4.29:1 on glass, `text-emerald-600` 3.39:1 on light, and
+ * `text-amber-400` 1.37:1 on the Stats chips.
+ *
+ * --focus-ring answers SC 1.4.11 rather than 1.4.3: a focus indicator has to
+ * reach 3:1 against whatever it is drawn over, and the light theme's --accent-2
+ * managed 1.72:1 against its own surfaces. Focus rings take this token instead
+ * of an accent.
  */
 
 :root,
@@ -31,8 +43,8 @@
   --border: rgba(28,24,20,0.08);
   --border-strong: rgba(28,24,20,0.14);
   --text: #1c1814;
-  --text-dim: #6f6457;
-  --text-mute: #73685b;
+  --text-dim: #635849;
+  --text-mute: #6c6155;
   --accent: #d97742;
   --accent-2: #e89163;
   --accent-3: #10b981;
@@ -45,6 +57,7 @@
   --on-accent: rgb(var(--on-accent-rgb));
   --accent-text-rgb: 149 72 30;
   --accent-text: rgb(var(--accent-text-rgb));
+  --focus-ring: #b8501f;
 }
 
 [data-theme="dark"] {
@@ -61,7 +74,7 @@
   --border-strong: rgba(250,245,240,0.18);
   --text: #faf5f0;
   --text-dim: #b5ab9a;
-  --text-mute: #8f8475;
+  --text-mute: #958b7c;
   --accent: #e89163;
   --accent-2: #f0ad88;
   --accent-3: #34d399;
@@ -74,6 +87,7 @@
   --on-accent: rgb(var(--on-accent-rgb));
   --accent-text-rgb: 232 145 99;
   --accent-text: rgb(var(--accent-text-rgb));
+  --focus-ring: #f0ad88;
 }
 
 [data-theme="glass"] {
@@ -90,7 +104,7 @@
   --border-strong: rgba(255,255,255,0.20);
   --text: #f5f6f8;
   --text-dim: #b7bcc6;
-  --text-mute: #80869a;
+  --text-mute: #8e94a5;
   --accent: #0a84ff;
   --accent-2: #5e9eff;
   --accent-3: #30d158;
@@ -116,6 +130,7 @@
   --glass-tint-row-hover: rgba(38,44,58,0.72);
   --glass-tint-row-hover-flat: rgba(38,44,58,0.94);
   --glass-tint-panel-flat: rgba(17,20,27,0.86);
+  --focus-ring: #5e9eff;
 }
 
 [data-theme="midnight"] {
@@ -132,7 +147,7 @@
   --border-strong: rgba(244,241,234,0.16);
   --text: #f4f1ea;
   --text-dim: #a3a6b8;
-  --text-mute: #797c90;
+  --text-mute: #878a9c;
   --accent: #e02f44;
   --accent-2: #ff5a6e;
   --accent-3: #f0c419;
@@ -145,6 +160,7 @@
   --on-accent: rgb(var(--on-accent-rgb));
   --accent-text-rgb: 230 89 106;
   --accent-text: rgb(var(--accent-text-rgb));
+  --focus-ring: #ff5a6e;
 }
 
 [data-theme="letterboxd"] {
@@ -161,7 +177,7 @@
   --border-strong: rgba(255,255,255,0.16);
   --text: #ffffff;
   --text-dim: #9ab;
-  --text-mute: #7b8b9c;
+  --text-mute: #909eac;
   --accent: #ff8000;
   --accent-2: #00e054;
   --accent-3: #40bcf4;
@@ -174,6 +190,7 @@
   --on-accent: rgb(var(--on-accent-rgb));
   --accent-text-rgb: 255 128 0;
   --accent-text: rgb(var(--accent-text-rgb));
+  --focus-ring: #00e054;
 }
 
 /*
@@ -272,13 +289,16 @@
  *
  * Only the text colour is a token. Fills and hairlines are mixed out of it
  * (see .status-chip), so a fill can never drift away from the text it sits
- * behind. Every value clears 4.5:1 against its themes' --bg-0 and --bg-1.
+ * behind. Every value clears 4.5:1 against its themes' --bg-0 and --bg-1, the
+ * --surface / --surface-strong tints, and the 10-20% chip fills these are read
+ * on — the light trio was measured against the two backgrounds only, and sat
+ * at 3.77-4.03:1 once the chip fill underneath it was counted.
  */
 :root,
 [data-theme="light"] {
-  --status-ok: #047857;
-  --status-bad: #be123c;
-  --status-warn: #b45309;
+  --status-ok: #036249;
+  --status-bad: #a80f34;
+  --status-warn: #96450a;
 }
 
 [data-theme="dark"],
@@ -326,6 +346,30 @@ html {
      page under the reader rather than just widening it. */
   -webkit-text-size-adjust: 100%;
   text-size-adjust: 100%;
+
+  /*
+   * Keeps a control the browser has just scrolled to clear of the fixed chrome.
+   *
+   * Tab moves focus and the browser scrolls the new target barely into view —
+   * it has no idea the app has pinned a 76px header to the top and, below `sm`,
+   * a tab bar to the bottom. Tabbing down the mobile dashboard landed the
+   * carousel's "Scroll right" button at y=800 in an 844px viewport: entirely
+   * behind the tab bar, which is what SC 2.4.11 is about. Scroll padding is
+   * what tells the browser those bands are occupied.
+   *
+   * The header is 76px on every viewport. The tab bar is `sm:hidden` and sits
+   * on the safe-area inset, so the bottom padding is only claimed below that
+   * breakpoint — see the media query below.
+   */
+  scroll-padding-top: 5.5rem;
+  scroll-padding-bottom: 1rem;
+}
+
+@media (width < 40rem) {
+  html {
+    /* Tab bar (~4.25rem) + its safe-area inset + a little air. */
+    scroll-padding-bottom: calc(5.5rem + env(safe-area-inset-bottom));
+  }
 }
 
 html[data-display-mode="standalone"] {
@@ -528,6 +572,30 @@ body {
   }
 
   /*
+   * The focus indicator for the controls we repaint ourselves — checkbox,
+   * switch, select. They all set `appearance: none`, which takes the platform's
+   * focus treatment with it, so each has to draw its own.
+   *
+   * What they drew before was the accent at 0.35 alpha (0.15 for the select),
+   * which is a glow rather than an indicator: blended against its own
+   * background that measured 1.42:1 on the light theme and 1.16:1 on the
+   * select, against the 3:1 SC 1.4.11 asks of a focus indicator. `outline`
+   * rather than a box-shadow ring so it survives on a control that already
+   * carries a shadow, and `outline-offset` so the 2px gap doesn't need a
+   * separately themed offset colour the way Tailwind's ring does.
+   *
+   * --focus-ring is measured at >= 3:1 against every surface in every theme;
+   * see the note at the top of this file.
+   */
+  .checkbox-control:focus-visible,
+  .switch-control:focus-visible,
+  .select-control:focus-visible {
+    outline: 2px solid var(--focus-ring);
+    outline-offset: 2px;
+    box-shadow: none;
+  }
+
+  /*
    * Radius ranks. Three, matching the three elevation tiers, so a surface's
    * corner and its shadow agree about how big it is:
    *
@@ -596,11 +664,6 @@ body {
     border-color: rgb(var(--accent-rgb));
   }
 
-  .checkbox-control:focus-visible {
-    outline: none;
-    box-shadow: 0 0 0 3px rgb(var(--accent-rgb) / 0.35);
-  }
-
   .checkbox-control:disabled {
     opacity: 0.5;
     cursor: default;
@@ -665,11 +728,6 @@ body {
     border-color: rgb(var(--accent-rgb));
   }
 
-  .switch-control:focus-visible {
-    outline: none;
-    box-shadow: 0 0 0 3px rgb(var(--accent-rgb) / 0.35);
-  }
-
   .switch-control:disabled {
     opacity: 0.5;
     cursor: default;
@@ -705,9 +763,7 @@ body {
   }
 
   .select-control:focus-visible {
-    outline: none;
-    border-color: rgb(var(--accent-rgb));
-    box-shadow: 0 0 0 3px rgb(var(--accent-rgb) / 0.15);
+    border-color: var(--focus-ring);
   }
 
   .select-control:disabled {
@@ -750,7 +806,7 @@ body {
     @apply inline-flex items-center justify-center gap-2 rounded-xl px-4 py-2.5 text-sm font-semibold;
     @apply transition-[color,background-color,border-color,box-shadow,transform] duration-base ease-in-out;
     @apply active:scale-[0.98];
-    @apply focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-400 focus-visible:ring-offset-2;
+    @apply focus:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2;
     @apply disabled:opacity-50 disabled:cursor-not-allowed disabled:active:scale-100;
     --tw-ring-offset-color: var(--bg-0);
   }
@@ -795,7 +851,7 @@ body {
      matches, so the ring doesn't say "accent" on a button that means danger. */
   .btn-danger {
     @apply bg-rose-600 text-white hover:bg-rose-700;
-    @apply focus-visible:ring-rose-400;
+    @apply focus-visible:ring-danger;
   }
 
   /* The settled state of a save button, not a rank of its own: the settings

--- a/apps/web/src/pages/CalendarPage.tsx
+++ b/apps/web/src/pages/CalendarPage.tsx
@@ -67,6 +67,10 @@ function dateLabelFor(airDate: Date, today: Date): string {
 }
 
 const WEEKDAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+// The visible headers are abbreviated to fit seven columns on a phone. The
+// column header's accessible name doesn't have that constraint, and "Sun" read
+// aloud is a different word.
+const WEEKDAY_FULL = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
 
 function entryKey(entry: CalendarEntry): string {
   return `${entry.seriesImdbId}-s${entry.season}e${entry.episode}`;
@@ -77,7 +81,7 @@ function EntryRow({ entry, onSelect }: { entry: CalendarEntry; onSelect: (entry:
     <button
       type="button"
       onClick={() => onSelect(entry)}
-      className="glass-row flex w-full items-center gap-3 rounded-xl p-3 text-left transition-colors hover:bg-[var(--surface-strong)] focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-400 focus-ring-offset"
+      className="glass-row flex w-full items-center gap-3 rounded-xl p-3 text-left transition-colors hover:bg-[var(--surface-strong)] focus:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-ring-offset"
       style={{ border: "1px solid var(--border)", background: "var(--bg-1)" }}
     >
       <div className="h-16 w-11 flex-none overflow-hidden rounded-lg" style={{ boxShadow: "0 0 0 1px var(--border)" }}>
@@ -305,7 +309,7 @@ export function CalendarPage() {
                 type="button"
                 onClick={() => setView(opt.key)}
                 aria-pressed={activeView === opt.key}
-                className="relative flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-400 focus-ring-offset"
+                className="relative flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-ring-offset"
                 style={activeView === opt.key ? { background: "var(--accent)", color: "var(--on-accent)" } : { color: "var(--text-dim)" }}
               >
                 <opt.icon className="h-3.5 w-3.5" />
@@ -317,7 +321,7 @@ export function CalendarPage() {
       </div>
 
       {error && (
-        <p className="rounded-xl bg-rose-500/5 border border-rose-500/20 px-4 py-3 text-rose-600 text-sm">{error}</p>
+        <p role="alert" className="rounded-xl bg-rose-500/5 border border-rose-500/20 px-4 py-3 text-danger text-sm">{error}</p>
       )}
 
       {activeView === "agenda" ? (
@@ -421,6 +425,14 @@ export function CalendarPage() {
             </p>
           )}
 
+          {/* The month grid below carries table roles rather than being a
+              <table>: it is a real grid of rows and columns, and without them a
+              screen reader met a stack of unrelated divs — the weekday strip
+              was seven labels for nothing, and a cell said "12" with no way to
+              find out which 12. Roles leave the CSS grid exactly as it is.
+              `role="table"` rather than `role="grid"` because a grid is a
+              composite widget that owes the user arrow-key cell navigation, and
+              this is a layout of links, not a spreadsheet. */}
           {monthOutOfRange ? (
             <div className="glass-panel rounded-2xl p-8 text-center" style={{ border: "1px solid var(--border)", background: "var(--bg-1)" }}>
               <CalendarDays className="mx-auto h-10 w-10" style={{ color: "var(--text-mute)" }} />
@@ -429,22 +441,35 @@ export function CalendarPage() {
               </p>
             </div>
           ) : (
-            <div className="overflow-hidden rounded-2xl" style={{ border: "1px solid var(--border)" }}>
-              <div className="grid grid-cols-7" style={{ borderBottom: "1px solid var(--border)" }}>
-                {WEEKDAY_LABELS.map((label) => (
-                  <div key={label} className={`px-2 py-2 text-center ${MICRO_LABEL}`} style={{ color: "var(--text-mute)" }}>
-                    {label}
-                  </div>
-                ))}
+            <div
+              className="overflow-hidden rounded-2xl"
+              style={{ border: "1px solid var(--border)" }}
+              role={loading ? undefined : "table"}
+              aria-label={loading ? undefined : `Episodes airing in ${monthCursor.toLocaleDateString(undefined, { month: "long", year: "numeric" })}`}
+            >
+              <div role={loading ? undefined : "rowgroup"} style={{ borderBottom: "1px solid var(--border)" }}>
+                <div className="grid grid-cols-7" role={loading ? undefined : "row"}>
+                  {WEEKDAY_LABELS.map((label, i) => (
+                    <div
+                      key={label}
+                      role={loading ? undefined : "columnheader"}
+                      aria-label={WEEKDAY_FULL[i]}
+                      className={`px-2 py-2 text-center ${MICRO_LABEL}`}
+                      style={{ color: "var(--text-mute)" }}
+                    >
+                      {label}
+                    </div>
+                  ))}
+                </div>
               </div>
               {loading ? (
                 <div className="p-4">
                   <div className="skeleton h-64 rounded-lg" />
                 </div>
               ) : (
-                <div>
+                <div role="rowgroup">
                   {monthWeeks.map((week, wi) => (
-                    <div key={wi} className="grid grid-cols-7" style={{ borderTop: wi > 0 ? "1px solid var(--border)" : undefined }}>
+                    <div key={wi} role="row" className="grid grid-cols-7" style={{ borderTop: wi > 0 ? "1px solid var(--border)" : undefined }}>
                       {week.map((day) => {
                         const inMonth = day.getMonth() === monthCursor.getMonth();
                         const isToday = startOfDay(day).getTime() === today.getTime();
@@ -452,6 +477,7 @@ export function CalendarPage() {
                         return (
                           <div
                             key={day.toISOString()}
+                            role="cell"
                             className="min-h-[6.5rem] p-1.5"
                             style={{
                               borderLeft: "1px solid var(--border)",
@@ -459,7 +485,16 @@ export function CalendarPage() {
                               opacity: inMonth ? 1 : 0.5,
                             }}
                           >
+                            {/* The visible number is the date within a grid
+                                that supplies the rest. Read on its own it is
+                                just "12", and "today" is carried by a fill
+                                colour — neither survives without this. */}
+                            <span className="sr-only">
+                              {day.toLocaleDateString(undefined, { weekday: "long", month: "long", day: "numeric", year: "numeric" })}
+                              {isToday ? " (today)" : ""}
+                            </span>
                             <span
+                              aria-hidden="true"
                               className={`inline-flex h-5 min-w-5 items-center justify-center rounded-full px-1 text-2xs font-semibold ${isToday ? "bg-claw-500 text-claw-on" : ""}`}
                               style={isToday ? undefined : { color: "var(--text-mute)" }}
                             >
@@ -483,7 +518,7 @@ export function CalendarPage() {
                                   type="button"
                                   onClick={() => setOpenDay(day)}
                                   aria-label={`Show all ${dayEntries.length} episodes on ${day.toLocaleDateString(undefined, { month: "long", day: "numeric" })}`}
-                                  className="block w-full rounded px-1 py-0.5 text-left text-2xs font-medium underline-offset-2 transition-colors hover:bg-[var(--surface-strong)] hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-400"
+                                  className="block w-full rounded px-1 py-0.5 text-left text-2xs font-medium underline-offset-2 transition-colors hover:bg-[var(--surface-strong)] hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-focus"
                                   style={{ color: "var(--text-mute)" }}
                                 >
                                   +{dayEntries.length - MONTH_CELL_ENTRIES} more

--- a/apps/web/src/pages/CalendarPage.tsx
+++ b/apps/web/src/pages/CalendarPage.tsx
@@ -360,7 +360,7 @@ export function CalendarPage() {
               <p className="mt-1 text-xs" style={{ color: "var(--text-mute)" }}>
                 The calendar only tracks series you have already started watching.
               </p>
-              <Link to="/search" className="mt-2 inline-block text-sm font-medium text-claw-text underline-offset-2 transition-colors hover:underline">
+              <Link to="/search" className="mt-2 inline-block py-1 text-sm font-medium text-claw-text underline-offset-2 transition-colors hover:underline">
                 Find a series to follow &rarr;
               </Link>
             </div>

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -118,7 +118,11 @@ export function DiscoveryCard({ item, badge, reason, onSelect, eager, fill }: {
             className="absolute top-2 left-2 flex h-7 w-7 items-center justify-center rounded-full bg-black/70 backdrop-blur-sm"
             style={{ boxShadow: "0 0 0 1.5px rgba(245,158,11,0.7)" }}
           >
-            <span aria-hidden="true" className="text-2xs font-bold tabular-nums text-warning">{formatRating(item.rating)}</span>
+            {/* Fixed amber rather than --status-warn — the badge is on a black
+                scrim over poster art, not on a theme surface, and the token
+                goes dark on the light theme. Same pairing as the Stats page's
+                rating badges. */}
+            <span aria-hidden="true" className="text-2xs font-bold tabular-nums text-[#f5c451]">{formatRating(item.rating)}</span>
           </div>
         )}
         {badge && <div className="absolute top-2 right-2">{badge}</div>}
@@ -1218,7 +1222,7 @@ export function DashboardPage() {
             <p className="mt-3 text-sm" style={{ color: "var(--text-dim)" }}>
               No series in progress. Series you start watching pick up here.
             </p>
-            <Link to="/search" className="mt-1 inline-block text-sm font-medium text-claw-text underline-offset-2 transition-colors hover:underline">
+            <Link to="/search" className="mt-1 inline-block py-1 text-sm font-medium text-claw-text underline-offset-2 transition-colors hover:underline">
               Find something to watch &rarr;
             </Link>
           </div>
@@ -1279,7 +1283,7 @@ export function DashboardPage() {
                   <p className="mt-3 text-sm" style={{ color: "var(--text-dim)" }}>
                     Trending needs a TMDB API key to fetch content.
                   </p>
-                  <Link to="/settings?tab=integrations" className="mt-1 inline-block text-sm font-medium text-claw-text underline-offset-2 transition-colors hover:underline">
+                  <Link to="/settings?tab=integrations" className="mt-1 inline-block py-1 text-sm font-medium text-claw-text underline-offset-2 transition-colors hover:underline">
                     Set it up in Settings &rarr;
                   </Link>
                 </>
@@ -1439,7 +1443,7 @@ export function DashboardPage() {
             <p className="mt-3 text-sm" style={{ color: "var(--text-dim)" }}>
               No watch history yet. Anything you mark watched shows up here.
             </p>
-            <Link to="/search" className="mt-1 inline-block text-sm font-medium text-claw-text underline-offset-2 transition-colors hover:underline">
+            <Link to="/search" className="mt-1 inline-block py-1 text-sm font-medium text-claw-text underline-offset-2 transition-colors hover:underline">
               Find something to watch &rarr;
             </Link>
           </div>

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -99,7 +99,7 @@ export function DiscoveryCard({ item, badge, reason, onSelect, eager, fill }: {
       {onSelect && (
         <button
           type="button"
-          className="absolute inset-0 z-10 cursor-pointer rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-400 focus-ring-offset"
+          className="absolute inset-0 z-10 cursor-pointer rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-ring-offset"
           onClick={() => onSelect(item)}
           aria-label={`View details for ${item.name}`}
         />
@@ -118,7 +118,7 @@ export function DiscoveryCard({ item, badge, reason, onSelect, eager, fill }: {
             className="absolute top-2 left-2 flex h-7 w-7 items-center justify-center rounded-full bg-black/70 backdrop-blur-sm"
             style={{ boxShadow: "0 0 0 1.5px rgba(245,158,11,0.7)" }}
           >
-            <span aria-hidden="true" className="text-2xs font-bold tabular-nums text-amber-400">{formatRating(item.rating)}</span>
+            <span aria-hidden="true" className="text-2xs font-bold tabular-nums text-warning">{formatRating(item.rating)}</span>
           </div>
         )}
         {badge && <div className="absolute top-2 right-2">{badge}</div>}
@@ -263,7 +263,7 @@ export function ContinueWatchingCard({
               onClick={onMarkNext}
               aria-label={isMarking ? "Marking" : isDone ? "Marked" : `Mark S${s.nextSeason}:E${s.nextEpisode}`}
               className={`mt-2 flex w-full items-center justify-center gap-1.5 rounded-lg py-2 text-xs font-semibold transition-all duration-base active:scale-[0.98] focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-claw-300 ${
-                isMarking ? "bg-white/10 text-white/50" : isDone ? "bg-emerald-500/20 text-emerald-400" : "bg-white/15 text-white backdrop-blur-sm hover:bg-white/25"
+                isMarking ? "bg-white/10 text-white/50" : isDone ? "bg-emerald-500/20 text-success" : "bg-white/15 text-white backdrop-blur-sm hover:bg-white/25"
               }`}
             >
               {isDone ? (
@@ -418,7 +418,7 @@ function ScrollArrows({
         type="button"
         onClick={() => onScroll("left")}
         disabled={!canScrollLeft}
-        className="flex h-8 w-8 items-center justify-center rounded-full transition-all duration-base disabled:opacity-30 disabled:cursor-default active:scale-95 focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-400 focus-ring-offset"
+        className="flex h-8 w-8 items-center justify-center rounded-full transition-all duration-base disabled:opacity-30 disabled:cursor-default active:scale-95 focus:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-ring-offset"
         style={{ border: "1px solid var(--border-strong)", background: "var(--bg-1)", color: "var(--text-dim)" }}
         aria-label="Scroll left"
       >
@@ -428,7 +428,7 @@ function ScrollArrows({
         type="button"
         onClick={() => onScroll("right")}
         disabled={!canScrollRight}
-        className="flex h-8 w-8 items-center justify-center rounded-full transition-all duration-base disabled:opacity-30 disabled:cursor-default active:scale-95 focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-400 focus-ring-offset"
+        className="flex h-8 w-8 items-center justify-center rounded-full transition-all duration-base disabled:opacity-30 disabled:cursor-default active:scale-95 focus:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-ring-offset"
         style={{ border: "1px solid var(--border-strong)", background: "var(--bg-1)", color: "var(--text-dim)" }}
         aria-label="Scroll right"
       >
@@ -483,7 +483,7 @@ function SectionError({ message, onRetry }: { message: string; onRetry: () => vo
       <button
         type="button"
         onClick={onRetry}
-        className="text-sm font-medium text-claw-text underline-offset-2 transition-colors hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-400 focus-ring-offset rounded"
+        className="text-sm font-medium text-claw-text underline-offset-2 transition-colors hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-ring-offset rounded"
       >
         Retry
       </button>
@@ -753,7 +753,7 @@ function DashboardHeader({
             <button
               type="button"
               onClick={onRetryStats}
-              className="rounded text-xs font-medium underline-offset-2 transition-colors hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-400 focus-ring-offset"
+              className="rounded text-xs font-medium underline-offset-2 transition-colors hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-ring-offset"
               style={{ color: "var(--text-mute)" }}
             >
               Streak unavailable &middot; Retry
@@ -1291,7 +1291,7 @@ export function DashboardPage() {
                   <button
                     type="button"
                     onClick={() => void loadTrending()}
-                    className="mt-1 rounded text-sm font-medium text-claw-text underline-offset-2 transition-colors hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-400 focus-ring-offset"
+                    className="mt-1 rounded text-sm font-medium text-claw-text underline-offset-2 transition-colors hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-ring-offset"
                   >
                     Retry
                   </button>
@@ -1362,7 +1362,7 @@ export function DashboardPage() {
                           isToday
                             ? "bg-claw-500/15 text-claw-text"
                             : isTomorrow
-                              ? "bg-amber-500/15 text-amber-400"
+                              ? "bg-amber-500/15 text-warning"
                               : ""
                         }`}
                         style={!isToday && !isTomorrow ? { background: "var(--surface-strong)", color: "var(--text-dim)" } : undefined}
@@ -1459,7 +1459,7 @@ export function DashboardPage() {
                     card that has exactly one action. */}
                 <button
                   type="button"
-                  className="absolute inset-0 z-10 cursor-pointer rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-400 focus-ring-offset"
+                  className="absolute inset-0 z-10 cursor-pointer rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-ring-offset"
                   onClick={() => setSelectedItem(toSearchResult(historyItemImdbId(event), event.type === "movie" ? "movie" : "series", event.name, { poster: event.poster }))}
                   aria-label={`View details for ${event.name}`}
                 />

--- a/apps/web/src/pages/GamesPage.tsx
+++ b/apps/web/src/pages/GamesPage.tsx
@@ -169,7 +169,7 @@ function AddGameModal({
             dialog has left over, so on a phone with the keyboard up it stops
             where the keyboard starts instead of scrolling on behind it. */}
         <div className="min-h-0 flex-auto overflow-y-auto px-5 py-3 sm:max-h-[50vh]">
-          {error && <p className="mb-2 rounded-lg bg-rose-500/10 border border-rose-500/20 px-3 py-2 text-xs text-rose-600">{error}</p>}
+          {error && <p role="alert" className="mb-2 rounded-lg bg-rose-500/10 border border-rose-500/20 px-3 py-2 text-xs text-danger">{error}</p>}
           {searching && <p className="py-6 text-center text-sm" style={{ color: "var(--text-mute)" }}>Searching...</p>}
           {!searching && query.trim() && results.length === 0 && !error && (
             <p className="py-6 text-center text-sm" style={{ color: "var(--text-mute)" }}>No results found.</p>
@@ -198,7 +198,7 @@ function AddGameModal({
                   </p>
                 </div>
                 {r.inLibrary ? (
-                  <Check className="h-4 w-4 flex-none text-emerald-600" />
+                  <Check className="h-4 w-4 flex-none text-success" />
                 ) : (
                   <Plus className="h-4 w-4 flex-none text-claw-text" />
                 )}
@@ -224,7 +224,7 @@ function GameCard({ game, onSelect }: { game: Game; onSelect: (game: Game) => vo
         // Dashboard's themed hairline. --border matches the Dashboard. It stays
         // a ring rather than an inline inset shadow so .card-lift's hover
         // shadow can still replace it; an inline style would outrank that.
-        className="card-lift relative cursor-pointer overflow-hidden rounded-xl ring-1 ring-[var(--border)] focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-400 focus-ring-offset"
+        className="card-lift relative cursor-pointer overflow-hidden rounded-xl ring-1 ring-[var(--border)] focus:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-ring-offset"
         style={{ aspectRatio: "var(--poster-ratio)" }}
         onClick={() => onSelect(game)}
         onKeyDown={(e) => {
@@ -248,9 +248,14 @@ function GameCard({ game, onSelect }: { game: Game; onSelect: (game: Game) => vo
           </div>
         )}
 
+        {/* Fixed green rather than --success-text, for the same reason
+            .btn-danger's rose is fixed: this badge sits on cover art, not on a
+            theme surface, so it has to carry its own contrast. The pale
+            emerald-500 it used measured 2.30:1 against the white on top of it;
+            this pairing is 6.8:1 and reads as the same green. */}
         {game.finished && (
-          <span className="absolute left-2.5 top-2.5 z-10 flex items-center gap-1 rounded-md bg-emerald-500/90 px-2 py-0.5 text-2xs font-semibold uppercase tracking-wide text-white shadow-e1">
-            <Check className="h-3 w-3" /> Finished
+          <span className="absolute left-2.5 top-2.5 z-10 flex items-center gap-1 rounded-md bg-[#00693e] px-2 py-0.5 text-2xs font-semibold uppercase tracking-wide text-white shadow-e1">
+            <Check aria-hidden="true" className="h-3 w-3" /> Finished
           </span>
         )}
       </div>
@@ -262,8 +267,8 @@ function GameCard({ game, onSelect }: { game: Game; onSelect: (game: Game) => vo
             <Clock className="h-3 w-3" /> {formatPlaytime(game.playtimeMinutes)}
           </span>
           {game.rating != null && (
-            <span className="flex items-center gap-0.5 text-xs text-amber-600" title={ratingLabel(game.rating)}>
-              <Star className="h-3 w-3 fill-amber-500 text-amber-500" />
+            <span className="flex items-center gap-0.5 text-xs text-warning" title={ratingLabel(game.rating)}>
+              <Star className="h-3 w-3 fill-warning text-warning" />
               {formatRating(game.rating)}
               <span style={{ color: "var(--text-mute)" }}>/{RATING_MAX}</span>
             </span>
@@ -431,7 +436,7 @@ export function GamesPage() {
       </div>
 
       {error && (
-        <p className="mb-4 rounded-lg bg-rose-500/10 border border-rose-500/20 px-3 py-2 text-sm text-rose-600">{error}</p>
+        <p role="alert" className="mb-4 rounded-lg bg-rose-500/10 border border-rose-500/20 px-3 py-2 text-sm text-danger">{error}</p>
       )}
 
       {loading && (

--- a/apps/web/src/pages/HistoryPage.test.tsx
+++ b/apps/web/src/pages/HistoryPage.test.tsx
@@ -101,29 +101,49 @@ describe("HistoryPage", () => {
     expect(screen.getByRole("button", { name: "Movies" })).toBeInTheDocument();
   });
 
+  // A button inside a button has no defined accessible mapping, and assistive
+  // tech resolves it differently from one implementation to the next — the row
+  // was a role="button" wrapping the note and delete controls. All three are
+  // still here; none of them contains another.
+  it("keeps the row's three controls as siblings, not nested buttons", async () => {
+    renderPage();
+    await screen.findByText("Alien");
+
+    const open = screen.getByRole("button", { name: /view details for alien/i });
+    const note = screen.getByRole("button", { name: /add note to alien/i });
+    const remove = screen.getByRole("button", { name: /delete watch of alien/i });
+
+    for (const [a, b] of [[open, note], [open, remove], [note, remove]]) {
+      expect(a.contains(b)).toBe(false);
+      expect(b.contains(a)).toBe(false);
+    }
+  });
+
   it("removes a row optimistically and offers the way back", async () => {
     const user = userEvent.setup();
     deleteWatchEvent.mockResolvedValue(undefined as never);
     renderPage();
     await screen.findByText("Alien");
 
-    await user.click(screen.getAllByRole("button", { name: "Delete watch event" })[0]);
+    await user.click(screen.getAllByRole("button", { name: /delete watch of alien/i })[0]);
 
     await waitFor(() => expect(screen.queryByText("Alien")).not.toBeInTheDocument());
     expect(await screen.findByText(/Removed Alien from history/)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /undo/i })).toBeInTheDocument();
   });
 
-  // The row is a role="button" that swallows Enter and Space, and a keystroke
-  // bubbling up from a button inside it used to be cancelled there — so the
-  // detail panel opened where a keyboard user had asked to delete.
+  // The row's controls used to sit inside a role="button" that swallowed Enter
+  // and Space, so a keystroke bubbling up from one of them was cancelled there
+  // and the detail panel opened where a keyboard user had asked to delete. The
+  // row-opening control is a sibling of these two now, not their ancestor —
+  // which is also what stops the pair reading as a button inside a button.
   it("deletes from the keyboard rather than opening the panel", async () => {
     const user = userEvent.setup();
     deleteWatchEvent.mockResolvedValue(undefined as never);
     renderPage();
     await screen.findByText("Alien");
 
-    screen.getAllByRole("button", { name: "Delete watch event" })[0].focus();
+    screen.getAllByRole("button", { name: /delete watch of alien/i })[0].focus();
     await user.keyboard("{Enter}");
 
     await waitFor(() => expect(deleteWatchEvent).toHaveBeenCalledWith(ALIEN.id));
@@ -148,7 +168,7 @@ describe("HistoryPage", () => {
     renderPage();
     await screen.findByText("Alien");
 
-    await user.click(screen.getAllByRole("button", { name: "Delete watch event" })[0]);
+    await user.click(screen.getAllByRole("button", { name: /delete watch of alien/i })[0]);
 
     expect(await screen.findByText("Server said no")).toBeInTheDocument();
     expect(screen.getByText("Alien")).toBeInTheDocument();

--- a/apps/web/src/pages/HistoryPage.tsx
+++ b/apps/web/src/pages/HistoryPage.tsx
@@ -298,7 +298,7 @@ export function HistoryPage() {
           </p>
           {/* The search page is the way out of this one: a brand-new install
               lands here with nothing to filter and no other route onward. */}
-          <Link to="/search" className="mt-1 inline-block text-sm font-medium text-claw-text underline-offset-2 transition-colors hover:underline">
+          <Link to="/search" className="mt-1 inline-block py-1 text-sm font-medium text-claw-text underline-offset-2 transition-colors hover:underline">
             Find something to watch &rarr;
           </Link>
         </div>

--- a/apps/web/src/pages/HistoryPage.tsx
+++ b/apps/web/src/pages/HistoryPage.tsx
@@ -39,6 +39,21 @@ function toSearchResult(event: WatchEvent): SearchResult {
   };
 }
 
+/**
+ * What a row's controls call the thing they act on.
+ *
+ * The visible row says the title once and the episode number beside it, in two
+ * separate elements; a label built from `event.name` alone would give three
+ * buttons in a row the same name on a series the user watched twice in a day.
+ * The episode number is what tells those rows apart, so it belongs in the name.
+ */
+function eventLabel(event: WatchEvent): string {
+  const name = event.name || "this watch";
+  return event.type === "episode" && event.season != null && event.episode != null
+    ? `${name} S${event.season}E${event.episode}`
+    : name;
+}
+
 export function HistoryPage() {
   // Only the first page goes through the cache. Appended pages are held
   // separately and merged for rendering: writing them through would grow the
@@ -234,7 +249,7 @@ export function HistoryPage() {
               key={opt}
               type="button"
               onClick={() => setTypeFilter(opt)}
-              className="relative rounded-full px-3 py-1.5 text-xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-400 focus-ring-offset"
+              className="relative rounded-full px-3 py-1.5 text-xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-ring-offset"
               style={
                 typeFilter === opt
                   ? { background: "var(--accent)", color: "var(--on-accent)" }
@@ -248,7 +263,7 @@ export function HistoryPage() {
       </div>
 
       {error && events.length > 0 && (
-        <p className="text-sm text-rose-500">{error}</p>
+        <p role="alert" className="text-sm text-danger">{error}</p>
       )}
 
       {/* Skeletons and the failure card render in place of the list rather than
@@ -267,8 +282,8 @@ export function HistoryPage() {
         </div>
       ) : error && events.length === 0 ? (
         <div className="mx-auto max-w-lg rounded-2xl p-8 text-center" style={{ border: "1px solid rgba(244,63,94,0.2)", background: "rgba(244,63,94,0.05)" }}>
-          <AlertCircle className="mx-auto h-12 w-12 text-rose-500" />
-          <p className={`mt-3 ${SECTION_TITLE} text-rose-500`}>{error}</p>
+          <AlertCircle className="mx-auto h-12 w-12 text-danger" />
+          <p role="alert" className={`mt-3 ${SECTION_TITLE} text-danger`}>{error}</p>
         </div>
       ) : events.length === 0 ? (
         <div className="glass-panel rounded-2xl p-8 text-center" style={{ border: "1px solid var(--border)", background: "var(--bg-1)" }}>
@@ -308,25 +323,41 @@ export function HistoryPage() {
               {group.events.map((event, i) => (
                 <div key={event.id} style={i > 0 ? { borderTop: "1px solid var(--border)" } : undefined}>
                 <div
-                  role="button"
-                  tabIndex={0}
-                  onClick={() => setSelectedItem(toSearchResult(event))}
-                  onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); setSelectedItem(toSearchResult(event)); } }}
                   // Not .glass-row: the group container is the .glass-panel now,
                   // and a row inside it would stack a second blurred layer per
                   // row and re-tint each one with `!important` — putting the
                   // wall of separate surfaces back on the Glass theme. Its only
                   // other job was restoring the hover answer that an inline
                   // `background` used to beat, and there is no longer one here.
-                  className="group flex cursor-pointer items-center gap-3 px-3 py-2.5 transition-colors hover:bg-[var(--surface-strong)] focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-claw-400"
+                  //
+                  // The row is a plain container, not a control. It used to be a
+                  // role="button" with the note and delete buttons inside it —
+                  // a button nested in a button, which has no defined mapping
+                  // and which assistive tech resolves differently from one
+                  // implementation to the next. What opens the panel is now the
+                  // overlay below, a sibling of the two action buttons rather
+                  // than their ancestor.
+                  className="group relative flex items-center gap-3 px-3 py-2.5 transition-colors hover:bg-[var(--surface-strong)]"
                 >
+                  {/* Fills the row behind its content, so the whole row is still
+                      one click target and still takes the inset ring on focus.
+                      The content is `pointer-events-none` so clicks fall through
+                      to this; the two action buttons opt back in and stack above
+                      it. */}
+                  <button
+                    type="button"
+                    onClick={() => setSelectedItem(toSearchResult(event))}
+                    aria-label={`View details for ${eventLabel(event)}`}
+                    className="absolute inset-0 z-0 cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-focus"
+                  />
+
                   {/* A 2:3 box, so a poster fills it instead of being cropped to
                       a square through its middle — the old 48px square showed a
                       band across the artwork that identified nothing. 40x60 is
                       as small as a poster can be and still be recognisable, and
                       it keeps the row close to the height it had. */}
                   <div
-                    className="flex aspect-poster w-10 flex-none items-center justify-center overflow-hidden rounded-lg"
+                    className="pointer-events-none flex aspect-poster w-10 flex-none items-center justify-center overflow-hidden rounded-lg"
                     style={{ background: "var(--surface-strong)" }}
                   >
                     {event.poster ? (
@@ -338,7 +369,7 @@ export function HistoryPage() {
                     )}
                   </div>
 
-                  <div className="min-w-0 flex-1">
+                  <div className="pointer-events-none relative min-w-0 flex-1">
                     <p className="truncate text-sm font-medium" style={{ color: "var(--text)" }}>
                       {event.name}
                       {event.type === "episode" && event.season != null && event.episode != null && (
@@ -360,33 +391,29 @@ export function HistoryPage() {
                     )}
                   </div>
 
-                  {/* Both buttons stop the keystroke as well as the click. The
-                      row is itself a role="button" that calls preventDefault on
-                      Enter and Space — which, for a keystroke that bubbled up
-                      from a focused button, cancels the click the browser was
-                      about to synthesise. Keyboard users got the detail panel
-                      where they had asked to delete or annotate. */}
+                  {/* `relative z-10` puts these above the row overlay, which
+                      would otherwise take the click. They no longer need to stop
+                      the event: the overlay is a sibling, so nothing bubbles
+                      from here to it. */}
                   <button
                     type="button"
-                    onClick={(e) => { e.stopPropagation(); openNoteEditor(event); }}
-                    onKeyDown={(e) => e.stopPropagation()}
-                    className="flex h-9 w-9 flex-none items-center justify-center rounded-lg opacity-100 transition-all duration-fast sm:opacity-0 sm:group-hover:opacity-100 hover:bg-[var(--surface-strong)] focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-400 focus-ring-offset"
-                    aria-label={event.note ? `Edit note on ${event.name || "this watch"}` : `Add note to ${event.name || "this watch"}`}
+                    onClick={() => openNoteEditor(event)}
+                    className="relative z-10 flex h-9 w-9 flex-none items-center justify-center rounded-lg opacity-100 transition-all duration-fast sm:opacity-0 sm:group-hover:opacity-100 hover:bg-[var(--surface-strong)] focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-ring-offset"
+                    aria-label={event.note ? `Edit note on ${eventLabel(event)}` : `Add note to ${eventLabel(event)}`}
                     title={event.note ? "Edit note" : "Add note"}
                   >
-                    <NotebookPen className="h-4 w-4" style={{ color: event.note ? "var(--accent)" : "var(--text-mute)" }} />
+                    <NotebookPen aria-hidden="true" className="h-4 w-4" style={{ color: event.note ? "var(--accent-text)" : "var(--text-mute)" }} />
                   </button>
 
                   <button
                     type="button"
-                    onClick={(e) => { e.stopPropagation(); void handleDelete(event); }}
-                    onKeyDown={(e) => e.stopPropagation()}
+                    onClick={() => void handleDelete(event)}
                     disabled={deletingId === event.id}
-                    className="flex h-9 w-9 flex-none items-center justify-center rounded-lg opacity-100 transition-all duration-fast sm:opacity-0 sm:group-hover:opacity-100 hover:bg-rose-500/10 disabled:opacity-50 focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-rose-400 focus-ring-offset"
-                    aria-label="Delete watch event"
+                    className="relative z-10 flex h-9 w-9 flex-none items-center justify-center rounded-lg opacity-100 transition-all duration-fast sm:opacity-0 sm:group-hover:opacity-100 hover:bg-rose-500/10 disabled:opacity-50 focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-danger focus-ring-offset"
+                    aria-label={`Delete watch of ${eventLabel(event)}`}
                     title="Remove from history"
                   >
-                    <Trash2 className="h-4 w-4 text-rose-500" />
+                    <Trash2 aria-hidden="true" className="h-4 w-4 text-danger dark:text-danger" />
                   </button>
                 </div>
 
@@ -405,7 +432,7 @@ export function HistoryPage() {
                       onChange={(e) => setNoteDraft(e.target.value)}
                       onKeyDown={(e) => { if (e.key === "Escape") { e.preventDefault(); closeNoteEditor(); } }}
                       placeholder="What did you think?"
-                      className="w-full resize-y rounded-lg px-2.5 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-claw-400"
+                      className="w-full resize-y rounded-lg px-2.5 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-focus"
                       style={{ border: "1px solid var(--border)", background: "var(--bg-0)", color: "var(--text)" }}
                     />
                     <div className="mt-2 flex justify-end gap-2">

--- a/apps/web/src/pages/ListsPage.tsx
+++ b/apps/web/src/pages/ListsPage.tsx
@@ -248,7 +248,7 @@ function AddItemModal({
         {/* Results — sized by what's left of the dialog rather than a `vh`
             fraction, so the on-screen keyboard can't bury the list. */}
         <div className="min-h-0 flex-auto overflow-y-auto px-5 py-3 sm:max-h-[50vh]">
-          {error && <p className="mb-2 rounded-lg bg-rose-500/10 border border-rose-500/20 px-3 py-2 text-xs text-rose-600">{error}</p>}
+          {error && <p role="alert" className="mb-2 rounded-lg bg-rose-500/10 border border-rose-500/20 px-3 py-2 text-xs text-danger">{error}</p>}
           {searching && <p className="py-6 text-center text-sm" style={{ color: "var(--text-mute)" }}>Searching...</p>}
           {!searching && query.trim() && results.length === 0 && (
             <p className="py-6 text-center text-sm" style={{ color: "var(--text-mute)" }}>No results found.</p>
@@ -287,7 +287,7 @@ function AddItemModal({
                     />
                   ) : already ? (
                     <span className="flex flex-none items-center gap-1 text-2xs font-semibold" style={{ color: "var(--text-mute)" }}>
-                      <Check className="h-4 w-4 text-emerald-600" />
+                      <Check className="h-4 w-4 text-success" />
                       Added
                     </span>
                   ) : (
@@ -561,7 +561,7 @@ export function ListsPage() {
           click around, so the page keeps a stable hidden h1 above it. */}
       <h1 className="sr-only">Lists</h1>
       {/* Sidebar */}
-      <aside className="w-full shrink-0 md:w-56 lg:w-64">
+      <aside aria-label="Your lists" className="w-full shrink-0 md:w-56 lg:w-64">
         {/* Mobile: horizontal scrollable tabs */}
         <div className="flex gap-2 overflow-x-auto pb-2 scrollbar-hide md:flex-col md:overflow-x-visible md:pb-0">
           {lists.map((list) => (
@@ -569,8 +569,8 @@ export function ListsPage() {
               {confirmDeleteId === list.id && list.kind === "custom" ? (
                 <div className="rounded-xl border border-rose-500/40 bg-rose-500/10 px-4 py-3">
                   <div className="flex items-center gap-2 mb-2">
-                    <AlertTriangle className="h-4 w-4 flex-none text-rose-500" />
-                    <p className="text-xs font-semibold text-rose-600">Delete "{list.name}"?</p>
+                    <AlertTriangle className="h-4 w-4 flex-none text-danger" />
+                    <p role="alert" className="text-xs font-semibold text-danger">Delete "{list.name}"?</p>
                   </div>
                   <p className="text-xs mb-3" style={{ color: "var(--text-mute)" }}>This will remove the list and all its items.</p>
                   <div className="flex gap-2">
@@ -624,7 +624,7 @@ export function ListsPage() {
                     <button
                       type="button"
                       onClick={(e) => { e.stopPropagation(); setConfirmDeleteId(list.id); }}
-                      className="mr-2 flex h-7 w-7 flex-none items-center justify-center rounded-lg opacity-100 sm:opacity-0 sm:group-hover:opacity-100 hover:bg-rose-500/15 hover:text-rose-500 transition-all duration-fast focus:opacity-100"
+                      className="mr-2 flex h-7 w-7 flex-none items-center justify-center rounded-lg opacity-100 sm:opacity-0 sm:group-hover:opacity-100 hover:bg-rose-500/15 hover:text-danger transition-all duration-fast focus:opacity-100"
                       style={{ color: "var(--text-mute)" }}
                       aria-label={`Delete list ${list.name}`}
                     >
@@ -660,7 +660,7 @@ export function ListsPage() {
           and a nested one would give the page two. */}
       <div className="min-w-0 flex-1">
         {error && (
-          <p className="mb-4 rounded-xl bg-rose-500/5 border border-rose-500/20 px-4 py-3 text-rose-600 text-sm">{error}</p>
+          <p role="alert" className="mb-4 rounded-xl bg-rose-500/5 border border-rose-500/20 px-4 py-3 text-danger text-sm">{error}</p>
         )}
 
         {!selectedList ? (
@@ -706,7 +706,7 @@ export function ListsPage() {
                       // Keeps focus in the input, so the click isn't cancelled
                       // by its own blur before it lands.
                       onMouseDown={(e) => e.preventDefault()}
-                      className="rounded-lg p-1.5 text-emerald-600 hover:bg-emerald-500/10"
+                      className="rounded-lg p-1.5 text-success hover:bg-emerald-500/10"
                     >
                       <Check className="h-5 w-5" />
                     </button>
@@ -856,7 +856,7 @@ export function ListsPage() {
                         type="button"
                         disabled={removingIds[item.imdbId]}
                         onClick={() => handleRemove(item)}
-                        className="absolute top-2.5 right-2.5 z-10 rounded-full bg-black/60 p-2 text-white opacity-100 sm:opacity-0 sm:group-hover:opacity-100 focus:opacity-100 focus-visible:opacity-100 transition-all duration-base hover:bg-rose-500 hover:text-white disabled:opacity-50 backdrop-blur-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-rose-400 focus-ring-offset"
+                        className="absolute top-2.5 right-2.5 z-10 rounded-full bg-black/60 p-2 text-white opacity-100 sm:opacity-0 sm:group-hover:opacity-100 focus:opacity-100 focus-visible:opacity-100 transition-all duration-base hover:bg-rose-500 hover:text-white disabled:opacity-50 backdrop-blur-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-danger focus-ring-offset"
                         aria-label="Remove from list"
                       >
                         <Trash2 className="h-4 w-4" />

--- a/apps/web/src/pages/ProfileSwitcher.tsx
+++ b/apps/web/src/pages/ProfileSwitcher.tsx
@@ -41,7 +41,7 @@ function Shell({ children, onClose }: { children: React.ReactNode; onClose?: () 
               type="button"
               onClick={onClose}
               aria-label="Close"
-              className="absolute right-4 top-4 flex h-8 w-8 items-center justify-center rounded-full transition-colors hover:bg-[var(--surface-strong)] focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-400 focus-ring-offset"
+              className="absolute right-4 top-4 flex h-8 w-8 items-center justify-center rounded-full transition-colors hover:bg-[var(--surface-strong)] focus:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-ring-offset"
               style={{ color: "var(--text-mute)" }}
             >
               <X className="h-4 w-4" />
@@ -133,7 +133,7 @@ function CreateProfileForm({
         style={{ borderColor: "var(--border)", color: "var(--text)", background: "var(--bg-1)" }}
       />
       {error && (
-        <p className="flex items-center gap-2 text-sm text-rose-600"><AlertCircle size={16} /> {error}</p>
+        <p role="alert" className="flex items-center gap-2 text-sm text-danger"><AlertCircle size={16} /> {error}</p>
       )}
       <div className="flex gap-2">
         {onCancel && (
@@ -208,7 +208,7 @@ function PinPrompt({
         style={{ borderColor: "var(--border)", color: "var(--text)", background: "var(--bg-1)" }}
       />
       {error && (
-        <p className="flex items-center gap-2 text-sm text-rose-600"><AlertCircle size={16} /> {error}</p>
+        <p role="alert" className="flex items-center gap-2 text-sm text-danger"><AlertCircle size={16} /> {error}</p>
       )}
       <div className="flex gap-2">
         <button
@@ -351,7 +351,7 @@ export function ProfileSwitcher({ onSelected, onClose }: { onSelected: (profile:
     return (
       <Shell onClose={onClose}>
         <Heading className="sr-only">Profiles</Heading>
-        <p className="flex items-center gap-2 text-sm text-rose-600"><AlertCircle size={16} /> {error}</p>
+        <p role="alert" className="flex items-center gap-2 text-sm text-danger"><AlertCircle size={16} /> {error}</p>
       </Shell>
     );
   }

--- a/apps/web/src/pages/SearchPage.test.tsx
+++ b/apps/web/src/pages/SearchPage.test.tsx
@@ -164,6 +164,27 @@ describe("SearchPage query handling", () => {
     expect(await screen.findByText(/no results found/i)).toBeInTheDocument();
   });
 
+  // The results swap under you as you type, and nothing moves focus when they
+  // do. Without a live region the outcome of a search is only discoverable by
+  // going to look for it.
+  it("announces the outcome of a search, not just the grid", async () => {
+    const user = userEvent.setup();
+    search.mockImplementation(async (type) => (type === "movie" ? [result("Solaris")] : []));
+    renderPage("/search?q=solaris");
+    expect(await screen.findByText("Solaris")).toBeInTheDocument();
+
+    const live = screen.getByRole("status", { name: /search status/i });
+    expect(live).toHaveAttribute("aria-live", "polite");
+    await waitFor(() => expect(live).toHaveTextContent(/showing 1 match/i));
+
+    // Still the same region afterwards — one that unmounts announces nothing.
+    search.mockResolvedValue([]);
+    await user.type(queryField(), "zzz");
+    await waitFor(() =>
+      expect(screen.getByRole("status", { name: /search status/i })).toHaveTextContent(/nothing matched/i)
+    );
+  });
+
   it("names the missing TMDB key instead of blaming the search term", async () => {
     search.mockRejectedValue(new Error("TMDB API key is not configured"));
     renderPage("/search?q=alien");

--- a/apps/web/src/pages/SearchPage.tsx
+++ b/apps/web/src/pages/SearchPage.tsx
@@ -89,6 +89,7 @@ export function SearchPage() {
   const { showToast } = useToast();
   const [openDropdown, setOpenDropdown] = useState<string | null>(null);
   const [filtersOpen, setFiltersOpen] = useState(false);
+  const advancedFiltersId = useId();
   const { selectedItem, setSelectedItem, panelHistory, setPanelHistory, panelHistoryLoading, detail: panelDetail, detailLoading: panelDetailLoading } = useDetailPanel();
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -305,6 +306,22 @@ export function SearchPage() {
   const hasSearched = rawResults !== null;
   const noResults = hasSearched && (results?.length ?? 0) === 0;
 
+  // Empty until something has actually happened, so the region doesn't announce
+  // on mount. Written as whole sentences rather than echoing the labels on
+  // screen: the visible copy sits next to an icon and a heading that supply the
+  // context, and an announcement arrives with none of that around it.
+  const searchStatus = (() => {
+    if (isSearching) return "Searching…";
+    if (!hasSearched) return "";
+    if (needsTmdb) return "A TMDB API key is needed before titles can be searched.";
+    if (searchError) return `Search could not run. ${searchError}`;
+    const count = results?.length ?? 0;
+    if (count === 0) return "Nothing matched that search.";
+    return rawResults && count !== rawResults.length
+      ? `Showing ${count} of ${rawResults.length} matches.`
+      : `Showing ${count} match${count === 1 ? "" : "es"}.`;
+  })();
+
   return (
     <div className="relative space-y-6">
       {/* Search bar.
@@ -337,10 +354,11 @@ export function SearchPage() {
             <button
               type="button"
               onClick={() => { setFilters({ query: "" }); setRawResults(null); }}
+              aria-label="Clear search"
               className="absolute right-4 top-1/2 -translate-y-1/2 flex h-6 w-6 items-center justify-center rounded-full text-xs font-bold hover:bg-[var(--border-strong)] transition-colors"
               style={{ backgroundColor: "var(--border)", color: "var(--text)" }}
             >
-              <X className="h-3.5 w-3.5" />
+              <X aria-hidden="true" className="h-3.5 w-3.5" />
             </button>
           )}
         </div>
@@ -369,24 +387,35 @@ export function SearchPage() {
             })}
           </div>
 
-          {/* Advanced filters toggle */}
+          {/* Advanced filters toggle.
+
+              The word "Filters" is hidden below `sm`, where the button is icons
+              only — so the name has to come from `aria-label` rather than the
+              text, or the control is anonymous on exactly the viewport where it
+              is hardest to guess at. The label carries the badge's count too,
+              which is otherwise a bare number beside an icon. */}
           <button
             type="button"
             onClick={() => setFiltersOpen((v) => !v)}
+            aria-expanded={filtersOpen}
+            aria-controls={advancedFiltersId}
+            aria-label={activeFilterCount > 0 ? `Filters (${activeFilterCount} active)` : "Filters"}
             className={`flex items-center gap-1.5 rounded-full border px-3.5 py-1.5 text-sm font-medium transition-all duration-base ${
               hasActiveFilters
                 ? "border-claw-500/50 bg-claw-500/10 text-claw-text"
                 : "border-[var(--border-strong)] bg-[var(--surface)] text-[var(--text-mute)] hover:text-[var(--text)]"
             }`}
           >
-            <SlidersHorizontal className="h-3.5 w-3.5" />
+            <SlidersHorizontal aria-hidden="true" className="h-3.5 w-3.5" />
             <span className="hidden sm:inline">Filters</span>
             {activeFilterCount > 0 && (
-              <span className="flex h-5 w-5 items-center justify-center rounded-full bg-claw-500 text-2xs font-bold text-claw-on">
+              <span aria-hidden="true" className="flex h-5 w-5 items-center justify-center rounded-full bg-claw-500 text-2xs font-bold text-claw-on">
                 {activeFilterCount}
               </span>
             )}
-            {filtersOpen ? <ChevronUp className="h-3.5 w-3.5" /> : <ChevronDown className="h-3.5 w-3.5" />}
+            {filtersOpen
+              ? <ChevronUp aria-hidden="true" className="h-3.5 w-3.5" />
+              : <ChevronDown aria-hidden="true" className="h-3.5 w-3.5" />}
           </button>
 
           {hasActiveFilters && (
@@ -410,7 +439,7 @@ export function SearchPage() {
 
         {/* Advanced filters panel */}
         {filtersOpen && (
-          <div className="mt-3 grid grid-cols-2 gap-3 rounded-2xl p-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6" style={{ borderWidth: 1, borderStyle: "solid", borderColor: "var(--border)", background: "var(--surface)" }}>
+          <div id={advancedFiltersId} className="mt-3 grid grid-cols-2 gap-3 rounded-2xl p-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6" style={{ borderWidth: 1, borderStyle: "solid", borderColor: "var(--border)", background: "var(--surface)" }}>
             {/* Genre */}
             <FilterSelect
               label="Genre"
@@ -473,6 +502,20 @@ export function SearchPage() {
           </div>
         )}
       </form>
+
+      {/* The search runs as you type and swaps the page under you: results
+          appear, a count changes, a filter empties the grid. None of that moves
+          focus, so without a live region the only way to find out anything
+          happened is to go looking — which is what SC 4.1.3 is about.
+
+          One region for every outcome rather than `aria-live` on each of the
+          visible pieces: those come and go as whole subtrees, and a region that
+          unmounts doesn't announce. This one stays mounted and only its text
+          changes. `sr-only` because the same information is already on screen
+          in the count line and the empty states. */}
+      <p className="sr-only" role="status" aria-live="polite" aria-label="Search status">
+        {searchStatus}
+      </p>
 
       {/* Empty state – no search yet */}
       {!hasSearched && !isSearching && (
@@ -748,7 +791,7 @@ function ResultCard({
         // Dashboard's themed hairline. --border matches the Dashboard. It stays
         // a ring rather than an inline inset shadow so .card-lift's hover
         // shadow can still replace it; an inline style would outrank that.
-        className="card-lift relative cursor-pointer overflow-hidden rounded-xl ring-1 ring-[var(--border)] focus:outline-none focus-visible:ring-2 focus-visible:ring-claw-400 focus-ring-offset"
+        className="card-lift relative cursor-pointer overflow-hidden rounded-xl ring-1 ring-[var(--border)] focus:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-ring-offset"
         style={{ aspectRatio: "var(--poster-ratio)" }}
         onClick={() => onSelect(result)}
         onKeyDown={(e) => {
@@ -870,7 +913,7 @@ function ResultCard({
                   className="flex w-full items-center gap-2 px-3 py-2.5 text-left text-sm transition-colors hover:bg-[var(--surface)] disabled:opacity-50"
                 >
                   {already ? (
-                    <Check className="h-3.5 w-3.5 text-emerald-600" />
+                    <Check className="h-3.5 w-3.5 text-success" />
                   ) : (
                     <Plus className="h-3.5 w-3.5" style={{ color: "var(--text-mute)" }} />
                   )}
@@ -935,8 +978,8 @@ function ResultCard({
         <div className="mt-0.5 flex items-center gap-2">
           <span className="text-xs" style={{ color: "var(--text-mute)" }}>{result.year ?? "Unknown year"}</span>
           {result.rating != null && result.rating > 0 && (
-            <span className="flex items-center gap-0.5 text-xs text-amber-600" title={ratingLabel(result.rating)}>
-              <Star className="h-3 w-3 fill-amber-500 text-amber-500" />
+            <span className="flex items-center gap-0.5 text-xs text-warning" title={ratingLabel(result.rating)}>
+              <Star className="h-3 w-3 fill-warning text-warning" />
               {formatRating(result.rating)}
               <span style={{ color: "var(--text-mute)" }}>/{RATING_MAX}</span>
             </span>

--- a/apps/web/src/pages/SetupWizard.tsx
+++ b/apps/web/src/pages/SetupWizard.tsx
@@ -140,7 +140,7 @@ function TokenStep({ onVerified }: { onVerified: () => void }) {
         </button>
       </div>
       {error && (
-        <p className="flex items-center gap-2 text-sm text-rose-600"><AlertCircle size={16} /> {error}</p>
+        <p role="alert" className="flex items-center gap-2 text-sm text-danger"><AlertCircle size={16} /> {error}</p>
       )}
       <button
         type="submit"
@@ -205,7 +205,7 @@ function DoneStep({ onFinish, onBack }: { onFinish: () => void; onBack: () => vo
   return (
     <div className="space-y-4 text-center">
       <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-emerald-500/15 ring-1 ring-emerald-500/20">
-        <Check className="h-7 w-7 text-emerald-600" />
+        <Check className="h-7 w-7 text-success" />
       </div>
       <div>
         <h1 className={SECTION_TITLE}>You're all set</h1>

--- a/apps/web/src/pages/StatsPage.tsx
+++ b/apps/web/src/pages/StatsPage.tsx
@@ -348,9 +348,14 @@ export function StatsPage() {
                       <Film className="h-8 w-8" style={{ color: "var(--text-mute)" }} />
                     </div>
                   )}
+                  {/* Fixed amber, not --status-warn: this badge sits on a
+                      black scrim over poster art rather than on a theme
+                      surface, so it can't take a token that goes dark on the
+                      light theme — that pairing measured 1.46:1. Against the
+                      scrim this is 5.2:1 even over a white poster. */}
                   {item.rating != null && (
                     <div role="img" aria-label={ratingLabel(item.rating)} title={ratingLabel(item.rating)} className="absolute top-2 left-2 flex h-7 w-7 items-center justify-center rounded-full bg-black/70 backdrop-blur-sm" style={{ boxShadow: "0 0 0 1.5px rgba(245,158,11,0.7)" }}>
-                      <span aria-hidden="true" className="text-2xs font-bold tabular-nums text-warning">{formatRating(item.rating)}</span>
+                      <span aria-hidden="true" className="text-2xs font-bold tabular-nums text-[#f5c451]">{formatRating(item.rating)}</span>
                     </div>
                   )}
                 </div>
@@ -429,7 +434,7 @@ export function StatsPage() {
                             pickers use — unlike the community score on the card
                             above, which is TMDB's and stays out of ten. */}
                         <div role="img" aria-label={starsLabel(item.rating)} title={starsLabel(item.rating)} className="absolute top-2 left-2 flex h-7 w-7 items-center justify-center rounded-full bg-black/70 backdrop-blur-sm" style={{ boxShadow: "0 0 0 1.5px rgba(245,158,11,0.7)" }}>
-                          <span aria-hidden="true" className="text-2xs font-bold tabular-nums text-warning">{formatStars(item.rating)}</span>
+                          <span aria-hidden="true" className="text-2xs font-bold tabular-nums text-[#f5c451]">{formatStars(item.rating)}</span>
                         </div>
                       </div>
                       <p className="mt-1.5 truncate text-sm font-medium" style={{ color: "var(--text)" }}>{item.name ?? item.imdbId}</p>

--- a/apps/web/src/pages/StatsPage.tsx
+++ b/apps/web/src/pages/StatsPage.tsx
@@ -88,8 +88,8 @@ export function StatsPage() {
       <div className="mx-auto max-w-4xl space-y-6">
         <h1 className={PAGE_TITLE} style={{ color: "var(--text)" }}>Watch Statistics</h1>
         <div className="mx-auto max-w-lg rounded-2xl p-8 text-center" style={{ border: "1px solid rgba(244,63,94,0.2)", background: "rgba(244,63,94,0.05)" }}>
-          <AlertCircle className="mx-auto h-12 w-12 text-rose-500" />
-          <p className={`mt-3 ${SECTION_TITLE} text-rose-500`}>{error}</p>
+          <AlertCircle className="mx-auto h-12 w-12 text-danger" />
+          <p role="alert" className={`mt-3 ${SECTION_TITLE} text-danger`}>{error}</p>
         </div>
       </div>
     );
@@ -158,9 +158,9 @@ export function StatsPage() {
               <span
                 className={`flex items-center gap-1 text-xs font-medium ${
                   momComparison.diff > 0
-                    ? "text-emerald-500"
+                    ? "text-success"
                     : momComparison.diff < 0
-                      ? "text-rose-500"
+                      ? "text-danger"
                       : ""
                 }`}
                 style={momComparison.diff === 0 ? { color: "var(--text-dim)" } : undefined}
@@ -178,14 +178,30 @@ export function StatsPage() {
               </span>
             )}
           </div>
+          {/* Twelve columns whose month labels have a min-content width the
+              flex track can't go below. At a 320px viewport that pushed the
+              chart 14px past the edge, where `body { overflow-x: hidden }`
+              clipped December off rather than letting anyone scroll to it —
+              content lost, which is what SC 1.4.10 is about.
+
+              A chart is one of the things 1.4.10 explicitly allows to scroll
+              sideways ("content requiring two-dimensional layout"), so the
+              overflow is moved off the page and into the chart, which keeps
+              its columns readable. `tabIndex` because a scroll container with
+              no focusable children is otherwise unreachable by keyboard; the
+              label and role ride with it. */}
           <div
-            className="flex items-end gap-1.5 sm:gap-2"
-            style={{ height: "180px" }}
+            tabIndex={0}
             role="img"
             aria-label={`Monthly activity chart for ${detailed.monthly
               .map((m) => `${new Date(m.month + "-15").toLocaleDateString(undefined, { month: "long", year: "numeric" })}: ${m.movies} movies, ${m.episodes} episodes`)
               .join("; ")}`}
+            className="-mx-1 overflow-x-auto px-1 pb-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-ring-offset"
           >
+            <div
+              className="flex min-w-[21rem] items-end gap-1.5 sm:gap-2"
+              style={{ height: "180px" }}
+            >
             {detailed.monthly.map((m, idx) => {
               const { total, height, movieHeight, episodeHeight } = monthlyBarGeometry(m.movies, m.episodes, maxMonthlyTotal);
               const label = new Date(m.month + "-15").toLocaleDateString(undefined, { month: "short" });
@@ -266,6 +282,7 @@ export function StatsPage() {
                 </div>
               );
             })}
+            </div>
           </div>
           <div className="mt-3 flex items-center gap-4 text-xs" style={{ color: "var(--text-dim)" }}>
             <span className="flex items-center gap-1.5">
@@ -307,7 +324,7 @@ export function StatsPage() {
       {detailed && detailed.topRated.length > 0 && (
         <section className="glass-panel rounded-2xl p-5" style={{ border: "1px solid var(--border)", background: "var(--bg-1)" }}>
           <h2 className={`mb-4 flex items-center gap-2 ${SECTION_TITLE}`} style={{ color: "var(--text)" }}>
-            <Star className="h-5 w-5 text-amber-400" /> Top Rated Watched
+            <Star className="h-5 w-5 text-warning" /> Top Rated Watched
           </h2>
           <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-5">
             {detailed.topRated.map((item, index) => (
@@ -333,7 +350,7 @@ export function StatsPage() {
                   )}
                   {item.rating != null && (
                     <div role="img" aria-label={ratingLabel(item.rating)} title={ratingLabel(item.rating)} className="absolute top-2 left-2 flex h-7 w-7 items-center justify-center rounded-full bg-black/70 backdrop-blur-sm" style={{ boxShadow: "0 0 0 1.5px rgba(245,158,11,0.7)" }}>
-                      <span aria-hidden="true" className="text-2xs font-bold tabular-nums text-amber-400">{formatRating(item.rating)}</span>
+                      <span aria-hidden="true" className="text-2xs font-bold tabular-nums text-warning">{formatRating(item.rating)}</span>
                     </div>
                   )}
                 </div>
@@ -361,7 +378,7 @@ export function StatsPage() {
           </SelectField>
         </div>
 
-        {yearError && <p className="text-sm text-rose-500">{yearError}</p>}
+        {yearError && <p role="alert" className="text-sm text-danger">{yearError}</p>}
 
         {!yearError && yearReview && (
           <div className="space-y-5">
@@ -392,7 +409,7 @@ export function StatsPage() {
             {yearReview.topRated.length > 0 && (
               <div>
                 <h3 className={`mb-2 flex items-center gap-2 ${KICKER}`} style={{ color: "var(--text-dim)" }}>
-                  <Star className="h-4 w-4 text-amber-400" /> Top Rated Picks
+                  <Star className="h-4 w-4 text-warning" /> Top Rated Picks
                 </h3>
                 <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-5">
                   {yearReview.topRated.map((item) => (
@@ -412,7 +429,7 @@ export function StatsPage() {
                             pickers use — unlike the community score on the card
                             above, which is TMDB's and stays out of ten. */}
                         <div role="img" aria-label={starsLabel(item.rating)} title={starsLabel(item.rating)} className="absolute top-2 left-2 flex h-7 w-7 items-center justify-center rounded-full bg-black/70 backdrop-blur-sm" style={{ boxShadow: "0 0 0 1.5px rgba(245,158,11,0.7)" }}>
-                          <span aria-hidden="true" className="text-2xs font-bold tabular-nums text-amber-400">{formatStars(item.rating)}</span>
+                          <span aria-hidden="true" className="text-2xs font-bold tabular-nums text-warning">{formatStars(item.rating)}</span>
                         </div>
                       </div>
                       <p className="mt-1.5 truncate text-sm font-medium" style={{ color: "var(--text)" }}>{item.name ?? item.imdbId}</p>
@@ -459,14 +476,14 @@ function MilestoneBadges({
   return (
     <section className="glass-panel rounded-2xl p-5" style={{ border: "1px solid var(--border)", background: "var(--bg-1)" }}>
       <h2 className={`mb-4 flex items-center gap-2 ${SECTION_TITLE}`} style={{ color: "var(--text)" }}>
-        <Award className="h-5 w-5 text-amber-400" /> Achievements
+        <Award className="h-5 w-5 text-warning" /> Achievements
       </h2>
       {earned.length > 0 ? (
         <div className="flex flex-wrap gap-2">
           {earned.map((m) => (
             <span
               key={m.label}
-              className="flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium text-amber-400"
+              className="flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium text-warning"
               style={{ border: "1px solid rgba(245,158,11,0.3)", background: "rgba(245,158,11,0.1)" }}
             >
               <m.icon className="h-3.5 w-3.5" /> {m.label}

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -30,6 +30,17 @@ export default {
           on: "rgb(var(--on-accent-rgb))",
           text: "rgb(var(--accent-text-rgb))",
         },
+        // Status text, themed — the Tailwind-side names for the --status-*
+        // trio, so `text-danger` and `style={{ color: "var(--status-bad)" }}`
+        // are the same colour rather than two that drift. See the note above
+        // those tokens in src/index.css for why a fixed `text-rose-600` can't
+        // do this job across five themes.
+        danger: "var(--status-bad)",
+        success: "var(--status-ok)",
+        warning: "var(--status-warn)",
+        // The focus indicator, which answers SC 1.4.11's 3:1 rather than
+        // 1.4.3's 4.5:1 — `ring-focus` everywhere a control takes a ring.
+        focus: "var(--focus-ring)",
         cream: {
           50: "#faf6ef",
           100: "#f3ecdd",


### PR DESCRIPTION
An audit of the running app — axe-core across every route, theme and
viewport, plus measurements taken from the DOM for the things axe cannot
see — turned up failures at Level A and AA. This fixes them.

Level A

  4.1.2  The search page's filter toggle hides its label below `sm`, so on
         a phone it was a button with no accessible name at all. It now
         carries one, along with the aria-expanded it also lacked.
  4.1.2  Each history row was a role="button" wrapping the note and delete
         buttons — a button inside a button, which has no defined mapping.
         The row-opening control is a sibling of those two now, which also
         retires the pair of stopPropagation calls that existed to stop the
         outer button swallowing their keystrokes.
  2.4.2  document.title was never assigned, so all nine routes announced
         "Cataloggy" in the tab strip, the history menu and to a screen
         reader. Each route names itself.

Level AA

  1.4.3  Status colours were fixed Tailwind ramp steps, and no single step
         clears 4.5:1 on both a cream page and a near-black one. Everything
         that carried one now reads from the existing --status-* trio,
         whose light values were measured against the two page backgrounds
         only and sat at 3.77-4.03:1 once the chip fill underneath them was
         counted. Worst case found was 1.37:1, on the Stats achievement
         chips. --text-mute failed on all five themes on a tinted surface,
         and --text-dim on the light one.
  1.4.11 Focus indicators. The light theme's ring measured 2.25:1 against
         its own background, and the checkbox, switch and select drew a
         semi-transparent accent glow that came out at 1.16-1.94:1 on every
         theme. A --focus-ring token, measured at >= 3:1 everywhere, and a
         real outline on the three controls that set appearance: none.
  2.5.8  The star picker's half-star buttons were 14x28, and 10x20 on a
         phone. Ten targets in a row can't use the spacing exception, so
         the cell is 48px wide and each half is 24px; the glyph is unchanged
         and centred in it.
  2.4.11 Tabbing down the mobile dashboard put the carousel's scroll button
         behind the fixed tab bar. Scroll padding keeps a focused control
         clear of both bars.
  4.1.3  aria-invalid appeared nowhere and only two of ~40 error messages
         were announced. Errors are alerts, the AI settings fields point at
         theirs, and the search page and command palette each publish their
         own outcome.
  1.4.10 The Stats chart overflowed a 320px viewport by 14px, where the
         body's overflow-x: hidden clipped December rather than letting
         anyone reach it. It scrolls within itself now.

Structure

  The command palette is a combobox over a listbox rather than an input
  beside a stack of buttons, so the row the arrow keys highlight — the one
  Enter acts on — is published rather than merely shaded. Settings section
  headers are real headings, which gives that page an outline past its h1.
  The calendar month carries table roles, so a cell says which day it is
  instead of "12". Both complementary landmarks are named.

Verified by re-running the same sweep, and by re-measuring target sizes,
tab-order obscuring, reflow at 320px, text spacing and 200% zoom in the
browser. 462 unit tests pass, including new cases covering the palette's
combobox contract, the search page's live region and the history row's
three sibling controls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added route-specific browser titles.
  * Improved command palette navigation with screen-reader announcements, keyboard support, and proper listbox semantics.
  * Added live search-result announcements and clearer filter controls.
  * Enhanced calendar, history, settings, charts, and error-message accessibility.
* **Bug Fixes**
  * Prevented nested interactive controls in history entries.
  * Improved narrow-screen wrapping for season and episode rows.
* **Style**
  * Standardized semantic colors and focus indicators across themes.
  * Improved star-rating controls, contrast, and mobile focus behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->